### PR TITLE
[PD-484] Fix TypeScript issue in Webpack projects using an SVG loader

### DIFF
--- a/.changeset/empty-bobcats-teach.md
+++ b/.changeset/empty-bobcats-teach.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/icon': patch
+---
+
+Fixes an issue where leafygreen-ui's local module definition for SVG files was overriding the module definition in consuming applications

--- a/packages/icon/src/glyphs/index.ts
+++ b/packages/icon/src/glyphs/index.ts
@@ -76,4 +76,4 @@ export default {
   Warning,
   X,
   XWithCircle,
-};
+} as { readonly [K: string]: SVGR.Component };

--- a/packages/icon/typings/svg.d.ts
+++ b/packages/icon/typings/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const value: SVGR.Component;
+  export = value;
+}

--- a/packages/icon/typings/svgr.d.ts
+++ b/packages/icon/typings/svgr.d.ts
@@ -7,8 +7,3 @@ declare namespace SVGR {
   }
   type Component = React.ComponentType<ComponentProps>;
 }
-
-declare module '*.svg' {
-  const value: SVGR.Component;
-  export = value;
-}


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

This fixes an issue where the module definition for SVGs was overriding the typing for SVG modules in consuming applications.

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [Fix SVG module definition issue](https://jira.mongodb.org/browse/PD-484)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes
