### PR TITLE
PD-421: Exclude react-dom from bundles

### DIFF
--- a/.changeset/silent-mangos-yawn/changes.json
+++ b/.changeset/silent-mangos-yawn/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@leafygreen-ui/portal", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/silent-mangos-yawn/changes.md
+++ b/.changeset/silent-mangos-yawn/changes.md
@@ -1,0 +1,1 @@
+Dramatically reduces the package's bundle size by excluding react-dom from the bundle.

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -11,6 +11,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "react-dom": "^16.0.0"
+  },
   "dependencies": {
     "@leafygreen-ui/lib": "^3.0.6"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = function(env = 'production') {
     externals: isProduction
       ? [
           'react',
+          'react-dom',
           'emotion',
           'react-emotion',
           'create-emotion',


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

This pull request adds `react-dom` to our list of external dependencies noted in our webpack config, dramatically reducing the portal component's bundle size.

🎟 _Jira ticket:_ [PD-421](https://jira.mongodb.org/browse/PD-421)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes
