### PR TITLE
PD-662: Allows consumers to override type prop in Input component

### DIFF
--- a/.changeset/honest-bulldogs-confess.md
+++ b/.changeset/honest-bulldogs-confess.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/text-input': minor
+---
+
+Allows consumer to set `type` attribute on input component

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -55,18 +55,21 @@ return (
 
 ## Properties
 
-| Prop           | Type                     | Description                                                                                                               | Default |
-| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `id`           | `string`                 | id associated with the TextInput component.                                                                               |         |
-| `label`        | `string`                 | Text shown in bold above the input element.                                                                               |         |
-| `description`  | `string`                 | Text that gives more detail about the requirements for the input.                                                         |         |
-| `optional`     | `boolean`                | Marks the input as optional                                                                                               | `false` |
-| `disabled`     | `boolean`                | Disabled the input                                                                                                        | `false` |
-| `onChange`     | `function`               | The event handler function for the 'onchange' event. Accepts the change event object as its argument and returns nothing. |         |
-| `placeholder`  | `string`                 | The placeholder text shown in the input field before the user begins typing.                                              |         |
-| `errorMessage` | `string`                 | Text that gives more detail about the requirements for the input.                                                         |         |
-| `state`        | `none`, `valid`, `error` | Describes the state of the TextInput element before and after the input has been validated                                | `none`  |
-| `value`        | `string`                 | Sets the HTML `value` attribute.                                                                                          | `''`    |
-| `className`    | `string`                 | Adds a className to the class attribute.                                                                                  | `''`    |
+| Prop           | Type                                                | Description                                                                                                               | Default |
+| -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `id`           | `string`                                            | id associated with the TextInput component.                                                                               |         |
+| `label`        | `string`                                            | Text shown in bold above the input element.                                                                               |         |
+| `description`  | `string`                                            | Text that gives more detail about the requirements for the input.                                                         |         |
+| `optional`     | `boolean`                                           | Marks the input as optional                                                                                               | `false` |
+| `disabled`     | `boolean`                                           | Disabled the input                                                                                                        | `false` |
+| `onChange`     | `function`                                          | The event handler function for the 'onchange' event. Accepts the change event object as its argument and returns nothing. |         |
+| `placeholder`  | `string`                                            | The placeholder text shown in the input field before the user begins typing.                                              |         |
+| `errorMessage` | `string`                                            | Text that gives more detail about the requirements for the input.                                                         |         |
+| `state`        | `none`, `valid`, `error`                            | Describes the state of the TextInput element before and after the input has been validated                                | `none`  |
+| `value`        | `string`                                            | Sets the HTML `value` attribute.                                                                                          | `''`    |
+| `className`    | `string`                                            | Adds a className to the class attribute.                                                                                  | `''`    |
+| `type`         | `email`, `password`, `search`, `text`, `url`, `tel` | Sets type for TextInput                                                                                                   | `text`  |
+
+};
 
 _Any other properties will be spread on the `input` element._

--- a/packages/text-input/src/TextInput.spec.tsx
+++ b/packages/text-input/src/TextInput.spec.tsx
@@ -34,7 +34,7 @@ describe('packages/text-input', () => {
     expect(getByPlaceholderText(defaultProps.placeholder)).toBeVisible();
   });
 
-  test(`renders ${defaultProps.className} in the XX classList`, () => {
+  test(`renders ${defaultProps.className} in the classList`, () => {
     const { container } = renderTextInput(defaultProps);
     expect(
       (container?.firstChild as HTMLElement)?.classList.contains(
@@ -46,6 +46,16 @@ describe('packages/text-input', () => {
   test('renders "optional" text when the prop is set to true', () => {
     const { getByText } = renderTextInput({ optional: true, ...defaultProps });
     expect(getByText('Optional')).toBeVisible();
+  });
+
+  test('renders type as "text" by default', () => {
+    const { textInput } = renderTextInput();
+    expect(textInput.getAttribute('type')).toBe('text');
+  });
+
+  test('renders type as "password" when the prop is set', () => {
+    const { textInput } = renderTextInput({ type: 'password' });
+    expect(textInput.getAttribute('type')).toBe('password');
   });
 
   test('does not render "optional" text when the prop is set to false ', () => {

--- a/packages/text-input/src/TextInput.story.tsx
+++ b/packages/text-input/src/TextInput.story.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, text, select } from '@storybook/addon-knobs';
 import { css } from '@leafygreen-ui/emotion';
-import TextInput from '.';
+import TextInput, { TextInputType } from '.';
 
 const wrapperStyle = css`
   width: 400px;
@@ -17,6 +17,7 @@ storiesOf('TextInput', module).add('Default', () => (
       disabled={boolean('Disabled', false)}
       placeholder={text('Placeholder Text', 'This is some placeholder text')}
       state={select('State', ['none', 'valid', 'error'], 'none')}
+      type={select('Type', Object.values(TextInputType), TextInputType.Text)}
       errorMessage={text('Error Message', 'This is an error message')}
     />
   </div>

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -286,10 +286,10 @@ const TextInput = React.forwardRef(
         {description && <p className={descriptionStyle}>{description}</p>}
         <div className={inputContainerStyle}>
           <input
+            type="text"
             {...inputSelectorProp.prop}
             {...rest}
             className={cx(inputStyle, getStatefulInputStyles(state, optional))}
-            type="text"
             value={value}
             required={!optional}
             disabled={disabled}

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -17,6 +17,17 @@ export const State = {
 
 export type State = typeof State[keyof typeof State];
 
+export const TextInputType = {
+  Email: 'email',
+  Password: 'password',
+  Search: 'search',
+  Text: 'text',
+  Url: 'url',
+  Tel: 'tel',
+};
+
+export type TextInputType = typeof TextInputType[keyof typeof TextInputType];
+
 interface TextInputProps extends HTMLElementProps<'input'> {
   /**
    * id associated with the TextInput component.
@@ -74,6 +85,8 @@ interface TextInputProps extends HTMLElementProps<'input'> {
    * className supplied to the TextInput container.
    */
   className?: string;
+
+  type?: TextInputType;
 }
 
 const interactionRing = css`
@@ -253,6 +266,7 @@ const TextInput = React.forwardRef(
       placeholder,
       errorMessage,
       state = State.None,
+      type = TextInputType.Text,
       value: controlledValue,
       className,
       ...rest
@@ -286,9 +300,9 @@ const TextInput = React.forwardRef(
         {description && <p className={descriptionStyle}>{description}</p>}
         <div className={inputContainerStyle}>
           <input
-            type="text"
             {...inputSelectorProp.prop}
             {...rest}
+            type={type}
             className={cx(inputStyle, getStatefulInputStyles(state, optional))}
             value={value}
             required={!optional}

--- a/packages/text-input/src/index.ts
+++ b/packages/text-input/src/index.ts
@@ -1,2 +1,3 @@
-import TextInput from './TextInput';
+import TextInput, { TextInputType } from './TextInput';
+export { TextInputType };
 export default TextInput;


### PR DESCRIPTION
## ✍️ Proposed changes

Allows consumers to override type prop in Input component

🎟 _Jira ticket:_ [PD-662](https://jira.mongodb.org/browse/PD-662)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<img width="469" alt="Screen Shot 2020-05-05 at 5 09 31 PM" src="https://user-images.githubusercontent.com/26016393/81116360-38d67f80-8ef3-11ea-98b1-9d4dc39e2adf.png">
