### PR TITLE
Chore: export popover props and clean object defaults

### DIFF
--- a/packages/Popover/src/Popover.tsx
+++ b/packages/Popover/src/Popover.tsx
@@ -59,7 +59,7 @@ export enum Justify {
   End = 'end',
 }
 
-interface PopoverProps {
+export interface PopoverProps {
   /**
    * Content that will appear inside of the popover component.
    */
@@ -139,15 +139,15 @@ interface PopoverProps {
  * @param props.adjustOnMutation Should the Popover auto adjust its content when the DOM changes (using MutationObserver).
  */
 function Popover({
-  children,
-  active,
+  children = undefined,
+  active = false,
+  usePortal = true,
+  spacing = 10,
+  align = Align.Bottom,
+  justify = Justify.Start,
+  adjustOnMutation = false,
   className,
-  usePortal,
-  spacing,
-  align,
-  justify,
   refEl,
-  adjustOnMutation,
   ...rest
 }: PopoverProps): ReactElement {
   const [placeholderNode, setPlaceholderNode] = useElementNode();
@@ -251,16 +251,6 @@ Popover.propTypes = {
   usePortal: PropTypes.bool,
   spacing: PropTypes.number,
   adjustOnMutation: PropTypes.bool,
-};
-
-Popover.defaultProps = {
-  children: undefined,
-  align: Align.Bottom,
-  justify: Justify.Start,
-  active: false,
-  usePortal: true,
-  spacing: 10,
-  adjustOnMutation: false,
 };
 
 export default Popover;

--- a/packages/Popover/src/Popover.tsx
+++ b/packages/Popover/src/Popover.tsx
@@ -139,13 +139,13 @@ export interface PopoverProps {
  * @param props.adjustOnMutation Should the Popover auto adjust its content when the DOM changes (using MutationObserver).
  */
 function Popover({
-  children = undefined,
   active = false,
   usePortal = true,
   spacing = 10,
   align = Align.Bottom,
   justify = Justify.Start,
   adjustOnMutation = false,
+  children,
   className,
   refEl,
   ...rest

--- a/packages/Popover/src/index.ts
+++ b/packages/Popover/src/index.ts
@@ -1,4 +1,4 @@
 import Popover from './Popover';
-export { Align, Justify } from './Popover';
+export { Align, Justify, PopoverProps } from './Popover';
 
 export default Popover;


### PR DESCRIPTION
## ✍️ Proposed changes

Export Popover props in Popover.tsx and index.ts to be used in Menu
Also removed defaultProps in favor of object defaults

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->
