### PR TITLE
PD-542: Side Nav scrolling and margin/height/padding tweaks

### DIFF
--- a/.changeset/clean-plums-swim.md
+++ b/.changeset/clean-plums-swim.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/side-nav': patch
+---
+
+Adjust styling to allow vertical scrolling and more accurately match design heights and padding/margins.

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -5,6 +5,8 @@ import { ulStyleOverrides } from './styles';
 
 const navStyles = css`
   width: 200px;
+  overflow-y: scroll;
+  padding-bottom: 24px;
 `;
 
 interface SideNavProps {

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -5,8 +5,6 @@ import { ulStyleOverrides } from './styles';
 
 const navStyles = css`
   width: 200px;
-  overflow-y: scroll;
-  padding-bottom: 24px;
 `;
 
 interface SideNavProps {

--- a/packages/side-nav/src/SideNavGroup.tsx
+++ b/packages/side-nav/src/SideNavGroup.tsx
@@ -6,6 +6,7 @@ import { ulStyleOverrides, SIDE_OFFSET } from './styles';
 
 const sideNavLabelStyle = css`
   font-size: 12px;
+  min-height: 24px;
   letter-spacing: 0.3px;
   font-weight: bold;
   text-transform: uppercase;

--- a/packages/side-nav/src/SideNavItem.tsx
+++ b/packages/side-nav/src/SideNavItem.tsx
@@ -21,7 +21,7 @@ const defaultStyle = css`
   position: relative;
   width: 100%;
   margin: unset;
-  padding: 8px ${SIDE_OFFSET}px 8px ${SIDE_OFFSET}px;
+  padding: 6px ${SIDE_OFFSET}px 6px ${SIDE_OFFSET}px;
   min-height: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## ✍️ Proposed changes

Per feedback from design and users, it was brought up that `side-nav` doesn't allow for vertical scrolling, and some specs regarding height and padding/margins were incorrect still (though off by very little). This updates those values according to the design screenshot attached to the Jira ticket.

🎟 _Jira ticket:_ [https://jira.mongodb.org/browse/PD-542](https://jira.mongodb.org/browse/[https://jira.mongodb.org/browse/PD-542])

## 🛠 Types of changes
- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes
