### PR TITLE
fix(icon): PD-355 Use currentcolor to set glyph fills

### DIFF
--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -19,9 +19,9 @@ const SomeComponent = () => <Icon glyph="plus" fill="#FF0000" />;
 **Output HTML**
 
 ```HTML
-<svg width="16" height="16" role="img" viewBox="0 0 16 16" fill="#000000" size="16">
+<svg width="16" height="16" role="img" viewBox="0 0 16 16" class="leafygreen-ui-yqbynm">
 	<title>Plus Icon</title>
-	<path d="M9 7h4v2H9v4H7V9H3V7h4V3h2v4z" fill="#FF0000" fill-rule="evenodd"></path>
+	<path d="M9 7h4v2H9v4H7V9H3V7h4V3h2v4z" fill="currentColor" fill-rule="evenodd"></path>
 </svg>
 ```
 
@@ -49,9 +49,7 @@ The height and width of the glyph's viewBox. This can be any `number` or one of 
 
 **Type:** `String`
 
-**Default:** `#000000`
-
-The fill color that is passed to the glyph.
+The fill color that is passed to the glyph. By default, the glyph will inherit its fill from the CSS color property of its nearest ancestor.
 
 ## Advanced Usage (Registering custom icon sets)
 

--- a/packages/icon/tsconfig.json
+++ b/packages/icon/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "declarationDir": "dist"
   },
-  "include": ["src/**/*", "../../typings"]
+  "include": ["src/**/*", "../../typings", "typings/**/*"]
 }


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Updated Icon component such that fill styling now uses currentColor, and thus CSS color rules can be used to style glyphs. 

🎟 _Jira ticket:_ [PD-355](https://jira.mongodb.org/browse/PD-355)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->
