### PR TITLE
Fix glyph `displayName`s

### DIFF
--- a/.changeset/tasty-ways-design.md
+++ b/.changeset/tasty-ways-design.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/icon': patch
+---
+
+Fixes displayName property of generated glyphs

--- a/packages/icon/src/Icon.spec.tsx
+++ b/packages/icon/src/Icon.spec.tsx
@@ -150,7 +150,7 @@ describe('packages/Icon/createIconComponent', () => {
   });
 });
 
-describe('Generated icons', () => {
+describe('Generated glyphs', () => {
   test('Edit icon has displayName: "Edit"', () => {
     expect(EditIcon.displayName).toBe('Edit');
   });

--- a/packages/icon/src/Icon.spec.tsx
+++ b/packages/icon/src/Icon.spec.tsx
@@ -7,6 +7,7 @@ import { typeIs } from '@leafygreen-ui/lib';
 import { SVGR } from './types';
 import { createIconComponent, glyphs } from '.';
 import createGlyphComponent, { getGlyphTitle } from './createGlyphComponent';
+import EditIcon from '@leafygreen-ui/icon/dist/Edit';
 
 afterAll(cleanup);
 
@@ -146,5 +147,11 @@ describe('packages/Icon/createIconComponent', () => {
 
     expect(glyph.nodeName.toLowerCase()).toBe('div');
     expect(glyph.textContent).toBe(text);
+  });
+});
+
+describe('Generated icons', () => {
+  test('Edit icon has displayName: "Edit"', () => {
+    expect(EditIcon.displayName).toBe('Edit');
   });
 });

--- a/packages/icon/src/template.ts
+++ b/packages/icon/src/template.ts
@@ -93,7 +93,7 @@ module.exports = function template(
       return ${jsx};
     }
 
-    ${componentName}.displayName = ${componentName};
+    ${componentName}.displayName = '${componentName}';
 
     ${componentName}.propTypes = {
         fill: PropTypes.string,


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Changes the generated icon code from:
```Edit.displayName = Edit;```
to
```Edit.displayName = 'Edit';```

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
This could technically be a breaking change, but I doubt anyone would be depending on the previous behavior.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
