### PR TITLE
PD-392: Make RadioGroup accessible

### DIFF
--- a/.changeset/blue-falcons-love/changes.json
+++ b/.changeset/blue-falcons-love/changes.json
@@ -1,4 +1,4 @@
 {
-  "releases": [{ "name": "@leafygreen-ui/radio-box-group", "type": "major" }],
+  "releases": [{ "name": "@leafygreen-ui/radio-box-group", "type": "patch" }],
   "dependents": []
 }

--- a/.changeset/tough-hounds-cheer/changes.json
+++ b/.changeset/tough-hounds-cheer/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/radio-group", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/tough-hounds-cheer/changes.md
+++ b/.changeset/tough-hounds-cheer/changes.md
@@ -1,0 +1,1 @@
+Added group role to RadioGroup container div and supplied aria-label to ensure component is accessible

--- a/packages/radio-box-group/README.md
+++ b/packages/radio-box-group/README.md
@@ -16,7 +16,11 @@ import { RadioBox, RadioBoxGroup } from '@leafygreen-ui/radio-box-group';
 ## Output HTML
 
 ```html
-<div class="leafygreen-ui-k008qs radio-box-group-style">
+<div
+  class="leafygreen-ui-k008qs radio-box-group-style"
+  role="group"
+  aria-label="radio-box-group-850132"
+>
   <label for="radio-box-group-850132-button-0" class="leafygreen-ui-i6e9um">
     <input
       type="radio"

--- a/packages/radio-group/README.md
+++ b/packages/radio-group/README.md
@@ -23,7 +23,11 @@ import { Radio, RadioGroup } from '@leafygreen-ui/radio-group';
 ## Output HTML
 
 ```html
-<div class="leafygreen-ui-16glayc my-radio-group">
+<div
+  class="leafygreen-ui-16glayc my-radio-group"
+  role="group"
+  aria-label="radio-group-660118"
+>
   <label
     for="radio-group-660118-button-0"
     class="leafygreen-ui-11wfvmq my-radio"

--- a/packages/radio-group/src/RadioGroup.tsx
+++ b/packages/radio-group/src/RadioGroup.tsx
@@ -164,7 +164,7 @@ export default class RadioGroup extends PureComponent<
           className,
         )}
         role="group"
-        aria-label={this.defaultName}
+        aria-label={name}
       >
         {renderChildren}
       </div>

--- a/packages/radio-group/src/RadioGroup.tsx
+++ b/packages/radio-group/src/RadioGroup.tsx
@@ -163,6 +163,8 @@ export default class RadioGroup extends PureComponent<
           `,
           className,
         )}
+        role="group"
+        aria-label={this.defaultName}
       >
         {renderChildren}
       </div>


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Added group role to RadioGroup container div and supplied aria-label to ensure component is accessible

🎟 _Jira ticket:_ [PD-392](https://jira.mongodb.org/browse/PD-392)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
