### PR TITLE
PD-459: Fix MenuItem target/rel props

### DIFF
--- a/.changeset/dirty-apples-type.md
+++ b/.changeset/dirty-apples-type.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/menu': patch
+---
+
+Change default behavior on MenuItems with anchor tags, such that the default is to target="\_self", and ensure ability of consumer to override the default

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/packages/menu/src/Menu.spec.js
+++ b/packages/menu/src/Menu.spec.js
@@ -74,7 +74,7 @@ describe('packages/Menu', () => {
         <MenuItem
           href="http://mongodb.design"
           data-testid="second-item"
-          target="_self"
+          target="_blank"
           rel="help"
         >
           Item 2
@@ -99,7 +99,7 @@ describe('packages/Menu', () => {
     });
 
     test('renders with correct target and rel values when set', () => {
-      expect(secondItem.target).toBe('_self');
+      expect(secondItem.target).toBe('_blank');
       expect(secondItem.rel).toBe('help');
     });
   });

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { HTMLElementProps, createDataProp } from '@leafygreen-ui/lib';
 import { css, cx } from '@leafygreen-ui/emotion';
@@ -126,6 +126,7 @@ const activeStyle = css`
 
 const disabledStyle = css`
   cursor: not-allowed;
+  pointer-events: none;
   background-color: ${uiColors.gray.light3};
 
   &:hover:before {
@@ -144,11 +145,6 @@ interface SharedMenuItemProps {
   className?: string;
 
   /**
-   * Main content displayed in MenuItem.
-   */
-  children?: React.ReactNode;
-
-  /**
    * Determines whether or not the MenuItem is active.
    */
   active?: boolean;
@@ -161,7 +157,7 @@ interface SharedMenuItemProps {
    * Determines whether or not the MenuItem is disabled.
    */
   disabled?: boolean;
-  ref?: any;
+  ref?: React.Ref<any>;
 }
 
 interface LinkMenuItemProps extends HTMLElementProps<'a'>, SharedMenuItemProps {
@@ -182,37 +178,22 @@ function usesLinkElement(
   return props.href != null;
 }
 
-/**
- * # MenuItem
- *
- * ```
-<MenuItem>Hello World!</MenuItem>
- * ```
- * @param props.href If supplied, MenuItem will render inside of `a` tags.
- * @param props.onClick Function to be executed when MenuItem is clicked.
- * @param props.className Classname applied to MenuItem.
- * @param props.children Content to appear inside of the MenuItem.
- * @param props.description Subtext to appear inside of MenuItem
- * @param props.disabled Determines if the MenuItem is disabled
- * @param props.active Determines whether the MenuItem will appear as active
- *
- */
 const MenuItem = React.forwardRef(
-  (
-    {
+  (props: MenuItemProps, forwardRef: React.Ref<any>) => {
+    const {
       disabled = false,
       active = false,
-      onClick,
       className,
       children,
       description,
+      href,
       ...rest
-    }: MenuItemProps,
-    forwardedref,
-  ) => {
-    const anchorProps = rest.href && {
-      target: '_blank',
-      rel: 'noopener noreferrer',
+    } = props;
+
+    const anchorProps = href && {
+      target: '_self',
+      rel: '',
+      href,
     };
 
     const renderMenuItem = (Root: React.ElementType<any> = 'button') => (
@@ -232,8 +213,7 @@ const MenuItem = React.forwardRef(
           )}
           role="menuitem"
           aria-disabled={disabled}
-          onClick={disabled ? undefined : onClick}
-          ref={forwardedref as RefObject<any>}
+          ref={forwardRef}
           tabIndex={disabled ? -1 : undefined}
         >
           <div
@@ -258,7 +238,7 @@ const MenuItem = React.forwardRef(
       </li>
     );
 
-    if (usesLinkElement(rest)) {
+    if (usesLinkElement(props)) {
       return renderMenuItem('a');
     }
 

--- a/packages/mongo-menu/src/MongoMenu.tsx
+++ b/packages/mongo-menu/src/MongoMenu.tsx
@@ -269,6 +269,8 @@ function MongoMenu({
             active={el.slug === activeProduct}
             href={el.href}
             description={el.description}
+            target="_blank"
+            rel="noopener noreferrer"
           >
             {el.displayName}
           </MenuItem>


### PR DESCRIPTION
## ✍️ Proposed changes

- Change MenuItem default from target="_blank" to "_self"
- Support ability of consumer to change target and rel props
- Make sure that MongoMenu still defaults to "_blank"

🎟 _Jira ticket:_ [PD-459](https://jira.mongodb.org/browse/PD-459)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes
