### PR TITLE
PD-605: Makes Atlas/Cloud Manager Tab Inactive when a user is on a project page

### DIFF
--- a/.changeset/cuddly-trains-heal.md
+++ b/.changeset/cuddly-trains-heal.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Makes Atlas/Cloud Manager tabs inactive when a user is on a project page

--- a/packages/mongo-nav/src/project-nav/ProjectNav.tsx
+++ b/packages/mongo-nav/src/project-nav/ProjectNav.tsx
@@ -254,6 +254,15 @@ type ProjectNavProps = Pick<
   hosts: Required<NonNullable<MongoNavInterface['hosts']>>;
 };
 
+const ProjectActiveMenuItems = [
+  ActiveNavElement.ProjectNavActivityFeed,
+  ActiveNavElement.ProjectNavAlerts,
+  ActiveNavElement.ProjectNavInvite,
+  ActiveNavElement.ProjectNavProjectIntegrations,
+  ActiveNavElement.ProjectNavProjectSettings,
+  ActiveNavElement.ProjectNavProjectSupport,
+];
+
 export default function ProjectNav({
   admin,
   current,
@@ -283,6 +292,10 @@ export default function ProjectNav({
     activeNav === ActiveNavElement.ProjectNavActivityFeed && isLoading;
   const isProjectAlerts =
     activeNav === ActiveNavElement.ProjectNavAlerts && isLoading;
+
+  const hideActiveProductTab = (ProjectActiveMenuItems as Array<
+    string
+  >).includes(activeNav as string);
 
   const currentProjectId = current?.projectId;
 
@@ -318,7 +331,11 @@ export default function ProjectNav({
 
   const getProductClassName = (product: Product) =>
     cx(anchorOverrides, projectNavAnchorOverrides, productStyle, {
-      [productStates.active]: !!(activeProduct === product && current),
+      [productStates.active]: !!(
+        activeProduct === product &&
+        current &&
+        !hideActiveProductTab
+      ),
       [productStates.focus]: showFocus,
       [productStates.loading]: !current,
       [cloudManagerStyle]: isCloudManager,
@@ -416,7 +433,11 @@ export default function ProjectNav({
           >
             {!isMobile && (
               <AtlasIcon
-                active={activeProduct === Product.Cloud && isLoading}
+                active={
+                  activeProduct === Product.Cloud &&
+                  isLoading &&
+                  !hideActiveProductTab
+                }
                 {...productIconProp.prop}
                 className={iconStyle}
               />
@@ -438,7 +459,11 @@ export default function ProjectNav({
               >
                 {!isMobile && (
                   <RealmIcon
-                    active={activeProduct === Product.Realm && isLoading}
+                    active={
+                      activeProduct === Product.Realm &&
+                      isLoading &&
+                      !hideActiveProductTab
+                    }
                     {...productIconProp.prop}
                     className={iconStyle}
                   />
@@ -460,7 +485,11 @@ export default function ProjectNav({
                   <ChartsIcon
                     {...productIconProp.prop}
                     className={iconStyle}
-                    active={activeProduct === Product.Charts && isLoading}
+                    active={
+                      activeProduct === Product.Charts &&
+                      isLoading &&
+                      !hideActiveProductTab
+                    }
                   />
                 )}
                 Charts


### PR DESCRIPTION
## ✍️ Proposed changes

- Makes Atlas/Cloud Manager Tab Inactive when a user is on a project page 
cc: @nellem23 

🎟 _Jira ticket:_ [PD-605](https://jira.mongodb.org/browse/PD-605)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

![Screen Shot 2020-04-03 at 3 04 08 PM](https://user-images.githubusercontent.com/26016393/78396085-b0e01b80-75bc-11ea-8fec-69bc8d4503fa.png)
