### PR TITLE
PD-373: Fix broken reference to SVGR namespace

### DIFF
--- a/packages/icon/src/index.ts
+++ b/packages/icon/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="../typings/svgr.d.ts" />
+
 import createIconComponent from './createIconComponent';
 import glyphs from './glyphs';
 

--- a/packages/icon/typings/svgr.d.ts
+++ b/packages/icon/typings/svgr.d.ts
@@ -7,3 +7,8 @@ declare namespace SVGR {
   }
   type Component = React.ComponentType<ComponentProps>;
 }
+
+declare module '*.svg' {
+  const value: SVGR.Component;
+  export = value;
+}

--- a/typings/images.d.ts
+++ b/typings/images.d.ts
@@ -12,8 +12,3 @@ declare module '*.gif' {
   const value: string;
   export = value;
 }
-
-declare module '*.svg' {
-  const value: SVGR.Component;
-  export = value;
-}


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Right now, users of the Icon component within a TypeScript project receive an error regarding a broken reference to the SVGR namespace. This fixes that broken reference.

🎟 _Jira ticket:_ [Fix SVGR typing issue](https://jira.mongodb.org/browse/PD-373)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~

