### PR TITLE
PD-497-Testing: Add Test Coverage for MongoNav component

### DIFF
--- a/packages/lib/src/Deferred.ts
+++ b/packages/lib/src/Deferred.ts
@@ -1,0 +1,43 @@
+export default class Deferred<T> {
+  private _promise: Promise<T>;
+
+  private _resolve: (val: T | PromiseLike<T>) => void;
+
+  private _reject: (reason?: any) => void;
+
+  constructor() {
+    this._resolve = () => {};
+    this._reject = () => {};
+
+    this._promise = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+  }
+
+  resolve(value: T) {
+    this._resolve(value);
+    return this;
+  }
+
+  reject(value: any) {
+    this._reject(value);
+    return this;
+  }
+
+  promise() {
+    return this._promise;
+  }
+
+  then: Promise<T>['then'] = (...args) => {
+    return this._promise.then(...args);
+  };
+
+  catch: Promise<T>['catch'] = (...args) => {
+    return this._promise.catch(...args);
+  };
+
+  finally: Promise<T>['finally'] = cb => {
+    return this._promise.finally(cb);
+  };
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,4 +1,7 @@
 import * as typeIs from './typeIs';
+import Deferred from './Deferred';
+
+export { typeIs, Deferred };
 
 /**
  * Utility for making it easier to couple a React Component to a css selector.
@@ -32,8 +35,6 @@ export type HTMLElementProps<
 >
   ? Props
   : never;
-
-export { typeIs };
 
 /** Helper type to check if element is a specific React Component  */
 export function isComponentType<T = React.ReactElement>(

--- a/packages/mongo-nav/src/Loading.tsx
+++ b/packages/mongo-nav/src/Loading.tsx
@@ -32,7 +32,7 @@ const projNavContainer = css`
 export default function Loading() {
   return (
     <>
-      <nav className={orgNavContainer}>
+      <nav className={orgNavContainer} data-testid="mongo-nav-loader">
         <LogoMark height={30} />
       </nav>
       <nav className={projNavContainer} />

--- a/packages/mongo-nav/src/MongoNav.spec.tsx
+++ b/packages/mongo-nav/src/MongoNav.spec.tsx
@@ -1,81 +1,208 @@
-import React from 'react';
-import { render, cleanup, wait } from '@testing-library/react';
+import React, { ChangeEventHandler } from 'react';
+import { render, cleanup, RenderResult } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import MongoNav from './MongoNav';
 
-const timeout = 200;
+import { Deferred } from '@leafygreen-ui/lib';
+import MongoNav, { MongoNavInterface } from './MongoNav';
+import { Product } from './types';
+import fixtureData from './data';
 
-afterAll(cleanup);
+// We need a consistent type for our fetch polyfill, but since the
+// polyfill is never used, only mocked, the type is irrelevant
+type mockFetchFunction = jest.MockedFunction<any>;
+type mockChangeHandler = jest.Mock<ChangeEventHandler>;
 
-describe('packages/MongoNav', () => {
-  const onOrganizationChange = jest.fn();
-  const onProjectChange = jest.fn();
-  const cloudHost = 'https://cloud-dev.mongodb.com';
+// Because JSDom doesn't implement fetch, it also doesn't implement
+// the Response API, so we mock the minimum interface we need for testing
+// and provide a helper to create the object and mock any calls to json
+interface ResponseInterface {
+  readonly ok: boolean;
+  readonly status: number;
+  json(): Promise<any>;
+}
 
-  const { getByText, getByTestId } = render(
+interface ConstructResponseInterface {
+  jsonResponse: Object;
+  ok: boolean;
+  status: number;
+}
+
+const constructResponse = ({
+  jsonResponse,
+  ok,
+  status,
+}: ConstructResponseInterface): ResponseInterface => {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(jsonResponse),
+  };
+};
+
+// a helper function to handle any repeated rendering of MongoNav
+const renderComponent = ({
+  activeProduct = Product.Cloud,
+  onOrganizationChange = jest.fn(),
+  onProjectChange = jest.fn(),
+  ...rest
+}: MongoNavInterface) => {
+  return render(
     <MongoNav
-      activeProduct="stitch"
-      mode="dev"
+      activeProduct={activeProduct}
       onOrganizationChange={onOrganizationChange}
       onProjectChange={onProjectChange}
-      urls={{
-        orgNav: {
-          accessManager: 'https://cloud.mongodb.com/access-manager-test',
-        },
-      }}
-      hosts={{ cloud: cloudHost }}
+      {...rest}
     />,
   );
+};
 
-  describe('by default', () => {
-    test('it renders the ProjectNav', async () => {
-      await wait(() => getByTestId('project-nav'), {
-        timeout,
-      });
-      const projectNav = getByTestId('project-nav');
-      expect(projectNav).toBeInTheDocument();
-    });
+describe('packages/MongoNav', () => {
+  let onOrgChangeMock: mockChangeHandler;
+  let onProjectChangeMock: mockChangeHandler;
+  let fetchDeferred: Deferred<Response>;
+  let fetchMock: mockFetchFunction;
+  let onErrorMock: jest.Mock<Function>;
+  let onSuccessMock: jest.Mock<Function>;
+  let consoleErrorMock: any;
 
-    test('it renders admin as false', async () => {
-      await wait(() => getByTestId('project-nav'), {
-        timeout,
-      });
-      const orgNav = getByTestId('organization-nav');
-      expect(orgNav.innerHTML.includes('Admin')).toBe(false);
-    });
+  const testIds = {
+    loading: 'mongo-nav-loader',
+    orgNav: 'organization-nav',
+    projectNav: 'project-nav',
+  };
+
+  beforeAll(() => {
+    // JSDom doesn't implement fetch, so we need to polyfill it
+    // in order to mock it (our polyfill's behavior doesn't matter)
+    // @ts-ignore "Property 'fetch' does not exist on type 'Global'"
+    global.fetch = () => {};
   });
 
-  describe('it successfully constructs urls based on hosts and urls props', () => {
-    test('specific url overrides take precedence over hosts, when the prop is set', async () => {
-      await wait(() => getByTestId('project-nav'), {
-        timeout,
-      });
-      const accessManager = getByText('Access Manager');
-      expect((accessManager as HTMLAnchorElement).href).toBe(
-        'https://cloud.mongodb.com/access-manager-test',
-      );
-    });
-    test('host string changes default host, when the prop is set', async () => {
-      await wait(() => getByTestId('project-nav'), {
-        timeout,
-      });
-      const support = getByText('Support');
-      const billing = getByText('Billing');
-
-      expect((support as HTMLAnchorElement).href).toBe(
-        `${cloudHost}/v2#/org/5d729a93/support`,
-      );
-
-      expect((billing as HTMLAnchorElement).href).toBe(
-        `${cloudHost}/v2#/org/5d729a93/billing/overview`,
-      );
-    });
+  afterAll(() => {
+    // Once finished, we need to remove our polyfill so that this
+    // doesn't adversely impact other tests
+    // @ts-ignore "Property 'fetch' does not exist on type 'Global'"
+    delete global.fetch;
   });
-  test('when mode prop is set to `dev`, fixture data is rendered inside of MongoNav', async () => {
-    await wait(() => getByTestId('project-nav'), {
-      timeout,
+
+  beforeEach(() => {
+    onOrgChangeMock = jest.fn();
+    onProjectChangeMock = jest.fn();
+    fetchDeferred = new Deferred();
+    fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockReturnValue(fetchDeferred.promise());
+    consoleErrorMock = jest
+      .spyOn(global.console, 'error')
+      .mockReturnValue();
+    onErrorMock = jest.fn();
+    onSuccessMock = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cleanup();
+  });
+
+  describe('when rendered with default props', () => {
+    let component: RenderResult;
+    let queryByTestId: typeof component.queryByTestId;
+
+    beforeEach(() => {
+      const { queryByTestId: currentQueryByTestId } = renderComponent({
+        activeProduct: Product.Cloud,
+        onOrganizationChange: onOrgChangeMock,
+        onProjectChange: onProjectChangeMock,
+        onError: onErrorMock,
+        onSuccess: onSuccessMock,
+      });
+
+      queryByTestId = currentQueryByTestId;
     });
-    const firstName = getByText('DevMode');
-    expect(firstName).toBeInTheDocument();
+
+    it('displays the loading component', () => {
+      expect(queryByTestId(testIds.loading)).toBeInTheDocument();
+    });
+
+    it('does not display the org or project nav components', () => {
+      expect(queryByTestId(testIds.orgNav)).not.toBeInTheDocument();
+      expect(queryByTestId(testIds.projectNav)).not.toBeInTheDocument();
+    });
+
+    it('calls to fetch the data from cloud', () => {
+      expect(fetchMock.mock.calls.length).toEqual(1);
+    });
+
+    describe('when the data is returned', () => {
+      describe('and the response is valid, with fixture data', () => {
+        beforeEach(() => {
+          const fetchResponse = constructResponse({
+            jsonResponse: fixtureData, ok: true, status: 200,
+          });
+          fetchDeferred.resolve(fetchResponse as Response);
+        });
+
+        it('calls the on success handler', () => {
+          expect(onSuccessMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('no longer displays the loading component', () => {
+          expect(queryByTestId(testIds.loading)).not.toBeInTheDocument();
+        });
+
+        it('displays the org nav component', () => {
+          expect(queryByTestId(testIds.orgNav)).toBeInTheDocument();
+        });
+
+        it('displays the product nav component', () => {
+          expect(queryByTestId(testIds.projectNav)).toBeInTheDocument();
+        });
+      });
+
+      describe('and the response is an error code', () => {
+        beforeEach(() => {
+          const fetchResponse = constructResponse({
+            jsonResponse: fixtureData, ok: false, status: 401,
+          });
+          fetchDeferred.resolve(fetchResponse as Response);
+        });
+
+        it('calls the on error handler', () => {
+          expect(onErrorMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('logs the error to the console', () => {
+          expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('still displays the loading component', () => {
+          expect(queryByTestId(testIds.loading)).toBeInTheDocument();
+        });
+
+        it('still does not display the org or project nav components', () => {
+          expect(queryByTestId(testIds.orgNav)).not.toBeInTheDocument();
+          expect(queryByTestId(testIds.projectNav)).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('when the data is not returned successfully', () => {
+      beforeEach(function() {
+        fetchDeferred.reject(new Error('fetch calls rarely result in a rejection'));
+      });
+
+      it('logs the error to the console', () => {
+        expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('still displays the loading component', () => {
+        expect(queryByTestId(testIds.loading)).toBeInTheDocument();
+      });
+
+      it('still does not display the org or project nav components', () => {
+        expect(queryByTestId(testIds.orgNav)).not.toBeInTheDocument();
+        expect(queryByTestId(testIds.projectNav)).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/mongo-nav/src/MongoNav.tsx
+++ b/packages/mongo-nav/src/MongoNav.tsx
@@ -17,7 +17,7 @@ const ErrorCodeMap = {
   401: ErrorCode.NO_AUTHORIZATION,
 };
 
-interface MongoNavInterface {
+export interface MongoNavInterface {
   /**
    * Describes what product is currently active
    */
@@ -157,15 +157,15 @@ export default function MongoNav({
   }
 
   async function handleResponse(response: Response) {
-    const res = await response;
+    const { ok, status } = response;
 
-    if (!res.ok) {
-      onError?.(ErrorCodeMap[res.status as 401]); //typecasting for now until we have more types to handle
-      console.error(ErrorCodeMap[res.status as 401]);
-    } else {
-      const data = await res.json();
+    if (ok) {
+      const data = await response.json();
       setData(data);
       onSuccess?.(data);
+    } else {
+      onError?.(ErrorCodeMap[status as 401]); //typecasting for now until we have more types to handle
+      console.error(ErrorCodeMap[status as 401]);
     }
   }
 


### PR DESCRIPTION
This adds unit testing using Jest for covering the MongoNav component. It currently handles the testing of the fetch request, but does not handle the handling of hosts and overrides. I'll dig into that a bit later.

This also adds Cloud's `Deferred` package we usually use when we need to test asynchronous code and want to be resolve or reject the resulting promise lazily. The functionality is built into Sinon, but I couldn't find an equivalent with Jest, but it's very lightweight.

If helpful, I'll also outline the test structure for other components, and am happy to do further work as you would like (I enjoy this stuff a lot).