### PR TITLE
PD-536: Add `glyph` and `size` prop to MenuItem, add UserFeedback to UserMenu

### DIFF
--- a/.changeset/afraid-cougars-shake.md
+++ b/.changeset/afraid-cougars-shake.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/menu': major
+---
+
+Changes glyph prop from string to React.ReactElement in SubMenu component and adds glyph and size props to MenuItem

--- a/.changeset/afraid-cougars-shake.md
+++ b/.changeset/afraid-cougars-shake.md
@@ -2,4 +2,5 @@
 '@leafygreen-ui/menu': major
 ---
 
-Changes glyph prop from string to React.ReactElement in SubMenu component and adds glyph and size props to MenuItem
+- Changes `glyph` prop from `string` to `React.ReactElement` in `<SubMenu />` 
+- Adds `glyph` and `size` props to `<MenuItem />`

--- a/.changeset/flat-seas-learn.md
+++ b/.changeset/flat-seas-learn.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/mongo-nav': minor
 ---
 
-Adds feedback link to UserMenu
+Adds User Feedback link to `UserMenu`

--- a/.changeset/flat-seas-learn.md
+++ b/.changeset/flat-seas-learn.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': minor
+---
+
+Adds feedback link to UserMenu

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -120,18 +120,36 @@ Self-closing component that provides a way to group `MenuItems` in a `Menu` comp
 
 ## Properties
 
-| Prop          | Type                 | Description                                                                                    | Default                                                |
-| ------------- | -------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `href`        | `string`             | If supplied, will render the `<MenuItem />` inside of an `<a>` tag, rather than a `<span>` tag |                                                        |
-| `children`    | `node`               | Content to appear inside of `<MenuItem />` component                                           |                                                        |
-| `className`   | `string`             | Classname applied to `li` element                                                              |                                                        |
-| `onClick`     | `function`           | Function that will be called when a `<MenuItem />` is clicked                                  |                                                        |
-| `active`      | `boolean`            | Determines if the `<MenuItem />` is `active`                                                   | `false`                                                |
-| `disabled`    | `boolean`            | Determines if the `<MenuItem />` is `disabled`                                                 | `false`                                                |
-| `description` | `string`             | Description text that will appear below the main content of `<MenuItem />`                     |                                                        |
-| `as`          | `React.ReactElement` | `HTMLElement`                                                                                  | Determines what the `<MenuItem />` will be rendered as |  |
+| Prop          | Type                 | Description                                                                                      | Default                                                |
+| ------------- | -------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| `href`        | `string`             | If supplied, will render the `<MenuItem />` inside of an `<a>` tag, rather than a `<button>` tag |                                                        |
+| `children`    | `node`               | Content to appear inside of `<MenuItem />` component                                             |                                                        |
+| `className`   | `string`             | Classname applied to `li` element                                                                |                                                        |
+| `onClick`     | `function`           | Function that will be called when a `<MenuItem />` is clicked                                    |                                                        |
+| `active`      | `boolean`            | Determines if the `<MenuItem />` is `active`                                                     | `false`                                                |
+| `disabled`    | `boolean`            | Determines if the `<MenuItem />` is `disabled`                                                   | `false`                                                |
+| `description` | `string`             | Description text that will appear below the main content of `<MenuItem />`                       |                                                        |
+| `as`          | `React.ReactElement` | `HTMLElement`                                                                                    | Determines what the `<MenuItem />` will be rendered as |  |
+| `size`        | `default` or `large` | Size of the `<MenuItem />` component                                                             | `default`                                              |
+| `glyph`       | `React.ReactElement` | Slot to pass in an Icon rendered to the left of `<MenuItem />` text.                             |                                                        |
 
 _Any other properties will be spread on the MenuItem `div` container_
+
+# SubMenu
+
+## Properties
+
+| Prop          | Type                                                                                            | Description                                                         | Default |
+| ------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------- |
+| `open`        | `boolean`                                                                                       | Determines if `<SubMenu />` item appears open                       | `false` |
+| `setOpen`     | `function`                                                                                      | Function to set the value of `open` in `<SubMenu />`                |         |
+| `className`   | `string`                                                                                        | className applied to `SubMenu` root element                         |         |
+| `description` | `React.ReactElement`                                                                            | Content to appear below main text of SubMenu                        |         |
+| `active`      | `boolean`                                                                                       | Determines if `<SubMenu />` appears `active`                        | `false` |
+| `disabled`    | `boolean`                                                                                       | Determines if `<SubMenu />` appears `disabled`                      | `false` |
+| `glyph`       | `React.ReactElement`                                                                            | Slot to pass in an Icon rendered to the left of `<SubMenu />` text. |         |
+| `title`       | `string`                                                                                        | Main text rendered in `<SubMenu />`                                 |
+| `href`        | If supplied, will render the `<SubMenu />` inside of an `<a>` tag, rather than a `<button>` tag |
 
 ## Advanced Use Case
 

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -12,6 +12,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "@leafygreen-ui/icon": "^4.0.0"
+  },
   "dependencies": {
     "react-transition-group": "^4.2.1",
     "@leafygreen-ui/hooks": "^2.0.0",

--- a/packages/menu/src/Menu.spec.js
+++ b/packages/menu/src/Menu.spec.js
@@ -7,6 +7,7 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { Menu, MenuSeparator, MenuItem, SubMenu } from './index';
+import Icon from '@leafygreen-ui/icon';
 
 afterAll(cleanup);
 
@@ -82,6 +83,9 @@ describe('packages/Menu', () => {
         <MenuItem data-testid="third-item" as="div">
           Item 3
         </MenuItem>
+        <MenuItem data-testid="fourth-item" glyph={<Icon glyph="Cloud" />}>
+          Item 4
+        </MenuItem>
       </div>,
     );
 
@@ -110,6 +114,10 @@ describe('packages/Menu', () => {
     test('renders as `div` tag when the as prop is set', () => {
       expect(thirdItem.tagName.toLowerCase()).toBe('div');
     });
+
+    // test('glyph is rendered when the prop is set', () => {
+    //   expect(fourthItem.innerHTML).toContain('svg');
+    // });
   });
 
   describe('sub-menu', () => {

--- a/packages/menu/src/Menu.spec.js
+++ b/packages/menu/src/Menu.spec.js
@@ -114,10 +114,6 @@ describe('packages/Menu', () => {
     test('renders as `div` tag when the as prop is set', () => {
       expect(thirdItem.tagName.toLowerCase()).toBe('div');
     });
-
-    // test('glyph is rendered when the prop is set', () => {
-    //   expect(fourthItem.innerHTML).toContain('svg');
-    // });
   });
 
   describe('sub-menu', () => {

--- a/packages/menu/src/Menu.story.js
+++ b/packages/menu/src/Menu.story.js
@@ -4,6 +4,7 @@ import { select, boolean } from '@storybook/addon-knobs';
 import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import { Menu, MenuSeparator, SubMenu, MenuItem } from '.';
 import { Align, Justify } from '@leafygreen-ui/popover';
+import Icon from '@leafygreen-ui/icon';
 
 function Uncontrolled() {
   return (
@@ -13,17 +14,23 @@ function Uncontrolled() {
         justify={select('Justify', Object.values(Justify), Justify.Start)}
         trigger={<button>trigger</button>}
       >
-        <MenuItem active>Active Menu Item</MenuItem>
         <MenuItem
-          disabled={boolean('Disabled', true)}
-          description="I am a description"
+          active
           size={select('Size', ['default', 'large'], 'default')}
+          glyph={<Icon glyph="Cloud" />}
         >
-          Disabled Menu Item
+          Active Menu Item
         </MenuItem>
         <MenuItem description="I am also a description">
           Menu Item With Description
         </MenuItem>
+        <MenuItem
+          disabled={boolean('Disabled', true)}
+          description="I am a description"
+        >
+          Disabled Menu Item
+        </MenuItem>
+
         <MenuItem href="http://mongodb.design">I am a link!</MenuItem>
       </Menu>
     </LeafyGreenProvider>
@@ -42,16 +49,24 @@ function Controlled() {
           open={open}
           setOpen={setOpen}
         >
-          <MenuItem active>Active Menu Item</MenuItem>
-          <MenuItem disabled={boolean('Disabled', true)}>
+          <MenuItem
+            active
+            size={select('Size', ['default', 'large'], 'large')}
+            glyph={<Icon glyph="Laptop" size="xlarge" />}
+          >
+            Active Menu Item
+          </MenuItem>
+          <MenuItem disabled={boolean('Disabled', true)} size="large">
             Disabled Menu Item
           </MenuItem>
-          <MenuItem description="I am a description">
+          <MenuItem description="I am a description" size="large">
             Menu Item With Description
           </MenuItem>
-          <MenuItem href="http://mongodb.design">I am a link!</MenuItem>
+          <MenuItem href="http://mongodb.design" size="large">
+            I am a link!
+          </MenuItem>
           <MenuSeparator />
-          <MenuItem>Left out of the MenuGroup</MenuItem>
+          <MenuItem size="large">Left out of the MenuGroup</MenuItem>
         </Menu>
       </button>
     </LeafyGreenProvider>
@@ -65,7 +80,7 @@ function SubMenuExample() {
         <SubMenu
           title="Menu Item 1"
           description="https://google.com"
-          glyph="Cloud"
+          glyph={<Icon glyph="Cloud" size="xlarge" />}
           active={true}
         >
           <MenuItem>SubMenu Item 1</MenuItem>
@@ -74,7 +89,7 @@ function SubMenuExample() {
         <SubMenu
           title="Menu Item 2"
           description="https://google.com"
-          glyph="Laptop"
+          glyph={<Icon glyph="Laptop" size="xlarge" />}
         >
           <MenuItem>Support 1</MenuItem>
         </SubMenu>

--- a/packages/menu/src/Menu.story.js
+++ b/packages/menu/src/Menu.story.js
@@ -17,6 +17,7 @@ function Uncontrolled() {
         <MenuItem
           disabled={boolean('Disabled', true)}
           description="I am a description"
+          size={select('Size', ['default', 'large'], 'default')}
         >
           Disabled Menu Item
         </MenuItem>

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -11,6 +11,9 @@ import {
   focusedMenuItemContainerStyle,
   linkStyle,
   disabledTextStyle,
+  svgWidth,
+  paddingLeft,
+  menuItemPadding,
 } from './styles';
 
 const menuItemContainer = createDataProp('menu-item-container');
@@ -40,6 +43,29 @@ const descriptionTextStyle = css`
   color: ${uiColors.gray.dark1};
   ${menuItemContainer.selector}:focus & {
     color: ${uiColors.blue.dark2};
+  }
+`;
+
+const mainIconStyle = css`
+  color: ${uiColors.gray.base};
+  margin-right: ${paddingLeft - svgWidth - menuItemPadding}px;
+  flex-shrink: 0;
+
+  ${menuItemContainer.selector}:hover > & {
+    color: ${uiColors.gray.dark1};
+  }
+`;
+
+const mainIconFocusedStyle = css`
+  ${menuItemContainer.selector}:focus > & {
+    color: ${uiColors.blue.base};
+  }
+`;
+
+const activeIconStyle = css`
+  color: ${uiColors.green.base};
+  ${menuItemContainer.selector}:hover > & {
+    color: ${uiColors.green.base};
   }
 `;
 
@@ -80,7 +106,15 @@ interface SharedMenuItemProps {
    */
   disabled?: boolean;
 
-  size: Size;
+  /**
+   * Slot to pass in an Icon rendered to the left of `MenuItem` text.
+   */
+  glyph?: React.ReactElement;
+
+  /**
+   * Size of the MenuItem component, can be `default` or `large`
+   */
+  size?: Size;
 
   ref?: React.Ref<any>;
 }
@@ -117,6 +151,8 @@ function usesLinkElement(
 
 const MenuItem = React.forwardRef(
   (props: MenuItemProps, forwardRef: React.Ref<any>) => {
+    const { usingKeyboard: showFocus } = useUsingKeyboardContext();
+
     const {
       disabled = false,
       active = false,
@@ -125,10 +161,22 @@ const MenuItem = React.forwardRef(
       children,
       description,
       href,
+      glyph,
       ...rest
     } = props;
 
-    const { usingKeyboard: showFocus } = useUsingKeyboardContext();
+    const updatedGlyph =
+      glyph &&
+      React.cloneElement(glyph, {
+        className: cx(
+          mainIconStyle,
+          {
+            [activeIconStyle]: active,
+            [mainIconFocusedStyle]: showFocus,
+          },
+          glyph.props?.className,
+        ),
+      });
 
     const anchorProps = href && {
       target: '_self',
@@ -158,24 +206,31 @@ const MenuItem = React.forwardRef(
           ref={forwardRef}
           tabIndex={disabled ? -1 : undefined}
         >
+          {updatedGlyph}
           <div
-            className={cx(titleTextStyle, {
-              [activeTitleTextStyle]: active,
-              [disabledTextStyle]: disabled,
-            })}
+            className={css`
+              width: 100%;
+            `}
           >
-            {children}
-          </div>
-          {description && (
             <div
-              className={cx(descriptionTextStyle, {
-                [activeDescriptionTextStyle]: active,
+              className={cx(titleTextStyle, {
+                [activeTitleTextStyle]: active,
                 [disabledTextStyle]: disabled,
               })}
             >
-              {description}
+              {children}
             </div>
-          )}
+            {description && (
+              <div
+                className={cx(descriptionTextStyle, {
+                  [activeDescriptionTextStyle]: active,
+                  [disabledTextStyle]: disabled,
+                })}
+              >
+                {description}
+              </div>
+            )}
+          </div>
         </Root>
       </li>
     );

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -15,10 +15,6 @@ import {
 
 const menuItemContainer = createDataProp('menu-item-container');
 
-const menuItemHeight = css`
-  min-height: 36px;
-`;
-
 const titleTextStyle = css`
   width: 100%;
   font-size: 14px;
@@ -47,6 +43,23 @@ const descriptionTextStyle = css`
   }
 `;
 
+const Size = {
+  Default: 'default',
+  Large: 'large',
+} as const;
+
+type Size = typeof Size[keyof typeof Size];
+
+const menuItemHeight: Record<Size, string> = {
+  [Size.Default]: css`
+    min-height: 36px;
+  `,
+
+  [Size.Large]: css`
+    min-height: 56px;
+  `,
+};
+
 interface SharedMenuItemProps {
   /**
    * Class name that will be applied to root MenuItem element.
@@ -66,6 +79,9 @@ interface SharedMenuItemProps {
    * Determines whether or not the MenuItem is disabled.
    */
   disabled?: boolean;
+
+  size: Size;
+
   ref?: React.Ref<any>;
 }
 
@@ -104,6 +120,7 @@ const MenuItem = React.forwardRef(
     const {
       disabled = false,
       active = false,
+      size = 'default',
       className,
       children,
       description,
@@ -127,7 +144,7 @@ const MenuItem = React.forwardRef(
           {...menuItemContainer.prop}
           className={cx(
             menuItemContainerStyle,
-            menuItemHeight,
+            menuItemHeight[size],
             linkStyle,
             {
               [activeMenuItemContainerStyle]: active,

--- a/packages/menu/src/MenuSeparator.tsx
+++ b/packages/menu/src/MenuSeparator.tsx
@@ -3,7 +3,7 @@ import { css } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
 
 const borderStyle = css`
-  border-top: 1px solid ${uiColors.gray.light1};
+  border-top: 1px solid ${uiColors.gray.light2};
 `;
 
 function MenuSeparator() {

--- a/packages/menu/src/SubMenu.tsx
+++ b/packages/menu/src/SubMenu.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import IconButton from '@leafygreen-ui/icon-button';
-import Icon, { glyphs } from '@leafygreen-ui/icon';
+import Icon from '@leafygreen-ui/icon';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
 import { HTMLElementProps, createDataProp } from '@leafygreen-ui/lib';
@@ -14,6 +14,9 @@ import {
   focusedMenuItemContainerStyle,
   linkStyle,
   disabledTextStyle,
+  paddingLeft,
+  menuItemPadding,
+  svgWidth,
 } from './styles';
 import { ExitHandler } from 'react-transition-group/Transition';
 
@@ -22,9 +25,6 @@ const iconButton = createDataProp('icon-button');
 
 const subMenuContainerHeight = 56;
 const iconButtonContainerHeight = 28;
-const paddingLeft = 60;
-const svgWidth = 32;
-const menuItemPadding = 15;
 
 const liStyle = css`
   position: relative;
@@ -32,7 +32,6 @@ const liStyle = css`
 `;
 
 const subMenuStyle = css`
-  flex-direction: row;
   min-height: 56px;
   border-top: 1px solid ${uiColors.gray.light2};
   background-color: ${uiColors.gray.light3};
@@ -146,16 +145,41 @@ const menuItemBorder = css`
   top: 0;
 `;
 
-type Glyph = keyof typeof glyphs;
-
 interface SharedSubMenuProps {
+  /**
+   * Determines if `<SubMenu />` item appears open
+   */
   open?: boolean;
+
+  /**
+   * Function to set the value of `open` in `<SubMenu />`
+   */
   setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /**
+   * className applied to `SubMenu` root element
+   */
   className?: string;
+
+  /**
+   * Content to appear below main text of SubMenu
+   */
   description?: React.ReactElement;
+
+  /**
+   * Determines if `<SubMenu />` item appears disabled
+   */
   disabled?: boolean;
+
+  /**
+   * Determines if `<SubMenu />` item appears active
+   */
   active?: boolean;
-  glyph?: Glyph;
+  /**
+   * Slot to pass in an Icon rendered to the left of `SubMenu` text.
+   */
+  glyph?: React.ReactElement;
+
   onExited?: ExitHandler;
 }
 
@@ -214,6 +238,19 @@ const SubMenu = React.forwardRef((props: SubMenuProps, ref) => {
 
   const numberOfMenuItems = React.Children.toArray(children).length;
 
+  const updatedGlyph =
+    glyph &&
+    React.cloneElement(glyph, {
+      className: cx(
+        mainIconStyle,
+        {
+          [activeIconStyle]: active,
+          [mainIconFocusedStyle]: showFocus,
+        },
+        glyph.props?.className,
+      ),
+    });
+
   const renderedSubMenuItem = (Root: React.ElementType<any> = 'button') => (
     <li role="none" className={liStyle}>
       <Root
@@ -238,17 +275,7 @@ const SubMenu = React.forwardRef((props: SubMenuProps, ref) => {
           className,
         )}
       >
-        {glyph && (
-          <Icon
-            glyph={glyph}
-            size="xlarge"
-            className={cx(mainIconStyle, {
-              [activeIconStyle]: active,
-              [mainIconFocusedStyle]: showFocus,
-            })}
-          />
-        )}
-
+        {updatedGlyph}
         <div>
           <div
             className={cx(mainTextStyle, {
@@ -359,7 +386,7 @@ SubMenu.propTypes = {
   onKeyDown: PropTypes.func,
   className: PropTypes.string,
   onClick: PropTypes.func,
-  glyph: PropTypes.string,
+  glyph: PropTypes.element,
   onExited: PropTypes.func,
   open: PropTypes.bool,
   active: PropTypes.bool,

--- a/packages/menu/src/styles.tsx
+++ b/packages/menu/src/styles.tsx
@@ -3,11 +3,14 @@ import { uiColors } from '@leafygreen-ui/palette';
 
 const indentation = 15;
 const leftBar = 5;
+export const svgWidth = 32;
+export const menuItemPadding = 15;
+export const paddingLeft = 60;
 
 export const menuItemContainerStyle = css`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  flex-direction: row;
+  align-items: center;
   padding-left: ${indentation}px;
   padding-right: ${indentation}px;
   text-decoration: none;

--- a/packages/mongo-menu/package.json
+++ b/packages/mongo-menu/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@leafygreen-ui/palette": "2.0.0",
-    "@leafygreen-ui/menu": "5.1.0",
+    "@leafygreen-ui/menu": "5.0.0",
     "@leafygreen-ui/icon": "4.0.0",
     "@leafygreen-ui/emotion": "2.0.1",
     "@leafygreen-ui/button": "4.0.0",

--- a/packages/mongo-nav/src/mongo-select/MongoSelect.spec.tsx
+++ b/packages/mongo-nav/src/mongo-select/MongoSelect.spec.tsx
@@ -134,7 +134,7 @@ describe('packages/mongo-select', () => {
 
     test('view all organizations href is changed, when the urls prop is set', () => {
       const viewAllOrganizations = getByText('View All Organizations')
-        .parentNode?.parentNode;
+        .parentNode?.parentNode?.parentNode;
       expect((viewAllOrganizations as HTMLAnchorElement)?.href).toBe(
         `https://cloud-dev.mongodb.com/v2#/preferences/organizations`,
       );

--- a/packages/mongo-nav/src/user-menu/UserMenu.spec.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.spec.tsx
@@ -167,7 +167,8 @@ describe('packages/UserMenu', () => {
 
       const universitySubMenuItem = getByText('Video Preferences');
       expect(
-        (universitySubMenuItem?.parentNode as HTMLAnchorElement).href,
+        (universitySubMenuItem?.parentNode?.parentNode as HTMLAnchorElement)
+          .href,
       ).toBe('https://university.mongodb.com/override-test');
     });
   });

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -22,6 +22,10 @@ import {
   HostsInterface,
 } from '../types';
 
+const paddingLeft = 60;
+const svgWidth = 32;
+const menuItemPadding = 15;
+
 const subMenuContainer = createDataProp('sub-menu-container');
 
 const triggerWrapper = css`
@@ -115,9 +119,29 @@ const descriptionStyle = css`
   max-width: 100%;
 `;
 
-const logoutContainer = css`
+const feedbackStyle = css`
+  min-height: 56px;
+  background-color: ${uiColors.gray.light3};
+`;
+
+const feedbackIconStyle = css`
+  color: ${uiColors.gray.base};
+  margin-right: ${paddingLeft - svgWidth - menuItemPadding}px;
+  flex-shrink: 0;
+
+  ${subMenuContainer.selector}:hover > & {
+    color: ${uiColors.gray.dark1};
+  }
+`;
+
+const menuItemHeight = css`
   height: 56px;
   background-color: ${uiColors.gray.light3};
+`;
+
+const feedbackFlexContainer = css`
+  display: flex;
+  align-items: center;
 `;
 
 interface DescriptionProps {
@@ -192,6 +216,12 @@ function UserMenu({
   };
 
   const { userMenu } = urls;
+
+  const feedbackAnchorProps = {
+    href: 'https://feedback.mongodb.com/',
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  };
 
   return (
     <div className={triggerWrapper}>
@@ -289,7 +319,19 @@ function UserMenu({
 
         <MenuSeparator />
 
-        <MenuItem onClick={onLogout} className={logoutContainer}>
+        <MenuItem
+          {...feedbackAnchorProps}
+          className={cx(menuItemHeight, feedbackStyle)}
+        >
+          <div className={feedbackFlexContainer}>
+            <Icon glyph="Bell" size="xlarge" className={feedbackIconStyle} />
+            Give us feedback
+          </div>
+        </MenuItem>
+
+        <MenuSeparator />
+
+        <MenuItem onClick={onLogout} className={menuItemHeight}>
           Logout
         </MenuItem>
       </Menu>

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -22,10 +22,6 @@ import {
   HostsInterface,
 } from '../types';
 
-const paddingLeft = 60;
-const svgWidth = 32;
-const menuItemPadding = 15;
-
 const subMenuContainer = createDataProp('sub-menu-container');
 
 const triggerWrapper = css`
@@ -117,31 +113,6 @@ const descriptionStyle = css`
   margin-top: 0px;
   margin-bottom: 16px;
   max-width: 100%;
-`;
-
-const feedbackStyle = css`
-  min-height: 56px;
-  background-color: ${uiColors.gray.light3};
-`;
-
-const feedbackIconStyle = css`
-  color: ${uiColors.gray.base};
-  margin-right: ${paddingLeft - svgWidth - menuItemPadding}px;
-  flex-shrink: 0;
-
-  ${subMenuContainer.selector}:hover > & {
-    color: ${uiColors.gray.dark1};
-  }
-`;
-
-const menuItemHeight = css`
-  height: 56px;
-  background-color: ${uiColors.gray.light3};
-`;
-
-const feedbackFlexContainer = css`
-  display: flex;
-  align-items: center;
 `;
 
 interface DescriptionProps {
@@ -256,7 +227,7 @@ function UserMenu({
           href={hosts.cloud}
           description={<Description isActive={isCloud} product="cloud" />}
           title="Atlas"
-          glyph="Cloud"
+          glyph={<Icon glyph="Cloud" size="xlarge" />}
           className={cx(subMenuContainerStyle, {
             [subMenuActiveContainerStyle]: isCloud,
           })}
@@ -290,7 +261,7 @@ function UserMenu({
             <Description isActive={isUniversity} product="university" />
           }
           title="University"
-          glyph="Laptop"
+          glyph={<Icon glyph="Laptop" size="xlarge" />}
           className={cx(subMenuContainerStyle, {
             [subMenuActiveContainerStyle]: isUniversity,
           })}
@@ -307,7 +278,7 @@ function UserMenu({
           href={hosts.support}
           description={<Description isActive={isSupport} product="support" />}
           title="Support"
-          glyph="Support"
+          glyph={<Icon glyph="Support" size="xlarge" />}
           className={cx(subMenuContainerStyle, {
             [subMenuActiveContainerStyle]: isSupport,
           })}
@@ -321,17 +292,15 @@ function UserMenu({
 
         <MenuItem
           {...feedbackAnchorProps}
-          className={cx(menuItemHeight, feedbackStyle)}
+          size="large"
+          glyph={<Icon glyph="Bell" size="xlarge" />}
         >
-          <div className={feedbackFlexContainer}>
-            <Icon glyph="Bell" size="xlarge" className={feedbackIconStyle} />
-            Give us feedback
-          </div>
+          Give us feedback
         </MenuItem>
 
         <MenuSeparator />
 
-        <MenuItem onClick={onLogout} className={menuItemHeight}>
+        <MenuItem onClick={onLogout} size="large">
           Logout
         </MenuItem>
       </Menu>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,6 +1685,17 @@
     facepaint "^1.2.1"
     polished "^2.3.0"
 
+"@leafygreen-ui/menu@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/menu/-/menu-5.0.0.tgz#9429d053b72eada1466976403a3d82d5d6193bfe"
+  integrity sha512-J7TKkMPT1ElHT5hGUL70eR9n2BcMZHkfq0Af4oz1hz4izPmNfsFi6o77XAxkChvT65nWz/MTkijrYg0HeG8rpA==
+  dependencies:
+    "@leafygreen-ui/hooks" "^2.0.0"
+    "@leafygreen-ui/leafygreen-provider" "^1.0.0"
+    "@leafygreen-ui/lib" "^4.0.0"
+    "@leafygreen-ui/palette" "^2.0.0"
+    "@leafygreen-ui/popover" "^3.0.0"
+
 "@lerna/add@3.18.0":
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.18.0.tgz#86e38f14d7a0a7c61315dccb402377feb1c9db83"


### PR DESCRIPTION
## ✍️ Proposed changes

- Combined PD-536: Add `glyph` and `size` prop to MenuItem component with PD-501, add User Feedback to UserMenu
- Add `glyph` and `size` prop to MenuItem
- Change `glyph` from accepting `string` to accepting `React.ReactElement` in SubMenu
- Add User Feedback item to UserMenu

🎟 _Jira ticket:_ [PD-536](https://jira.mongodb.org/browse/PD-536)
🎟 _Jira ticket:_ [PD-501](https://jira.mongodb.org/browse/PD-501)


## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

