### PR TITLE
PD-457: Allow target/rel props to be passed to MenuItem

### DIFF
--- a/.changeset/witty-goats-mate.md
+++ b/.changeset/witty-goats-mate.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/menu': patch
+---
+
+Allow target and rel props to be passed to MenuItem, when MenuItem is a link

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -15,7 +15,7 @@
     "@leafygreen-ui/hooks": "^1.1.0",
     "@leafygreen-ui/lib": "^3.2.0",
     "@leafygreen-ui/popover": "^2.0.0",
-    "@leafygreen-ui/palette": "^1.1.0"
+    "@leafygreen-ui/palette": "^1.1.1"
   },
   "gitHead": "dd71a2d404218ccec2e657df9c0263dc1c15b9e0"
 }

--- a/packages/menu/src/Menu.spec.js
+++ b/packages/menu/src/Menu.spec.js
@@ -71,7 +71,12 @@ describe('packages/Menu', () => {
         >
           Item 1
         </MenuItem>
-        <MenuItem href="http://mongodb.design" data-testid="second-item">
+        <MenuItem
+          href="http://mongodb.design"
+          data-testid="second-item"
+          target="_self"
+          rel=""
+        >
           Item 2
         </MenuItem>
       </div>,
@@ -91,6 +96,11 @@ describe('packages/Menu', () => {
 
     test('renders inside of an `a` instead of a `button` tag, when `href` prop is supplied', () => {
       expect(secondItem.tagName.toLowerCase()).toBe('a');
+    });
+
+    test('renders with correct target and rel values when set', () => {
+      expect(secondItem.target).toBe('_self');
+      expect(secondItem.rel).toBe('');
     });
   });
 });

--- a/packages/menu/src/Menu.spec.js
+++ b/packages/menu/src/Menu.spec.js
@@ -75,7 +75,7 @@ describe('packages/Menu', () => {
           href="http://mongodb.design"
           data-testid="second-item"
           target="_self"
-          rel=""
+          rel="help"
         >
           Item 2
         </MenuItem>
@@ -100,7 +100,7 @@ describe('packages/Menu', () => {
 
     test('renders with correct target and rel values when set', () => {
       expect(secondItem.target).toBe('_self');
-      expect(secondItem.rel).toBe('');
+      expect(secondItem.rel).toBe('help');
     });
   });
 });

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -1,8 +1,8 @@
 import React, { RefObject } from 'react';
 import PropTypes from 'prop-types';
+import { HTMLElementProps, createDataProp } from '@leafygreen-ui/lib';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
-import { createDataProp } from '@leafygreen-ui/lib';
 
 const menuItemContainer = createDataProp('menu-item-container');
 
@@ -137,21 +137,11 @@ const disbaledTextStyle = css`
   color: ${uiColors.gray.light1};
 `;
 
-export interface MenuItemProps {
-  /**
-   * If supplied, MenuItem will be rendered inside of `a` tags.
-   */
-  href?: string;
-
+interface SharedMenuItemProps {
   /**
    * Class name that will be applied to root MenuItem element.
    */
   className?: string;
-
-  /**
-   * Callback function to be executed when MenuItem is clicked.
-   */
-  onClick?: React.MouseEventHandler;
 
   /**
    * Main content displayed in MenuItem.
@@ -159,21 +149,37 @@ export interface MenuItemProps {
   children?: React.ReactNode;
 
   /**
-   * Description text displayed below title in MenuItem.
-   */
-  description?: string;
-
-  /**
-   * Determines whether or not the MenuItem is disabled.
-   */
-  disabled?: boolean;
-
-  /**
    * Determines whether or not the MenuItem is active.
    */
   active?: boolean;
 
+  /**
+   * Description text displayed below title in MenuItem.
+   */
+  description?: string;
+  /**
+   * Determines whether or not the MenuItem is disabled.
+   */
+  disabled?: boolean;
   ref?: any;
+}
+
+interface LinkMenuItemProps extends HTMLElementProps<'a'>, SharedMenuItemProps {
+  href: string;
+}
+
+interface ButtonMenuItemProps
+  extends HTMLElementProps<'button'>,
+    SharedMenuItemProps {
+  href?: null;
+}
+
+type MenuItemProps = LinkMenuItemProps | ButtonMenuItemProps;
+
+function usesLinkElement(
+  props: LinkMenuItemProps | ButtonMenuItemProps,
+): props is LinkMenuItemProps {
+  return props.href != null;
 }
 
 /**
@@ -196,7 +202,6 @@ const MenuItem = React.forwardRef(
     {
       disabled = false,
       active = false,
-      href,
       onClick,
       className,
       children,
@@ -205,19 +210,17 @@ const MenuItem = React.forwardRef(
     }: MenuItemProps,
     forwardedref,
   ) => {
-    const Root = href ? 'a' : 'button';
-
-    const anchorProps = href && {
+    const anchorProps = rest.href && {
       target: '_blank',
       rel: 'noopener noreferrer',
     };
 
-    return (
+    const renderMenuItem = (Root: React.ElementType<any> = 'button') => (
       <li role="none">
         <Root
+          {...anchorProps}
           {...rest}
           {...menuItemContainer.prop}
-          {...anchorProps}
           className={cx(
             containerStyle,
             linkStyle,
@@ -230,7 +233,6 @@ const MenuItem = React.forwardRef(
           role="menuitem"
           aria-disabled={disabled}
           onClick={disabled ? undefined : onClick}
-          href={href}
           ref={forwardedref as RefObject<any>}
           tabIndex={disabled ? -1 : undefined}
         >
@@ -255,6 +257,12 @@ const MenuItem = React.forwardRef(
         </Root>
       </li>
     );
+
+    if (usesLinkElement({ ...rest })) {
+      return renderMenuItem('a');
+    }
+
+    return renderMenuItem();
   },
 );
 

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -258,7 +258,7 @@ const MenuItem = React.forwardRef(
       </li>
     );
 
-    if (usesLinkElement({ ...rest })) {
+    if (usesLinkElement(rest)) {
       return renderMenuItem('a');
     }
 


### PR DESCRIPTION
## ✍️ Proposed changes

- Make MenuItem props extend HTML element based on whether it's being rendered as a button or an anchor tag
- Allow consumers to customize `target` and `rel` props
- Added test to prove that fix works

🎟 _Jira ticket:_ [PD-457](https://jira.mongodb.org/browse/PD-457)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

