### PR TITLE
Adds changesets for the Card, Button, and Icon updates

### DIFF
--- a/.changeset/fresh-foxes-hang/changes.json
+++ b/.changeset/fresh-foxes-hang/changes.json
@@ -1,0 +1,10 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/icon", "type": "major" }],
+  "dependents": [
+    {
+      "name": "@leafygreen-ui/modal",
+      "type": "patch",
+      "dependencies": ["@leafygreen-ui/icon"]
+    }
+  ]
+}

--- a/.changeset/fresh-foxes-hang/changes.md
+++ b/.changeset/fresh-foxes-hang/changes.md
@@ -1,1 +1,2 @@
-Icon now uses currentColor to set fill. If the fill prop is not set, the fill of an icon will now be inherited from its decendent's color. Additionally, Icon now includes a `small` size variant that renders the glyph as a 14x14px SVG element.
+- Icon now uses currentColor to set fill. If the fill prop is not set, the fill of an icon will now be inherited from its decendent's color.
+- Icon now includes a `small` size variant that renders the glyph as a 14x14px SVG element.

--- a/.changeset/fresh-foxes-hang/changes.md
+++ b/.changeset/fresh-foxes-hang/changes.md
@@ -1,0 +1,1 @@
+Icon now uses currentColor to set fill. If the fill prop is not set, the fill of an icon will now be inherited from its decendent's color. Additionally, Icon now includes a `small` size variant that renders the glyph as a 14x14px SVG element.

--- a/.changeset/itchy-hotels-pretend/changes.json
+++ b/.changeset/itchy-hotels-pretend/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/card", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/itchy-hotels-pretend/changes.md
+++ b/.changeset/itchy-hotels-pretend/changes.md
@@ -1,0 +1,1 @@
+Fixes a TypeScript issue with the typing of rest parameters in Card

--- a/.changeset/silver-jokes-turn/changes.json
+++ b/.changeset/silver-jokes-turn/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/button", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/silver-jokes-turn/changes.md
+++ b/.changeset/silver-jokes-turn/changes.md
@@ -1,0 +1,1 @@
+Fixes an issue where the children of Button had a z-index that was being applied in a global stacking context.

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 package.json
 storybook/public/
+.changeset/


### PR DESCRIPTION
Adds changesets for several recent PRs.

Additionally, this ignores the `.changeset` directory when validating formatting with prettier.