### PR TITLE
PD-680: Wrap Banner children in div tags rather than span tags

### DIFF
--- a/.changeset/wicked-socks-camp.md
+++ b/.changeset/wicked-socks-camp.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/banner': major
+---
+
+Changes innerHTML of Banner component such that children are wrapped with `div` tags rather than `span` tags

--- a/packages/banner/src/Banner.tsx
+++ b/packages/banner/src/Banner.tsx
@@ -259,9 +259,7 @@ export default function Banner({
       {...rest}
     >
       {renderIcon}
-      <span className={getTextStyle(image != null, dismissible)}>
-        {children}
-      </span>
+      <div className={getTextStyle(image != null, dismissible)}>{children}</div>
       {dismissible && (
         <XIcon
           fill={color}


### PR DESCRIPTION
## ✍️ Proposed changes

PD-680: Wrap Banner children in div tags rather than span tags

🎟 _Jira ticket:_ [PD-680](https://jira.mongodb.org/browse/PD-680)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes
