### PR TITLE
PD-670: Clean up package-builder script

### DIFF
--- a/scripts/package-builder.js
+++ b/scripts/package-builder.js
@@ -120,8 +120,7 @@ export default function ${PACKAGE_UC}({}) {
 `;
 
 const index = `
-import ${PACKAGE_UC} from './${PACKAGE_UC}';
-export default ${PACKAGE_UC};
+export { default } from './${PACKAGE_UC}';
 `;
 
 const storybook = `
@@ -137,10 +136,9 @@ storiesOf('${PACKAGE_UC}', module)
 
 const spec = `
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import ${PACKAGE_UC} from '.';
-
-afterAll(cleanup);
 
 describe('packages/${PACKAGE_LC}', () => {
   test('condition', () => {


### PR DESCRIPTION
- Changes export pattern in index
- Removes cleanup from spec and adds jest-dom/extend-expect by default 