### PR TITLE
PD-569: Hide Scrollbars in MongoSelect

### DIFF
--- a/.changeset/stupid-poets-melt.md
+++ b/.changeset/stupid-poets-melt.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Conditionally apply overflow rule to MongoSelect components

--- a/packages/mongo-nav/src/data.ts
+++ b/packages/mongo-nav/src/data.ts
@@ -33,6 +33,26 @@ export const dataFixtures = {
       orgName: 'Demo Organization 2',
       planType: 'cloud',
     },
+    {
+      orgId: '5d729a93',
+      orgName: 'Demo Organization',
+      planType: 'atlas',
+    },
+    {
+      orgId: '5e0fa79',
+      orgName: 'Demo Organization 2',
+      planType: 'cloud',
+    },
+    {
+      orgId: '5d729a93',
+      orgName: 'Demo Organization',
+      planType: 'atlas',
+    },
+    {
+      orgId: '5e0fa79',
+      orgName: 'Demo Organization 2',
+      planType: 'cloud',
+    },
   ],
   projects: [
     {

--- a/packages/mongo-nav/src/data.ts
+++ b/packages/mongo-nav/src/data.ts
@@ -33,26 +33,6 @@ export const dataFixtures = {
       orgName: 'Demo Organization 2',
       planType: 'cloud',
     },
-    {
-      orgId: '5d729a93',
-      orgName: 'Demo Organization',
-      planType: 'atlas',
-    },
-    {
-      orgId: '5e0fa79',
-      orgName: 'Demo Organization 2',
-      planType: 'cloud',
-    },
-    {
-      orgId: '5d729a93',
-      orgName: 'Demo Organization',
-      planType: 'atlas',
-    },
-    {
-      orgId: '5e0fa79',
-      orgName: 'Demo Organization 2',
-      planType: 'cloud',
-    },
   ],
   projects: [
     {

--- a/packages/mongo-nav/src/mongo-select/MongoSelect.tsx
+++ b/packages/mongo-nav/src/mongo-select/MongoSelect.tsx
@@ -39,10 +39,7 @@ const ulStyle = css`
   max-height: ${5 * menuItemHeight}px;
   list-style: none;
   padding: unset;
-`;
-
-const overflowScroll = css`
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
 const viewAllStyle = css`
@@ -121,7 +118,6 @@ function OrgSelect({
   loading = false,
 }: OrganizationMongoSelectProps) {
   const [open, setOpen] = useState(false);
-  const menuItemLength = data?.length ?? 0;
 
   const renderOrganizationOption = (datum: OrganizationInterface) => {
     const { orgId, orgName, planType } = datum;
@@ -171,11 +167,7 @@ function OrgSelect({
           />
         </FocusableMenuItem>
 
-        <ul
-          className={cx(ulStyle, {
-            [overflowScroll]: menuItemLength > 5,
-          })}
-        >
+        <ul className={ulStyle}>
           {data?.map(renderOrganizationOption) ?? (
             <li>
               You do not belong to any organizations. Create an organization to
@@ -210,7 +202,6 @@ function ProjectSelect({
   loading = false,
 }: ProjectMongoSelectProps) {
   const [open, setOpen] = useState(false);
-  const menuItemLength = data?.length ?? 0;
 
   const renderProjectOption = (datum: ProjectInterface) => {
     const { projectId, projectName, orgId } = datum;
@@ -252,11 +243,7 @@ function ProjectSelect({
           />
         </FocusableMenuItem>
 
-        <ul
-          className={cx(ulStyle, {
-            [overflowScroll]: menuItemLength > 5,
-          })}
-        >
+        <ul className={ulStyle}>
           {data?.map(datum => renderProjectOption(datum))}
         </ul>
 

--- a/packages/mongo-nav/src/mongo-select/MongoSelect.tsx
+++ b/packages/mongo-nav/src/mongo-select/MongoSelect.tsx
@@ -37,9 +37,12 @@ const menuItemContainerStyle = css`
 
 const ulStyle = css`
   max-height: ${5 * menuItemHeight}px;
-  overflow: scroll;
   list-style: none;
   padding: unset;
+`;
+
+const overflowScroll = css`
+  overflow-y: scroll;
 `;
 
 const viewAllStyle = css`
@@ -118,6 +121,7 @@ function OrgSelect({
   loading = false,
 }: OrganizationMongoSelectProps) {
   const [open, setOpen] = useState(false);
+  const menuItemLength = data?.length ?? 0;
 
   const renderOrganizationOption = (datum: OrganizationInterface) => {
     const { orgId, orgName, planType } = datum;
@@ -167,7 +171,11 @@ function OrgSelect({
           />
         </FocusableMenuItem>
 
-        <ul className={ulStyle}>
+        <ul
+          className={cx(ulStyle, {
+            [overflowScroll]: menuItemLength > 5,
+          })}
+        >
           {data?.map(renderOrganizationOption) ?? (
             <li>
               You do not belong to any organizations. Create an organization to
@@ -202,6 +210,7 @@ function ProjectSelect({
   loading = false,
 }: ProjectMongoSelectProps) {
   const [open, setOpen] = useState(false);
+  const menuItemLength = data?.length ?? 0;
 
   const renderProjectOption = (datum: ProjectInterface) => {
     const { projectId, projectName, orgId } = datum;
@@ -243,7 +252,11 @@ function ProjectSelect({
           />
         </FocusableMenuItem>
 
-        <ul className={ulStyle}>
+        <ul
+          className={cx(ulStyle, {
+            [overflowScroll]: menuItemLength > 5,
+          })}
+        >
           {data?.map(datum => renderProjectOption(datum))}
         </ul>
 


### PR DESCRIPTION
## ✍️ Proposed changes

- Room for scrollbars displaying unnecessarily in OrgSelect and ProjectSelect components
- Made overflow logic more specific to overflow-y, and conditionally applying the CSS rule based on the number of MenuItems that will appear in the Select components 

- To test locally, update OS preferences to always display scroll bars and add varying levels of orgs/projects to the data.ts file

- With 5 MenuItems: ![Screen Shot 2020-03-09 at 9 46 02 AM](https://user-images.githubusercontent.com/26016393/76218907-605ae580-61eb-11ea-9310-ed57940f3c71.png)
- With 5+: ![Screen Shot 2020-03-09 at 9 46 10 AM](https://user-images.githubusercontent.com/26016393/76218958-723c8880-61eb-11ea-960a-107b5b4e6d15.png)


🎟 _Jira ticket:_ [PD-569](https://jira.mongodb.org/browse/PD-569)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

