### PR TITLE
PD-616: Adds closeOnBackdropClick prop

### DIFF
--- a/.changeset/many-cougars-wait.md
+++ b/.changeset/many-cougars-wait.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/modal': minor
+---
+
+Adds `closeOnBackdropClick` prop to handle Modal closing when the backdrop is clicked

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -70,14 +70,15 @@ function ExampleComponent() {
 
 ## Properties
 
-| Prop               | Type                        | Description                                                                                                                                 | Default      |
-| ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `open`             | `boolean`                   | Determines open state of `Modal` component                                                                                                  | `false`      |
-| `setOpen`          | `function`                  | Callback to set open state of Modal component. `setOpen` accepts a boolean value, which will determine the open state of `Modal` component. | `() => {}`   |
-| `size`             | `small`, `default`, `large` | Determines `Modal` size.                                                                                                                    | `default`    |
-| `shouldClose`      | `function`                  | Callback to determine whether or not Modal should close when user tries to close it.                                                        | `() => true` |
-| `children`         | `node`                      | Children that will be rendered inside `<Modal />` component.                                                                                |              |
-| `className`        | `string`                    | Style to be applied to the container's root node.                                                                                           |              |
-| `contentClassName` | `string`                    | Style to be applied to the content div.                                                                                                     |              |
+| Prop                   | Type                        | Description                                                                                                                                 | Default      |
+| ---------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `open`                 | `boolean`                   | Determines open state of `Modal` component                                                                                                  | `false`      |
+| `setOpen`              | `function`                  | Callback to set open state of Modal component. `setOpen` accepts a boolean value, which will determine the open state of `Modal` component. | `() => {}`   |
+| `size`                 | `small`, `default`, `large` | Determines `Modal` size.                                                                                                                    | `default`    |
+| `shouldClose`          | `function`                  | Callback to determine whether or not Modal should close when user tries to close it.                                                        | `() => true` |
+| `children`             | `node`                      | Children that will be rendered inside `<Modal />` component.                                                                                |              |
+| `className`            | `string`                    | Style to be applied to the container's root node.                                                                                           |              |
+| `contentClassName`     | `string`                    | Style to be applied to the content div.                                                                                                     |              |
+| `closeOnBackdropClick` | `boolean`                   | Determines whether or not a Modal should close when a user clicks outside the modal.                                                        | `true`       |
 
 _Any other properties will be spread on the overlay container's root node._

--- a/packages/modal/src/Modal.spec.tsx
+++ b/packages/modal/src/Modal.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Modal from './Modal';
 
@@ -57,6 +57,12 @@ describe('packages/modal', () => {
 
       window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       expect(container.innerHTML).toBe('');
+    });
+
+    test('when "closeOnBackdropClick" is false', () => {
+      renderModal({ closeOnBackdropClick: false, open: true });
+      window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(screen.getByText(modalContent)).toBeInTheDocument();
     });
   });
 

--- a/packages/modal/src/Modal.spec.tsx
+++ b/packages/modal/src/Modal.spec.tsx
@@ -62,7 +62,7 @@ describe('packages/modal', () => {
     test('when "closeOnBackdropClick" is false', () => {
       renderModal({ closeOnBackdropClick: false, open: true });
       window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      expect(screen.getByText(modalContent)).toBeInTheDocument();
+      expect(screen.getByTestId('modal-test-id')).toBeInTheDocument();
     });
     test('when the "closeOnBackdropClick" is true', () => {
       const { container } = renderModal({

--- a/packages/modal/src/Modal.spec.tsx
+++ b/packages/modal/src/Modal.spec.tsx
@@ -64,6 +64,14 @@ describe('packages/modal', () => {
       window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       expect(screen.getByText(modalContent)).toBeInTheDocument();
     });
+    test('when the "closeOnBackdropClick" is true', () => {
+      const { container } = renderModal({
+        closeOnBackdropClick: true,
+        open: true,
+      });
+      window.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(container.innerHTML).toBe('');
+    });
   });
 
   describe('when "open" prop is false', () => {

--- a/packages/modal/src/Modal.story.tsx
+++ b/packages/modal/src/Modal.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { select } from '@storybook/addon-knobs';
+import { select, boolean } from '@storybook/addon-knobs';
 import { css } from '@leafygreen-ui/emotion';
 import Modal, { ModalSize } from '.';
 
@@ -18,6 +18,7 @@ function Default() {
         open={open}
         setOpen={setOpen}
         size={select('size', Object.values(ModalSize), ModalSize.Default)}
+        closeOnBackdropClick={boolean('closeOnBackdropClick', true)}
       >
         Modal Content goes here.
       </Modal>

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -106,8 +106,7 @@ interface ModalProps {
 
   /**
    * Determines the open state of the modal
-   *
-   * default: `false`
+   * @default: `false`
    */
   open?: boolean;
 
@@ -129,6 +128,12 @@ interface ModalProps {
    *
    */
   shouldClose?: () => boolean;
+
+  /**
+   * Determines whether or not a Modal should close when a user clicks outside the modal.
+   * @default: `true`
+   */
+  closeOnBackdropClick?: boolean;
 
   /**
    * className applied to root div.
@@ -164,7 +169,7 @@ interface ModalProps {
  * @param props.shouldClose Callback to determine whether or not Modal should close when user tries to close it.
  * @param props.className className applied to container div.
  * @param props.contentClassName className applied to overlay div.
- *
+ * @param props.closeOnBackdropClick Determines whether or not a Modal should close when a user clicks outside the modal.
  *
  */
 function Modal({
@@ -172,6 +177,7 @@ function Modal({
   size = ModalSize.Default,
   setOpen = () => {},
   shouldClose = () => true,
+  closeOnBackdropClick = true,
   children,
   className,
   contentClassName,
@@ -187,7 +193,7 @@ function Modal({
   }, [setOpen, shouldClose]);
 
   const handleBackdropClick = (e: React.SyntheticEvent) => {
-    if (scrollContainerRef.current && e.target === scrollContainerRef.current) {
+    if (closeOnBackdropClick && e.target === scrollContainerRef?.current) {
       handleClose();
     }
   };


### PR DESCRIPTION
## ✍️ Proposed changes

- Addresses: Cannot prevent closing modal when clicking backdrop by adding `closeOnBackdropClick` prop

🎟 _Jira ticket:_ [PD-616](https://jira.mongodb.org/browse/PD-616)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes
