### PR TITLE
Update package.json files for publishing to public NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "eslint \"packages/**/*.js\"",
     "prettier": "prettier --write \"**/*.js\"",
     "test": "jest --env jsdom",
-    "release": "lerna publish --registry https://artifactory.corp.mongodb.com/artifactory/api/npm/mongodb-cloud-local/",
+    "release": "lerna publish",
     "release:site": "gh-pages --dist storybook/public"
   },
   "devDependencies": {

--- a/packages/Badge/package.json
+++ b/packages/Badge/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/Badge",
+  "name": "@leafygreen-ui/badge",
   "version": "1.0.0",
   "description": "leafyGreen UI Kit Badge",
   "main": "./dist/index.js",

--- a/packages/Button/package.json
+++ b/packages/Button/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/Button",
+  "name": "@leafygreen-ui/button",
   "version": "2.2.0",
   "description": "leafyGreen UI Kit Button",
   "main": "./dist/index.js",

--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/Checkbox",
+  "name": "@leafygreen-ui/checkbox",
   "version": "1.1.1",
   "description": "LeafyGreen UI Kit Checkbox",
   "main": "./dist/index.js",

--- a/packages/Portal/package.json
+++ b/packages/Portal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/Portal",
+  "name": "@leafygreen-ui/portal",
   "version": "0.9.0",
   "description": "LeafyGreen UI Kit Portal",
   "main": "./dist/index.js",

--- a/packages/RadioBoxGroup/package.json
+++ b/packages/RadioBoxGroup/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/RadioBoxGroup",
+  "name": "@leafygreen-ui/radio-box-group",
   "version": "1.0.0",
   "description": "leafyGreen UI Kit RadioBoxGroup",
   "main": "./dist/index.js",

--- a/packages/RadioGroup/package.json
+++ b/packages/RadioGroup/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/RadioGroup",
+  "name": "@leafygreen-ui/radio-group",
   "version": "1.1.1",
   "description": "leafyGreen UI Kit RadioGroup",
   "main": "./dist/index.js",

--- a/packages/Toggle/package.json
+++ b/packages/Toggle/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@leafygreen-ui/Toggle",
+  "name": "@leafygreen-ui/toggle",
   "version": "1.1.1",
   "description": "LeafyGreen UI Kit Toggle",
   "main": "./dist/index.js",


### PR DESCRIPTION
These updates should allow `npm run release` or `lerna publish` to publish all packages to the public NPM.