### PR TITLE
PD-553: Fix typo in project links

### DIFF
--- a/.changeset/blue-timers-explode.md
+++ b/.changeset/blue-timers-explode.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+This fixes a bug involving broken project links.

--- a/packages/mongo-nav/src/MongoNav.tsx
+++ b/packages/mongo-nav/src/MongoNav.tsx
@@ -250,7 +250,7 @@ export default function MongoNav({
     constructOrganizationURLProp ?? defaultOrgURL;
 
   const defaultProjectURL = (projectId: string) =>
-    `${hosts.cloud}/v2#/${projectId}`;
+    `${hosts.cloud}/v2/${projectId}#`;
   const constructProjectURL = constructProjectURLProp ?? defaultProjectURL;
 
   return (

--- a/packages/mongo-nav/src/data.ts
+++ b/packages/mongo-nav/src/data.ts
@@ -83,12 +83,12 @@ export const urlDefaults: Required<URLSInterface> = {
     admin: `https://cloud.mongodb.com/v2/admin#general/overview/servers`,
   },
   projectNav: {
-    settings: `https://cloud.mongodb.com/v2/currentProjectId098#settings/groupSettings`,
-    accessManager: `https://cloud.mongodb.com/v2/currentProjectId098#access`,
-    support: `https://cloud.mongodb.com/v2/currentProjectId098#info/support`,
-    integrations: `https://cloud.mongodb.com/v2/currentProjectId098#integrations`,
-    alerts: `https://cloud.mongodb.com/v2/currentProjectId098#alerts`,
-    activityFeed: `https://cloud.mongodb.com/v2/currentProjectId098#activity`,
+    settings: `https://cloud.mongodb.com/v2/${dataFixtures.currentProject?.projectId}#settings/groupSettings`,
+    accessManager: `https://cloud.mongodb.com/v2/${dataFixtures.currentProject?.projectId}#access`,
+    support: `https://cloud.mongodb.com/v2/${dataFixtures.currentProject?.projectId}#info/support`,
+    integrations: `https://cloud.mongodb.com/v2/${dataFixtures.currentProject?.projectId}#integrations`,
+    alerts: `https://cloud.mongodb.com/v2/${dataFixtures.currentProject?.projectId}#alerts`,
+    activityFeed: `https://cloud.mongodb.com/v2/${dataFixtures.currentProject?.projectId}#activity`,
   },
   onPrem: {
     profile: `https://cloud.mongodb.com/v2#/account/profile`,


### PR DESCRIPTION
## ✍️ Proposed changes
This corrects the default project url to put the hash after the projectId. It also corrects a similar issue in the fixture data, though it does not appear to be used in testing.

🎟 _Jira ticket:_ [PD-553](https://jira.mongodb.org/browse/[PD-553])

## 🛠 Types of changes
- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes