### PR TITLE
PD-237: Fix Icon / theme build

### DIFF
--- a/packages/Icon/src/createIconComponent.js
+++ b/packages/Icon/src/createIconComponent.js
@@ -27,6 +27,10 @@ export default function createIconComponent(glyphs) {
     );
   };
 
+  Icon.createIconComponent = createIconComponent;
+
+  Icon.glyphs = glyphs;
+
   Icon.displayName = 'Icon';
 
   Icon.propTypes = {
@@ -42,4 +46,4 @@ export default function createIconComponent(glyphs) {
   };
 
   return Icon;
-};
+}

--- a/packages/Icon/src/createIconComponent.js
+++ b/packages/Icon/src/createIconComponent.js
@@ -27,10 +27,6 @@ export default function createIconComponent(glyphs) {
     );
   };
 
-  Icon.createIconComponent = createIconComponent;
-
-  Icon.glyphs = glyphs;
-
   Icon.displayName = 'Icon';
 
   Icon.propTypes = {

--- a/packages/Icon/src/index.js
+++ b/packages/Icon/src/index.js
@@ -1,5 +1,4 @@
 import createIconComponent from './createIconComponent';
 import glyphs from './glyphs';
 
-export { glyphs, createIconComponent };
 export default createIconComponent(glyphs);

--- a/packages/Icon/src/index.js
+++ b/packages/Icon/src/index.js
@@ -1,4 +1,5 @@
 import createIconComponent from './createIconComponent';
 import glyphs from './glyphs';
 
+export { glyphs, createIconComponent };
 export default createIconComponent(glyphs);

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,1 +1,1 @@
-export {default as colors} from './colors';
+export { default as colors } from './colors';

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,2 +1,1 @@
-import colors from './colors';
-export default { colors };
+export {default as colors} from './colors';


### PR DESCRIPTION
Previously, the following import didn't work:
```JS
import Icon, {glyphs, createIconComponent} from '@leafygreen-ui/Icon'
```

This pull request fixes this issue.