### PR TITLE
Make the root button element a new stacking context

### DIFF
--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -183,6 +183,10 @@ const buttonSizes: { readonly [K in Size]: string } = {
 
 const baseStyle = css`
   position: relative;
+  // Establishes the root element as a new stacking context
+  // so that the z-index of the span within the button doesn't
+  // appear above other elements on the page that it shouldn't.
+  z-index: 0;
   border-radius: 3px;
   box-sizing: border-box;
   cursor: pointer;

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -320,7 +320,11 @@ export default function Button(props: ButtonProps) {
     >
       <span
         className={css`
-          position: relative;
+          // Usually for this to take effect, you would need the element to be
+          // "positioned". Due to an obscure part of CSS spec, flex children
+          // respect z-index without the position property being set.
+          //
+          // https://www.w3.org/TR/css-flexbox-1/#painting
           z-index: 1;
         `}
       >


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

A fix for a bug that was reported directly to me.

The recently introduced span element in button has a z-index assigned that was being applied in a global stacking context. This change makes the button root element a new stacking context to avoid this issue.

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~
