### PR TITLE
fix: make popover props optional where necc

### DIFF
--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -47,6 +47,7 @@ function Menu({
   align = Align.Bottom,
   justify = Justify.End,
   usePortal = true,
+  adjustOnMutation = false,
   active,
   children,
   className,
@@ -65,6 +66,7 @@ function Menu({
       refEl={refEl}
       usePortal={usePortal}
       spacing={15}
+      adjustOnMutation={adjustOnMutation}
     >
       <div {...rest} className={cx(rootMenuStyle, className)} role="menu">
         {children}

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -58,14 +58,14 @@ export interface PopoverProps {
    *
    * default: `bottom`
    */
-  align: Align;
+  align?: Align;
 
   /**
    * Determines the justification of the popover content relative to the trigger element
    *
    * default: `start`
    */
-  justify: Justify;
+  justify?: Justify;
 
   /**
    * A reference to the element against which the popover component will be positioned.
@@ -78,21 +78,21 @@ export interface PopoverProps {
    *
    * default: `true`
    */
-  usePortal: boolean;
+  usePortal?: boolean;
 
   /**
    * Specifies the amount of spacing (in pixels) between the trigger element and the Popover content.
    *
    * default: `10`
    */
-  spacing: number;
+  spacing?: number;
 
   /**
    * Should the Popover auto adjust its content when the DOM changes (using MutationObserver).
    *
    * default: false
    */
-  adjustOnMutation: boolean;
+  adjustOnMutation?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Popover required the use of all of its props, which was causing errors in Menu and other components that use it as a dependency. PR to make some of these props optional.

🎟 _Jira ticket:_ [Name of ticket](https://my.jira/ticket)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->
