### PR TITLE
PD-628: Makes Cloud section of UserMenu clickable, even if Cloud is not the active product

### DIFF
--- a/.changeset/silent-boxes-brush.md
+++ b/.changeset/silent-boxes-brush.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/menu': patch
+---
+
+Fixes style bug when MenuItem is focused and rendered as anchor tag

--- a/.changeset/tall-deers-exist.md
+++ b/.changeset/tall-deers-exist.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Makes Cloud section of UserMenu clickable, even if Cloud is not the active product

--- a/packages/menu/src/styles.tsx
+++ b/packages/menu/src/styles.tsx
@@ -28,6 +28,7 @@ export const menuItemContainerStyle = css`
 
   &:focus {
     outline: none;
+    text-decoration: none;
   }
 
   &:before {

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -335,7 +335,7 @@ function UserMenu({
             {...subMenuContainer.prop}
             {...sharedProps}
             active={isCloud}
-            disabled={!account || !isCloud}
+            disabled={!account}
             href={hosts.cloud}
             description={<Description isActive={isCloud} product="cloud" />}
             title="Cloud"


### PR DESCRIPTION
## ✍️ Proposed changes

- Makes Cloud section of UserMenu clickable, even if Cloud is not the active product
also fixes bug in MenuItem, which removes text-decoration from the focused style when MenuItem is rendered as an anchor tag

cc: @nellem23 

🎟 _Jira ticket:_ [PD-628](https://jira.mongodb.org/browse/PD-628)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->
