### PR TITLE
PD-461: Update anchor styles for Menu and MongoMenu components

### DIFF
--- a/.changeset/clean-tables-eat.md
+++ b/.changeset/clean-tables-eat.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/button': patch
+---
+
+Added fallback CSS for focus and hover states

--- a/.changeset/five-socks-jam.md
+++ b/.changeset/five-socks-jam.md
@@ -1,0 +1,6 @@
+---
+'@leafygreen-ui/menu': patch
+'@leafygreen-ui/mongo-menu': patch
+---
+
+Update anchor styles to minimize overrides

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -200,8 +200,10 @@ const baseStyle = css`
   user-select: none;
   overflow: hidden;
 
+  &:focus,
   &:hover {
     text-decoration: none;
+    color: inherit;
   }
 
   // We're using CSS pseudo elements here in order to

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -37,6 +37,7 @@ const containerStyle = css`
   }
 
   &:hover {
+    text-decoration: none;
     background-color: ${uiColors.gray.light3};
 
     &:before {
@@ -54,6 +55,7 @@ const containerStyle = css`
 
   &:focus {
     outline: none;
+    text-decoration: none;
     background-color: ${uiColors.blue.light3};
     color: ${uiColors.blue.dark3};
 

--- a/packages/mongo-menu/src/MongoMenu.tsx
+++ b/packages/mongo-menu/src/MongoMenu.tsx
@@ -134,12 +134,6 @@ const accountButtonStyle = css`
   justify-content: center;
   align-items: center;
   margin-bottom: 14px;
-
-  &:focus,
-  &:hover {
-    text-decoration: none;
-    color: ${uiColors.gray.dark2};
-  }
 `;
 
 const descriptionStyle = css`

--- a/packages/mongo-menu/src/MongoMenu.tsx
+++ b/packages/mongo-menu/src/MongoMenu.tsx
@@ -26,6 +26,7 @@ const buttonReset = css`
   }
 
   &:active {
+    outline: none;
     color: ${uiColors.gray.dark2};
 
     &:before {
@@ -133,6 +134,12 @@ const accountButtonStyle = css`
   justify-content: center;
   align-items: center;
   margin-bottom: 14px;
+
+  &:focus,
+  &:hover {
+    text-decoration: none;
+    color: ${uiColors.gray.dark2};
+  }
 `;
 
 const descriptionStyle = css`


### PR DESCRIPTION
## ✍️ Proposed changes

This updates the styles specifically for focus/active states for anchors in Menu and MongoMenu with rules that are already inherited but need to be specifically included in order to avoid third party libraries from overwriting these with values set on `a` tags specifically. This was found during [library upgrades for the quarter](https://jira.mongodb.org/browse/CLOUDP-49387), and we figured we needed to address this soon anyway for the work we're doing on the Account app.

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [Update MongoMenu and MenuItem styles for Cloud usage](https://jira.mongodb.org/browse/PD-461)

## 🛠 Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

## 💬 Further comments

### Menu (before)
![Screen Shot 2019-11-21 at 2 08 43 PM](https://user-images.githubusercontent.com/1130737/69368605-72c70880-0c68-11ea-9d1f-ca7f91640e02.png)
### Menu (current)
![Screen Shot 2019-11-21 at 2 10 05 PM](https://user-images.githubusercontent.com/1130737/69368730-a73ac480-0c68-11ea-94a0-531ea20bf2c0.png)

### MongoMenu (before)
![Screen Shot 2019-11-21 at 2 08 38 PM](https://user-images.githubusercontent.com/1130737/69368606-72c70880-0c68-11ea-9021-8639df83b1d9.png)
### MongoMenu (current)
![Screen Shot 2019-11-21 at 2 10 11 PM](https://user-images.githubusercontent.com/1130737/69368729-a73ac480-0c68-11ea-90ea-533116fd0876.png)


