### PR TITLE
position input inside the boundary of parent label

### DIFF
--- a/.changeset/spicy-dolphins-juggle/changes.json
+++ b/.changeset/spicy-dolphins-juggle/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/checkbox", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/spicy-dolphins-juggle/changes.md
+++ b/.changeset/spicy-dolphins-juggle/changes.md
@@ -1,0 +1,1 @@
+psition input inside the boundary of parent label

--- a/.changeset/spicy-dolphins-juggle/changes.md
+++ b/.changeset/spicy-dolphins-juggle/changes.md
@@ -1,1 +1,1 @@
-psition input inside the boundary of parent label
+Position input inside the boundary of parent label

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -45,8 +45,10 @@ const checkboxStyle = css`
 const inputStyle = css`
   margin: 0;
   position: absolute;
-  left: 100%;
-  top: 100%;
+  height: 0;
+  width: 0;
+  left: 0;
+  top: 0;
   pointer-events: none;
   opacity: 0;
 


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This fixes the bug logged at https://jira.mongodb.org/browse/CHARTS-2938. It happens because the hidden input is positioned out side of the boundary box of the parent label. Fix it by move the input inside the bounding box and also set its width and height to 0 for added safety.

🎟 _Jira ticket:_ [CHARTS-2938](https://jira.mongodb.org/browse/CHARTS-2938)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->
