### PR TITLE
PD-378: Add a 'small' size variant to the Icon component

### DIFF
--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -13,7 +13,7 @@ npm install @leafygreen-ui/icon
 ```js
 import Icon from '@leafygreen-ui/icon';
 
-const SomeComponent = () => <Icon glyph="plus" fill="#FF0000" />;
+const SomeComponent = () => <Icon glyph="Plus" fill="#FF0000" />;
 ```
 
 **Output HTML**
@@ -43,7 +43,7 @@ Specifies the glyph to use. This can be one of the following:
 
 The height and width of the glyph's viewBox. This can be any `number` or one of the following:
 
-`default`, `large`, `xLarge`
+`small`, `default`, `large`, `xLarge`
 
 ### fill
 

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -43,7 +43,7 @@ Specifies the glyph to use. This can be one of the following:
 
 The height and width of the glyph's viewBox. This can be any `number` or one of the following:
 
-`small`, `default`, `large`, `xLarge`
+`small`, `default`, `large`, `xlarge`
 
 ### fill
 

--- a/packages/icon/src/createIconComponent.tsx
+++ b/packages/icon/src/createIconComponent.tsx
@@ -6,6 +6,7 @@ interface GlyphMap {
 }
 
 export const Size = {
+  Small: 'small',
   Default: 'default',
   Large: 'large',
   XLarge: 'xlarge',
@@ -20,6 +21,7 @@ export interface IconProps<G extends GlyphMap>
 }
 
 const sizeMap: { [S in Size]: number } = {
+  small: 14,
   default: 16,
   large: 24,
   xlarge: 32,

--- a/packages/palette/README.md
+++ b/packages/palette/README.md
@@ -17,7 +17,7 @@ npm install @leafygreen-ui/palette
 ```
 
 ```js
-import { uiColors } from `@leafygreen-ui/palette`;
+import { uiColors } from '@leafygreen-ui/palette';
 
 /**
  * uiColors = {

--- a/packages/palette/README.md
+++ b/packages/palette/README.md
@@ -64,8 +64,6 @@ import { uiColors } from '@leafygreen-ui/palette';
  */
 
 const example = () => (
-	<span style={{ color: uiColors.gray.dark1 }}>
-		Hello World
-	</span>
-)
+  <span style={{ color: uiColors.gray.dark1 }}>Hello World</span>
+);
 ```


### PR DESCRIPTION
## ✍️ Proposed changes
Add a `small` variant to the `Icon` component

🎟 _Jira ticket:_ [PD-378](https://jira.mongodb.org/browse/PD-378)

## 🛠 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Some small README fixes included here
