### PR TITLE
PD-295: Make Menu accessible

### DIFF
--- a/.changeset/shaggy-camels-nail/changes.json
+++ b/.changeset/shaggy-camels-nail/changes.json
@@ -1,0 +1,10 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/menu", "type": "patch" }],
+  "dependents": [
+    {
+      "name": "@leafygreen-ui/mongo-menu",
+      "type": "patch",
+      "dependencies": ["@leafygreen-ui/menu"]
+    }
+  ]
+}

--- a/.changeset/shaggy-camels-nail/changes.md
+++ b/.changeset/shaggy-camels-nail/changes.md
@@ -1,0 +1,1 @@
+Removed `role='menu'` from MenuGroup in order to make component accessible

--- a/packages/menu/src/Menu.spec.js
+++ b/packages/menu/src/Menu.spec.js
@@ -11,7 +11,7 @@ describe('packages/Menu', () => {
   const setOpen = jest.fn();
   const className = 'test-className';
 
-  const { getByTestId, getByText, getAllByRole } = render(
+  const { getByTestId, getByText } = render(
     <Menu open setOpen={setOpen} data-testid="test-menu">
       <MenuGroup>
         <MenuItem className={className} onClick={onClick}>
@@ -60,14 +60,6 @@ describe('packages/Menu', () => {
       fireEvent.click(button);
 
       expect(menuItem).not.toBeVisible();
-    });
-  });
-
-  describe('packages/MenuGroup', () => {
-    test('Creates a dropdown group div with role menu', () => {
-      const menuGroup = getAllByRole('menu')[1];
-      const menuItem = getByText('Item A');
-      expect(menuGroup).toContainElement(menuItem);
     });
   });
 

--- a/packages/menu/src/MenuGroup.tsx
+++ b/packages/menu/src/MenuGroup.tsx
@@ -30,7 +30,7 @@ interface MenuGroupProps {
  */
 function MenuGroup({ children, className, ...rest }: MenuGroupProps) {
   return (
-    <section {...rest} {...menuGroup.prop} className={className} role="menu">
+    <section {...rest} {...menuGroup.prop} className={className}>
       {children}
     </section>
   );


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Removed role='menu' from MenuGroup component, based on accessibility guidelines. And removed associated test (which was testing that MenuGroup had that role).

🎟 _Jira ticket:_ [PD-295](https://jira.mongodb.org/browse/PD-295)
