### PR TITLE
PD-393: Make Tabs more accessible

### DIFF
--- a/.changeset/slimy-insects-lie/changes.json
+++ b/.changeset/slimy-insects-lie/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/tabs", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/slimy-insects-lie/changes.md
+++ b/.changeset/slimy-insects-lie/changes.md
@@ -1,0 +1,1 @@
+Fixed aria tags in Tab component to be accessible against a11y standards

--- a/packages/tabs/src/Tab.tsx
+++ b/packages/tabs/src/Tab.tsx
@@ -80,8 +80,8 @@ function Tab({
     <div
       {...rest}
       aria-disabled={disabled}
-      aria-selected={selected}
       aria-controls={ariaControl}
+      id={ariaControl}
       role="tabpanel"
     >
       {children}


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Updating Tabs component to be more accessible based on bugs detected with the Storybook accessibility add-on. 

* Want to note that the color contrast on the non-active Tabs is not sufficient, so this PR does not make Tabs fully compliant.

🎟 _Jira ticket:_ [PD-393](https://jira.mongodb.org/browse/PD-393?workflowName=Product+Design+Workflow&stepId=54)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

