### PR TITLE
Remove async await syntax from MongoNav

### DIFF
--- a/.changeset/kind-beans-fly.md
+++ b/.changeset/kind-beans-fly.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Remove async await syntax to avoid having to polyfill regenerator runtime

--- a/packages/mongo-nav/src/MongoNav.tsx
+++ b/packages/mongo-nav/src/MongoNav.tsx
@@ -291,20 +291,26 @@ function MongoNav({
     return fetch(endpointURI, configObject);
   }
 
-  async function getDataFixtures() {
-    onSuccess?.(dataFixtures);
-    return dataFixtures;
+  function getDataFixtures() {
+    return new Promise(resolve => {
+      onSuccess?.(dataFixtures);
+      resolve(dataFixtures);
+    });
   }
 
-  async function handleResponse(response: Response) {
+  function handleResponse(response: Response) {
     if (!response.ok) {
       const mappedStatus = ErrorCodeMap[response.status];
       onError?.(mappedStatus);
       console.error(mappedStatus);
     } else {
-      const data = await response.json();
-      setData(data);
-      onSuccess?.(data);
+      response
+        .json()
+        .then(data => {
+          setData(data);
+          onSuccess?.(data);
+        })
+        .catch(console.error);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

While debugging Realm's integration of MongoNav, it appears that async await syntax is being polyfilled with regenerator runtime, but it wasn't being required in the build. Rather than adding a rather large polyfill (+50% to the MongoNav build file size, IIRC), this PR switches use of the syntax to more traditional Promise API.

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~
- [x] I have run `yarn changeset` and documented my changes