### PR TITLE
PD-470: Fix bug with color in Button component 

### DIFF
--- a/.changeset/pink-berries-teach.md
+++ b/.changeset/pink-berries-teach.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/button': patch
+---
+
+Fix bug such that on hover, color is explicitly set rather than inherited

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -50,6 +50,11 @@ const buttonVariants: { readonly [K in Variant]: string } = {
       background-image: linear-gradient(#dde4e2, ${uiColors.gray.light3});
       box-shadow: inset 0 2px 2px ${transparentize(0.9, uiColors.black)};
     }
+
+    &:focus,
+    &:hover {
+      color: ${uiColors.gray.dark2};
+    }
   `,
 
   [Variant.Primary]: css`
@@ -70,6 +75,11 @@ const buttonVariants: { readonly [K in Variant]: string } = {
       background-color: ${uiColors.green.base};
       background-image: linear-gradient(#148040, #129f4c);
       box-shadow: inset 0 2px 2px ${uiColors.green.dark2};
+    }
+
+    &:focus,
+    &:hover {
+      color: ${uiColors.white};
     }
   `,
 
@@ -122,6 +132,11 @@ const buttonVariants: { readonly [K in Variant]: string } = {
       background-image: linear-gradient(#ad231b, #e45b26);
       box-shadow: inset 0 2px 2px ${uiColors.red.dark2};
     }
+
+    &:focus,
+    &:hover {
+      color: ${uiColors.white};
+    }
   `,
 
   [Variant.Dark]: css`
@@ -149,6 +164,11 @@ const buttonVariants: { readonly [K in Variant]: string } = {
         ${uiColors.gray.base}
       );
       box-shadow: inset 0 2px 2px ${uiColors.gray.dark2};
+    }
+
+    &:focus,
+    &:hover {
+      color: ${uiColors.white};
     }
   `,
 };
@@ -203,7 +223,6 @@ const baseStyle = css`
   &:focus,
   &:hover {
     text-decoration: none;
-    color: inherit;
   }
 
   // We're using CSS pseudo elements here in order to


### PR DESCRIPTION
## ✍️ Proposed changes

- Setting `color: inherit` on :hover, :focus broke some states of the component, so updated property values to be explicitly set with each state

🎟 _Jira ticket:_ [PD-470](https://jira.mongodb.org/browse/PD-470)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->

Before:
![Screen Shot 2019-12-05 at 1 59 16 PM](https://user-images.githubusercontent.com/26016393/70264984-7cbc3180-1767-11ea-9abc-695ed9a7968b.png)

After:
![Screen Shot 2019-12-05 at 1 52 17 PM](https://user-images.githubusercontent.com/26016393/70264994-82197c00-1767-11ea-9524-174c620b01e4.png)

Before:
![Screen Shot 2019-12-05 at 1 59 20 PM](https://user-images.githubusercontent.com/26016393/70265018-8b0a4d80-1767-11ea-925c-19499103192a.png)

After:
![Screen Shot 2019-12-05 at 1 52 13 PM](https://user-images.githubusercontent.com/26016393/70265028-8d6ca780-1767-11ea-9125-ea37ade2b04d.png)
