### PR TITLE
PD-409: useEscapeKey

### DIFF
--- a/.changeset/silly-trees-approve/changes.md
+++ b/.changeset/silly-trees-approve/changes.md
@@ -1,1 +1,1 @@
-Replaced existing Escape handling with new useEscapeHandler hook
+Replaced existing Escape handling with new useEscapeKey hook

--- a/.changeset/tidy-buckets-pretend/changes.md
+++ b/.changeset/tidy-buckets-pretend/changes.md
@@ -1,1 +1,1 @@
-Add useEscapeHandler hook
+Add useEscapeKey hook

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -2,12 +2,12 @@ import useEventListener from './useEventListener';
 import useElementNode from './useElementNode';
 import useMutationObserver from './useMutationObserver';
 import useViewportSize from './useViewportSize';
-import useHandleEscape from './useHandleEscape';
+import useEscapeKey from './useEscapeKey';
 
 export {
   useEventListener,
   useElementNode,
   useMutationObserver,
   useViewportSize,
-  useHandleEscape,
+  useEscapeKey,
 };

--- a/packages/hooks/src/useEscapeKey.ts
+++ b/packages/hooks/src/useEscapeKey.ts
@@ -4,7 +4,7 @@ const escapeKeyCode = 27;
 
 const handleEscape = (e: KeyboardEvent, callback: () => void) => {
   if (e.keyCode === escapeKeyCode) {
-    e.stopPropagation();
+    e.stopImmediatePropagation();
     callback();
   }
 };

--- a/packages/hooks/src/useEscapeKey.ts
+++ b/packages/hooks/src/useEscapeKey.ts
@@ -4,7 +4,7 @@ const escapeKeyCode = 27;
 
 const handleEscape = (e: KeyboardEvent, callback: () => void) => {
   if (e.keyCode === escapeKeyCode) {
-    e.stopImmediatePropagation();
+    e.stopPropagation();
     callback();
   }
 };
@@ -18,8 +18,8 @@ const handleEscape = (e: KeyboardEvent, callback: () => void) => {
  * @param options.dependencies Array to be passed to useEffect hook, such that the hook will only run if the array's values have changed.
  * @param options.element Value to be passed as target of event handler, will default to document.
  */
-const useHandleEscape = (callback: () => void, options?: UseEventOptions) => {
+const useEscapeKey = (callback: () => void, options?: UseEventOptions) => {
   return useEventListener('keydown', e => handleEscape(e, callback), options);
 };
 
-export default useHandleEscape;
+export default useEscapeKey;

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Popover, { Align, Justify, PopoverProps } from '@leafygreen-ui/popover';
-import { useEventListener, useHandleEscape } from '@leafygreen-ui/hooks';
+import { useEventListener, useEscapeKey } from '@leafygreen-ui/hooks';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
 import { transparentize } from 'polished';
@@ -110,7 +110,7 @@ function Menu({
     enabled,
   });
 
-  useHandleEscape(handleClose, { enabled });
+  useEscapeKey(handleClose, { enabled });
 
   const popoverContent = (
     <Popover

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -5,7 +5,7 @@ import { transparentize } from 'polished';
 import facepaint from 'facepaint';
 import Portal from '@leafygreen-ui/portal';
 import Icon, { Size } from '@leafygreen-ui/icon';
-import { useHandleEscape } from '@leafygreen-ui/hooks';
+import { useEscapeKey } from '@leafygreen-ui/hooks';
 import { uiColors } from '@leafygreen-ui/palette';
 import { css, cx } from '@leafygreen-ui/emotion';
 
@@ -183,7 +183,7 @@ function Modal({
     }
   };
 
-  useHandleEscape(handleClose);
+  useEscapeKey(handleClose);
 
   return (
     <Transition in={open} timeout={500} mountOnEnter unmountOnExit>


### PR DESCRIPTION
- Renamed useEscapeHandler to useEscapeKey
- Updated instances in use and changeset to reflect new name
- Removed `immediateProp` in favor of `stopProp`
