### PR TITLE
PD-665: Upgrade to react-transition-group 4.4.x which fixes StrictMode warnings

### DIFF
--- a/.changeset/cyan-plums-grow.md
+++ b/.changeset/cyan-plums-grow.md
@@ -4,4 +4,4 @@
 '@leafygreen-ui/popover': patch
 ---
 
-Upgrades react-transition-group to 4.4.1
+Upgrades `react-transition-group` to 4.4.1 which removes all React `StrictMode` warnings, making these components `StrictMode` safe.

--- a/.changeset/cyan-plums-grow.md
+++ b/.changeset/cyan-plums-grow.md
@@ -1,0 +1,7 @@
+---
+'@leafygreen-ui/menu': patch
+'@leafygreen-ui/modal': patch
+'@leafygreen-ui/popover': patch
+---
+
+Upgrades react-transition-group to 4.4.1

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -16,7 +16,7 @@
     "@leafygreen-ui/icon": "^5.1.0"
   },
   "dependencies": {
-    "react-transition-group": "^4.2.1",
+    "react-transition-group": "^4.4.1",
     "@leafygreen-ui/hooks": "^2.1.0",
     "@leafygreen-ui/lib": "^4.4.1",
     "@leafygreen-ui/popover": "^5.0.1",

--- a/packages/menu/src/SubMenu.tsx
+++ b/packages/menu/src/SubMenu.tsx
@@ -381,7 +381,8 @@ SubMenu.displayName = 'SubMenu';
 // @ts-ignore: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37660
 SubMenu.propTypes = {
   title: PropTypes.string,
-  description: PropTypes.element,
+  // @ts-ignore
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   // @ts-ignore
   href: PropTypes.string,
   children: PropTypes.node,

--- a/packages/menu/src/SubMenu.tsx
+++ b/packages/menu/src/SubMenu.tsx
@@ -222,7 +222,7 @@ const SubMenu = React.forwardRef((props: SubMenuProps, ref) => {
   } = props;
 
   const { usingKeyboard: showFocus } = useUsingKeyboardContext();
-
+  const nodeRef = React.useRef(null);
   const iconButtonRef: React.RefObject<HTMLElement | null> = useRef(null);
 
   const onRootClick = (
@@ -323,9 +323,11 @@ const SubMenu = React.forwardRef((props: SubMenuProps, ref) => {
         mountOnEnter
         unmountOnExit
         onExited={onExited}
+        nodeRef={nodeRef}
       >
         {(state: string) => (
           <ul
+            ref={nodeRef}
             className={cx(ulStyle, {
               [css`
                 height: ${subMenuItemHeight * numberOfMenuItems}px;

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "react-transition-group": "^4.2.1",
+    "react-transition-group": "^4.4.1",
     "@leafygreen-ui/hooks": "^2.0.0",
     "@leafygreen-ui/icon": "^5.1.0",
     "@leafygreen-ui/lib": "^4.2.0",

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -178,6 +178,7 @@ function Modal({
   ...rest
 }: ModalProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const nodeRef = React.useRef(null);
 
   const handleClose = useCallback(() => {
     if (setOpen && shouldClose()) {
@@ -194,10 +195,17 @@ function Modal({
   useEscapeKey(handleClose, { enabled: open });
 
   return (
-    <Transition in={open} timeout={500} mountOnEnter unmountOnExit>
+    <Transition
+      in={open}
+      timeout={500}
+      mountOnEnter
+      unmountOnExit
+      nodeRef={nodeRef}
+    >
       {(state: string) => (
         <Portal>
           <div
+            ref={nodeRef}
             {...rest}
             // Setting role to 'none', because elements with a click event should have a specific role
             // Here we are just using a div to handle backdrop clicks, so this is the most appropriate value

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -197,7 +197,7 @@ function Modal({
   return (
     <Transition
       in={open}
-      timeout={500}
+      timeout={150}
       mountOnEnter
       unmountOnExit
       nodeRef={nodeRef}

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "react-transition-group": "^4.2.1",
+    "react-transition-group": "^4.4.1",
     "@leafygreen-ui/hooks": "^2.1.0",
     "@leafygreen-ui/lib": "^4.2.0",
     "@leafygreen-ui/portal": "^2.0.0",

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -197,7 +197,13 @@ function Popover({
   })();
 
   return (
-    <Transition in={active} timeout={{ exit: 150 }} mountOnEnter unmountOnExit>
+    <Transition
+      nodeRef={contentNode}
+      in={active}
+      timeout={{ exit: 150 }}
+      mountOnEnter
+      unmountOnExit
+    >
       {(state: string) => (
         <>
           <div

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -74,6 +74,13 @@ function Popover({
   const [contentNode, setContentNode] = useElementNode();
   const [forceUpdateCounter, setForceUpdateCounter] = useState(0);
 
+  // To remove StrictMode warnings produced by react-transition-group we need
+  // to pass in a useRef object to the <Transition> component.
+  // To do so we're shadowing the contentNode onto this nodeRef as
+  // <Transition> only accepts useRef objects.
+  const contentNodeRef = React.useRef(contentNode);
+  contentNodeRef.current = contentNode;
+
   let referenceElement: HTMLElement | null = null;
 
   if (refEl && refEl.current) {
@@ -196,11 +203,9 @@ function Popover({
     return children;
   })();
 
-  const nodeRef = React.useRef(null);
-
   return (
     <Transition
-      nodeRef={nodeRef}
+      nodeRef={contentNodeRef}
       in={active}
       timeout={{ exit: 150 }}
       mountOnEnter
@@ -215,10 +220,6 @@ function Popover({
             `}
           />
           <Root>
-            {/* Added new static ref to be able to pass a ref to <Transition /> */}
-            {/* Eliminates error message from react-strict-mode: 'findDOMNode is deprecated' */}
-            {/* Existing refs don't work to eliminate the error message, as they are dynamic and passing them to <Transition /> breaks the exit animation */}
-            <span ref={nodeRef} />
             <div
               {...rest}
               ref={setContentNode}

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -196,9 +196,11 @@ function Popover({
     return children;
   })();
 
+  const nodeRef = React.useRef(null);
+
   return (
     <Transition
-      nodeRef={contentNode}
+      nodeRef={nodeRef}
       in={active}
       timeout={{ exit: 150 }}
       mountOnEnter
@@ -213,6 +215,10 @@ function Popover({
             `}
           />
           <Root>
+            {/* Added new static ref to be able to pass a ref to <Transition /> */}
+            {/* Eliminates error message from react-strict-mode: 'findDOMNode is deprecated' */}
+            {/* Existing refs don't work to eliminate the error message, as they are dynamic and passing them to <Transition /> breaks the exit animation */}
+            <span ref={nodeRef} />
             <div
               {...rest}
               ref={setContentNode}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11985,10 +11985,20 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^4.2.1, react-transition-group@^4.3.0:
+react-transition-group@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
   integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
+react-transition-group@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"


### PR DESCRIPTION
## ✍️ Proposed changes

- Upgrade to react-transition-group 4.4.x which fixes StrictMode warnings
- Validates that animations still work
- Validates that strict mode console warnings no longer appear
🎟 _Jira ticket:_ [PD-665](https://jira.mongodb.org/browse/PD-665)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes
