### PR TITLE
PD-391: Make RadioBoxGroup accessible

### DIFF
--- a/.changeset/blue-falcons-love/changes.json
+++ b/.changeset/blue-falcons-love/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/radio-box-group", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/blue-falcons-love/changes.json
+++ b/.changeset/blue-falcons-love/changes.json
@@ -1,4 +1,4 @@
 {
-  "releases": [{ "name": "@leafygreen-ui/radio-box-group", "type": "patch" }],
+  "releases": [{ "name": "@leafygreen-ui/radio-box-group", "type": "major" }],
   "dependents": []
 }

--- a/.changeset/blue-falcons-love/changes.md
+++ b/.changeset/blue-falcons-love/changes.md
@@ -1,1 +1,1 @@
-Added group role to RadioBoxGroup container div and supplied aria-label to ensure component is accessible
+Added `group` role to RadioBoxGroup container div and supplied a value `aria-label` attribute, in order to ensure component is accessible.

--- a/.changeset/blue-falcons-love/changes.md
+++ b/.changeset/blue-falcons-love/changes.md
@@ -1,0 +1,1 @@
+Added group role to RadioBoxGroup container div and supplied aria-label to ensure component is accessible

--- a/packages/radio-box-group/src/RadioBoxGroup.tsx
+++ b/packages/radio-box-group/src/RadioBoxGroup.tsx
@@ -147,7 +147,7 @@ export default class RadioBoxGroup extends PureComponent<
         {...rest}
         className={cx(baseGroupStyle, className)}
         role="group"
-        aria-label={this.defaultName}
+        aria-label={name}
       >
         {renderedChildren}
       </div>

--- a/packages/radio-box-group/src/RadioBoxGroup.tsx
+++ b/packages/radio-box-group/src/RadioBoxGroup.tsx
@@ -143,7 +143,12 @@ export default class RadioBoxGroup extends PureComponent<
     });
 
     return (
-      <div {...rest} className={cx(baseGroupStyle, className)}>
+      <div
+        {...rest}
+        className={cx(baseGroupStyle, className)}
+        role="group"
+        aria-label={this.defaultName}
+      >
         {renderedChildren}
       </div>
     );


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Added role="group" and aria-label to containing RadioBoxGroup div to make component accessible by a11y standards.

🎟 _Jira ticket:_ [PD-391](https://jira.mongodb.org/browse/PD-391)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

