### PR TITLE
PD-168: Removed ref from Toggle component

### DIFF
--- a/packages/Toggle/src/Toggle.js
+++ b/packages/Toggle/src/Toggle.js
@@ -25,7 +25,6 @@ export default class Toggle extends PureComponent {
   };
 
   state = { checked: false };
-  inputRef = React.createRef();
   checkboxId = `toggle-${Math.floor(Math.random() * 10000000)}`;
 
   onChange = e => {
@@ -65,7 +64,6 @@ export default class Toggle extends PureComponent {
         <input
           {...rest}
           id={this.checkboxId}
-          ref={this.inputRef}
           className={style.input}
           type="checkbox"
           role="checkbox"


### PR DESCRIPTION
There was an unused ref in the Toggle component, which I removed for cleanliness and performance. I tested the component without the ref in MMS and the component is still passing all of the tests.