### PR TITLE
PD-545: Add new types such that usermenu can be used without mongonav

### DIFF
--- a/.changeset/long-tools-clap.md
+++ b/.changeset/long-tools-clap.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': minor
+---
+
+Update UserMenu types such that Component can work independently of <MongoNav />

--- a/packages/mongo-nav/src/types.ts
+++ b/packages/mongo-nav/src/types.ts
@@ -115,6 +115,32 @@ export interface DataInterface {
   readonly projects: Array<ProjectInterface>;
 }
 
+export interface UserMenuURLSInterface {
+  userMenu: {
+    cloud: {
+      userPreferences: string;
+      organizations: string;
+      invitations: string;
+      mfa: string;
+    };
+    university: {
+      videoPreferences: string;
+    };
+    support: {
+      userPreferences: string;
+    };
+    account: {
+      homepage: string;
+    };
+  };
+}
+
+export interface UserMenuHostsInterface {
+  cloud: string;
+  support: string;
+  university: string;
+}
+
 export interface URLSInterface {
   userMenu?: {
     cloud?: {

--- a/packages/mongo-nav/src/types.ts
+++ b/packages/mongo-nav/src/types.ts
@@ -115,32 +115,6 @@ export interface DataInterface {
   readonly projects: Array<ProjectInterface>;
 }
 
-export interface UserMenuURLSInterface {
-  userMenu: {
-    cloud: {
-      userPreferences: string;
-      organizations: string;
-      invitations: string;
-      mfa: string;
-    };
-    university: {
-      videoPreferences: string;
-    };
-    support: {
-      userPreferences: string;
-    };
-    account: {
-      homepage: string;
-    };
-  };
-}
-
-export interface UserMenuHostsInterface {
-  cloud: string;
-  support: string;
-  university: string;
-}
-
 export interface URLSInterface {
   userMenu?: {
     cloud?: {

--- a/packages/mongo-nav/src/user-menu/README.md
+++ b/packages/mongo-nav/src/user-menu/README.md
@@ -6,15 +6,15 @@
 
 ### Yarn
 
-\`\`\`shell
+```shell
 yarn add @leafygreen-ui/mongo-nav
-\`\`\`
+```
 
 ### NPM
 
-\`\`\`shell
+```shell
 npm install @leafygreen-ui/mongo-nav
-\`\`\`
+```
 
 ## Example
 

--- a/packages/mongo-nav/src/user-menu/README.md
+++ b/packages/mongo-nav/src/user-menu/README.md
@@ -31,6 +31,235 @@ import { UserMenu } from '@leafygreen-ui/mongo-nav';
 
 **Output HTML**
 
+```html
+<button data-leafygreen-ui="button-data-prop" class="leafygreen-ui-161kcxt">
+  <span class="leafygreen-ui-1w553ho">DevMode</span>
+  <svg>...</svg>
+</button>
+<div>
+  <div class="leafygreen-ui-14miqj0">
+    <ul class="leafygreen-ui-9rckhy" role="menu">
+      <div class="leafygreen-ui-16vs4iz">
+        <div class="leafygreen-ui-ey57f9">
+          <svg>...</svg>
+        </div>
+        <h3 class="leafygreen-ui-1sz0213">DevMode Developer</h3>
+        <p class="leafygreen-ui-eb24fp">dev+only+mode@example.com</p>
+        <a
+          href="https://account.mongodb.com/account/profile/overview"
+          class="leafygreen-ui-64m91y"
+          aria-disabled="false"
+        >
+          <span class="leafygreen-ui-1pz0klt">Manage your MongoDB Account</span>
+        </a>
+      </div>
+      <li role="separator" class="leafygreen-ui-1xz620q"></li>
+      <li role="none" class="leafygreen-ui-1ipix51">
+        <a
+          data-leafygreen-ui="sub-menu-container"
+          target="_blank"
+          rel="noopener noreferrer"
+          role="menuitem"
+          href="https://cloud.mongodb.com"
+          aria-haspopup="true"
+          class="leafygreen-ui-5zw952"
+        >
+          <svg>...</svg>
+          <div>
+            <div class="leafygreen-ui-1cw9d0t">Atlas</div>
+            <div class="">
+              <div class="leafygreen-ui-12kbxt0">
+                cloud.mongodb.com
+                <svg>...</svg>
+              </div>
+            </div>
+          </div>
+        </a>
+        <button
+          data-leafygreen-ui="icon-button"
+          aria-disabled="false"
+          aria-label="Close Sub-menu"
+          class="leafygreen-ui-1x584s8"
+        >
+          <span class="leafygreen-ui-1rvdyoi"><svg>...</svg></span>
+        </button>
+        <ul class="leafygreen-ui-23uywq" role="menu" aria-label="Atlas">
+          <li role="none">
+            <a
+              target="_self"
+              rel=""
+              href="https://cloud.mongodb.com/v2#/preferences/personalization"
+              data-leafygreen-ui="menu-item-container"
+              class="leafygreen-ui-127tgf0"
+              role="menuitem"
+              aria-disabled="false"
+            >
+              <div class="leafygreen-ui-vrj1me">
+                <div class="leafygreen-ui-2863pl">
+                  <div class="leafygreen-ui-3f75pk"></div>
+                  User Preferences
+                </div>
+              </div>
+            </a>
+          </li>
+          <li role="none">
+            <a
+              target="_self"
+              rel=""
+              href="https://cloud.mongodb.com/v2#/preferences/invitations"
+              data-leafygreen-ui="menu-item-container"
+              class="leafygreen-ui-127tgf0"
+              role="menuitem"
+              aria-disabled="false"
+            >
+              <div class="leafygreen-ui-vrj1me">
+                <div class="leafygreen-ui-2863pl">
+                  <div class="leafygreen-ui-3f75pk"></div>
+                  <span class="leafygreen-ui-uf1ume">
+                    Invitations
+                    <div class="leafygreen-ui-g4d1vq">1</div>
+                  </span>
+                </div>
+              </div>
+            </a>
+          </li>
+          <li role="none">
+            <a
+              target="_self"
+              rel=""
+              href="https://cloud.mongodb.com/v2#/preferences/organizations"
+              data-leafygreen-ui="menu-item-container"
+              class="leafygreen-ui-127tgf0"
+              role="menuitem"
+              aria-disabled="false"
+            >
+              <div class="leafygreen-ui-vrj1me">
+                <div class="leafygreen-ui-2863pl">
+                  <div class="leafygreen-ui-3f75pk"></div>
+                  Organizations
+                </div>
+              </div>
+            </a>
+          </li>
+          <li role="none">
+            <a
+              target="_self"
+              rel=""
+              href="https://cloud.mongodb.com/v2#/preferences/2fa"
+              data-leafygreen-ui="menu-item-container"
+              class="leafygreen-ui-127tgf0"
+              role="menuitem"
+              aria-disabled="false"
+            >
+              <div class="leafygreen-ui-vrj1me">
+                <div class="leafygreen-ui-2863pl">
+                  <div class="leafygreen-ui-3f75pk"></div>
+                  Two-Factor Authorization
+                </div>
+              </div>
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li role="none" class="leafygreen-ui-1ipix51">
+        <a
+          data-leafygreen-ui="sub-menu-container"
+          target="_blank"
+          rel="noopener noreferrer"
+          role="menuitem"
+          href="https://university.mongodb.com"
+          aria-haspopup="true"
+          class="leafygreen-ui-lcbwlw"
+        >
+          <svg>...</svg>
+          <div>
+            <div class="leafygreen-ui-x1ohas">University</div>
+            <div class="">
+              <div class="leafygreen-ui-1y5lwzw">
+                university.mongodb.com
+                <svg>...</svg>
+              </div>
+            </div>
+          </div>
+        </a>
+        <button
+          data-leafygreen-ui="icon-button"
+          aria-disabled="false"
+          aria-label="Open Sub-menu"
+          class="leafygreen-ui-1fct8le"
+        >
+          <span class="leafygreen-ui-1rvdyoi">
+            <svg>...</svg>
+          </span>
+        </button>
+      </li>
+      <li role="none" class="leafygreen-ui-1ipix51">
+        <a
+          data-leafygreen-ui="sub-menu-container"
+          target="_blank"
+          rel="noopener noreferrer"
+          role="menuitem"
+          href="https://support.mongodb.com"
+          aria-haspopup="true"
+          class="leafygreen-ui-lcbwlw"
+        >
+          <svg>...</svg>
+          <div>
+            <div class="leafygreen-ui-x1ohas">Support</div>
+            <div class="">
+              <div class="leafygreen-ui-1y5lwzw">
+                support.mongodb.com
+                <svg>...</svg>
+              </div>
+            </div>
+          </div>
+        </a>
+        <button
+          data-leafygreen-ui="icon-button"
+          aria-disabled="false"
+          aria-label="Open Sub-menu"
+          class="leafygreen-ui-1fct8le"
+        >
+          <span class="leafygreen-ui-1rvdyoi">
+            <svg>...</svg>
+          </span>
+        </button>
+      </li>
+      <li role="separator" class="leafygreen-ui-1xz620q"></li>
+      <li role="none">
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://feedback.mongodb.com/"
+          data-leafygreen-ui="menu-item-container"
+          class="leafygreen-ui-1yd5tpt"
+          role="menuitem"
+          aria-disabled="false"
+        >
+          <svg>...</svg>
+          <div class="leafygreen-ui-vrj1me">
+            <div class="leafygreen-ui-2863pl">Give us feedback</div>
+          </div>
+        </a>
+      </li>
+      <li role="separator" class="leafygreen-ui-1xz620q"></li>
+      <li role="none">
+        <button
+          data-leafygreen-ui="menu-item-container"
+          class="leafygreen-ui-1yd5tpt"
+          role="menuitem"
+          aria-disabled="false"
+        >
+          <div class="leafygreen-ui-vrj1me">
+            <div class="leafygreen-ui-2863pl">Logout</div>
+          </div>
+        </button>
+      </li>
+    </ul>
+  </div>
+</div>
+```
+
 ## Properties
 
 | Prop              | Type                                                                                                                                                                 | Description                                                                                                                                                | Default                                                                                                                                                                       |

--- a/packages/mongo-nav/src/user-menu/README.md
+++ b/packages/mongo-nav/src/user-menu/README.md
@@ -1,0 +1,43 @@
+# UserMenu
+
+![npm (scoped)](https://img.shields.io/npm/v/@leafygreen-ui/mongo-nav.svg)
+
+## Installation
+
+### Yarn
+
+\`\`\`shell
+yarn add @leafygreen-ui/mongo-nav
+\`\`\`
+
+### NPM
+
+\`\`\`shell
+npm install @leafygreen-ui/mongo-nav
+\`\`\`
+
+## Example
+
+```js
+import { UserMenu } from '@leafygreen-ui/mongo-nav';
+
+<UserMenu
+  account={account}
+  activeProduct={activeProduct}
+  urls={urls}
+  hosts={hosts}
+/>;
+```
+
+**Output HTML**
+
+## Properties
+
+| Prop              | Type                                                                                                                                                                 | Description                                                                                                                                                | Default                                                                                                                                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `account`         | `{firstName: string, lastName: string, email: string, alerts: number}`                                                                                               | Object that contains information about the active user.                                                                                                    |                                                                                                                                                                               |
+| `activeProduct`   | `cloud`, `university` or `support`                                                                                                                                   | MongoDB product that is currently active                                                                                                                   |                                                                                                                                                                               |
+| `onLogout`        | `Function`                                                                                                                                                           | Callback invoked after the user clicks log out                                                                                                             | `() => {}`                                                                                                                                                                    |
+| `onProductChange` | `Function`                                                                                                                                                           | Callback invoked after the user clicks a product.                                                                                                          | `() => {}`                                                                                                                                                                    |
+| `hosts`           | `{ cloud, support, university, account }`                                                                                                                            | Object where keys are MDB products and values are the desired hostURL override for that product, to enable `<UserMenu />` to work across all environments. | `{ cloud: 'cloud.mongodb.com', support: 'support.mongodb.com', university: 'university.mongodb.com', account: 'account.mongodb.com' }`                                        |
+| `urls`            | `{ userMenu:{ cloud: { userPreferences, organizations, invitations, mfa }, university: { videoPreferences }, support: { userPreferences }, account: { homepage } }}` | Object to enable custom overrides for every `href` used in `<UserMenu />`.                                                                                 | If overrides are not passed in, default values are constructed based on hosts prop. In the absence of the hosts prop, will default to URLS that suit a production environment |

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -210,7 +210,7 @@ function UserMenu({
 }: UserMenuProps) {
   const hosts = defaultsDeep(hostsProp, defaultHosts);
 
-  // wil make this logic more abstract, but wanted to get a quick fix in so that UserMenu can be consumed outside of MongoNav
+  // will make this logic more abstract, but wanted to get a quick fix in so that UserMenu can be consumed outside of MongoNav
   const defaultURLs = {
     userMenu: {
       cloud: {

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -30,7 +30,7 @@ const defaultHosts: Required<HostsInterface> = {
   support: 'https://support.mongodb.com',
   charts: 'https://charts.mongodb.com',
   realm: 'https://stitch.mongodb.com',
-};
+} as const;
 
 const subMenuContainer = createDataProp('sub-menu-container');
 
@@ -210,6 +210,7 @@ function UserMenu({
 }: UserMenuProps) {
   const hosts = defaultsDeep(hostsProp, defaultHosts);
 
+  // wil make this logic more abstract, but wanted to get a quick fix in so that UserMenu can be consumed outside of MongoNav
   const defaultURLs = {
     userMenu: {
       cloud: {

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -20,6 +20,8 @@ import {
   URLSInterface,
   Product,
   HostsInterface,
+  UserMenuURLSInterface,
+  UserMenuHostsInterface,
 } from '../types';
 
 const subMenuContainer = createDataProp('sub-menu-container');
@@ -154,9 +156,9 @@ interface UserMenuProps {
    */
   onProductChange?: React.MouseEventHandler;
 
-  urls: Required<URLSInterface>;
+  urls: Required<URLSInterface> | UserMenuURLSInterface;
 
-  hosts: Required<HostsInterface>;
+  hosts: Required<HostsInterface> | UserMenuHostsInterface;
 }
 
 function UserMenu({


### PR DESCRIPTION
## ✍️ Proposed changes
- University needs a Menu to use ASAP, and we've deprecated MongoMenu, so we need to make UserMenu resilient when used in environments outside of the MongoNav component
- Only blocker here is that the Hosts/URLs are currently required for the entire MongoNav component, so suggested changes.. 

- Hosts/URLs are no longer required props
- Duplicated logic for creating defaults for Hosts and URLs from MongoNav, as if this component is to be used outside of the MongoNav component, it will need this logic implemented
- To Note: I know there is a PR floating around out there made by @seanmhanson which moves some of this URL logic outside of the <MongoNav /> component, so I didn't want to duplicate this work right now and was thinking we could merge without the more generalized defaults and then update once their PR is in


🎟 _Jira ticket:_ [PD-545](https://jira.mongodb.org/browse/[PD-545])

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes