### PR TITLE
PD-701 Add onLogput prop to OnPremUserMenu

### DIFF
--- a/.changeset/eight-spiders-unite.md
+++ b/.changeset/eight-spiders-unite.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Adds `onLogout` prop to `OnPremUserMenu`.

--- a/packages/mongo-nav/src/helpers/OnPremUserMenu.tsx
+++ b/packages/mongo-nav/src/helpers/OnPremUserMenu.tsx
@@ -28,10 +28,10 @@ interface OnPremUserMenuProps {
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 
   /**
-   * Object that supplies URL overrides to UserMenu component.
-   * Shape: { userMenu:{ cloud: { userPreferences, organizations, invitations, mfa }, university: { universityPreferences }, support: { userPreferences }, account: { homepage } }}
+   * Object that supplies URL overrides to OnPremUserMenu component.
+   * Shape: { onPrem: { profile, mfa, personalization, invitations, organizations, publicApiAccess, featureRequest }}
    */
-  urls: URLSInterface;
+  urls: Pick<Required<URLSInterface>, 'onPrem'>;
 
   /**
    * Whether or not multifactor authentication is permitted in the current enivronment.

--- a/packages/mongo-nav/src/helpers/OnPremUserMenu.tsx
+++ b/packages/mongo-nav/src/helpers/OnPremUserMenu.tsx
@@ -31,7 +31,7 @@ interface OnPremUserMenuProps {
    * Object that supplies URL overrides to UserMenu component.
    * Shape: { userMenu:{ cloud: { userPreferences, organizations, invitations, mfa }, university: { universityPreferences }, support: { userPreferences }, account: { homepage } }}
    */
-  urls: Required<URLSInterface>;
+  urls: URLSInterface;
 
   /**
    * Whether or not multifactor authentication is permitted in the current enivronment.
@@ -42,6 +42,11 @@ interface OnPremUserMenuProps {
    * Determines what nav item is currently active.
    */
   activeNav?: NavElement;
+
+  /**
+   * Callback invoked after the user clicks log out.
+   */
+  onLogout?: React.MouseEventHandler;
 }
 
 /**
@@ -57,6 +62,7 @@ interface OnPremUserMenuProps {
   urls={urls}
   mfa={false}
   activeNav={UserMenuOnPremProfile}
+  onLogout={onLogout}
 />
 ```
  * @param props.name The current user's first and last name, or username if unavailable.
@@ -65,6 +71,7 @@ interface OnPremUserMenuProps {
  * @param props.urls Object that supplies URL overrides to UserMenu component.
  * @param props.mfa Whether or not multifactor authentication is permitted in the current enivronment.
  * @param props.activeNav Determines what nav item is currently active.
+ * @param props.onLogout Callback fired when a user logs out.
  */
 export default function OnPremUserMenu({
   name,
@@ -73,8 +80,17 @@ export default function OnPremUserMenu({
   urls,
   mfa,
   activeNav,
+  onLogout: onLogoutProp,
 }: OnPremUserMenuProps) {
   const onElementClick = useOnElementClick();
+
+  const onLogout = (e: React.MouseEvent) => {
+    if (onLogoutProp) {
+      return onLogoutProp(e);
+    } else {
+      return onElementClick(NavElement.Logout)(e);
+    }
+  };
 
   return (
     <div className={onPremMenuWrapper}>
@@ -151,7 +167,7 @@ export default function OnPremUserMenu({
         </MenuItem>
 
         <MenuItem
-          onClick={onElementClick(NavElement.Logout, () => setOpen(false))}
+          onClick={onLogout}
           data-testid="om-user-menuitem-sign-out"
         >
           Log out

--- a/packages/mongo-nav/src/helpers/OnPremUserMenu.tsx
+++ b/packages/mongo-nav/src/helpers/OnPremUserMenu.tsx
@@ -166,10 +166,7 @@ export default function OnPremUserMenu({
           Feature Request
         </MenuItem>
 
-        <MenuItem
-          onClick={onLogout}
-          data-testid="om-user-menuitem-sign-out"
-        >
+        <MenuItem onClick={onLogout} data-testid="om-user-menuitem-sign-out">
           Log out
         </MenuItem>
       </Menu>


### PR DESCRIPTION
Description: `OnPremUserMenu` that is exported currently, does not support `Logout` functionality. As a result, when it's consumed inside the external component, click on the Logout does not do anything. `UserMenu` does support `onLogout` prop which can be used to provide overrides for `Logout` click. This PR replicates the same functionality of `onLogout` prop to `OnPremUserMenu`. 

In addition to that, the type definition for `urls` in `OnPremUserMenu` has `Required<URLSInterface` which actually expects all the properties of `URLSInterface` to be there in `urls` prop that is supplied. For `OnPremUserMenu` the `urls` would just only have `onPrem` property from `URLSInterface`. This PR fixes that typescript definition as well. 

## ✍️ Proposed changes

🎟 _Jira ticket:_ [Logout functionality is missing from OnPremUserMenu](https://jira.mongodb.org/browse/PD-701)

## 🛠 Types of changes

- [ ] Tooling (updates to workspace config or internal tooling)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] I have run `yarn changeset` and documented my changes
