### PR TITLE
PD-455: Fix bug in storybook to display hex values

### DIFF
--- a/.changeset/fresh-pumpkins-change.md
+++ b/.changeset/fresh-pumpkins-change.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/palette': patch
+---
+
+Fix bug in storybook such that HEX values are now displayed

--- a/packages/palette/src/palette.story.tsx
+++ b/packages/palette/src/palette.story.tsx
@@ -19,12 +19,11 @@ const ColorBlock = styled<'div', ColorBlockProps>('div')`
   border-radius: 8px;
   margin: 10px;
   margin-bottom: 20px;
-  box-shadow: 0 8px 6px -8px ${props =>
-    transparentize(0.7, darken(0.2, props.color))},
+  box-shadow: 0 8px 6px -8px ${props => transparentize(0.7, darken(0.2, props.color))},
     0 2px 3px ${props => transparentize(0.8, darken(0.5, props.color))};
 
   &:before {
-    content: attr(data-color);
+    content: attr(color);
     position: absolute;
     bottom: 0.3rem;
     left: 0.3rem;
@@ -38,7 +37,7 @@ const ColorBlock = styled<'div', ColorBlockProps>('div')`
   }
 
   &:after {
-    content: "${props => props.name}";
+    content: attr(name);
     position: absolute;
     top: calc(100% + 8px);
     font-size: 12px;


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

- Fixed bug in Palette storybook such that hex values and color names are now displayed

🎟 _Jira ticket:_ [PD-455](https://jira.mongodb.org/browse/PD-455)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

