### PR TITLE
Prevent against possible undefined value

### DIFF
--- a/packages/mongo-nav/src/MongoNav.tsx
+++ b/packages/mongo-nav/src/MongoNav.tsx
@@ -326,11 +326,9 @@ function MongoNav({
     }
   }, [mode, endpointURI, activeOrgId, activeProjectId, loadData]);
 
-  const filteredProjects = data?.projects
-    ? data.projects.filter(project => {
-        return project.orgId === data.currentProject?.orgId;
-      })
-    : undefined;
+  const filteredProjects = data?.projects?.filter(project => {
+    return project.orgId === data.currentProject?.orgId;
+  });
 
   return (
     <OnElementClickProvider onElementClick={onElementClick}>

--- a/packages/mongo-nav/src/MongoNav.tsx
+++ b/packages/mongo-nav/src/MongoNav.tsx
@@ -326,9 +326,11 @@ function MongoNav({
     }
   }, [mode, endpointURI, activeOrgId, activeProjectId, loadData]);
 
-  const filteredProjects = data?.projects.filter(project => {
-    return project.orgId === data.currentProject?.orgId;
-  });
+  const filteredProjects = data?.projects
+    ? data.projects.filter(project => {
+        return project.orgId === data.currentProject?.orgId;
+      })
+    : undefined;
 
   return (
     <OnElementClickProvider onElementClick={onElementClick}>


### PR DESCRIPTION
Super small tweak, encountered when updating tests in mms. Better to be safe and check that it exists before trying to filter on it so MongoNav doesn't fail hard.