### PR TITLE
PD-698: Change behavior of Access Manager dropdown in MongoNav

### DIFF
--- a/.changeset/tough-countries-remain.md
+++ b/.changeset/tough-countries-remain.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': major
+---
+
+Removes `href` from Access Manager in OrgNav, and now is used as as a button to control the Access Manager dropdown menu. In order to make this change, the OrgNavAccessManager and OrgNavDropdown NavElement types have been combined to OrgNavAccessManagerDropdown.

--- a/packages/mongo-nav/README.md
+++ b/packages/mongo-nav/README.md
@@ -84,7 +84,7 @@ _Any other properties will be spread on the root element_
 
 #### Org Nav Elements
 
-`OrgNavAccessManager`
+`OrgNavAccessManagerDropdown`
 `OrgNavAdmin`
 `OrgNavAllClusters`
 `OrgNavBilling`

--- a/packages/mongo-nav/src/MongoNav.spec.tsx
+++ b/packages/mongo-nav/src/MongoNav.spec.tsx
@@ -97,7 +97,6 @@ describe('packages/mongo-nav', () => {
     });
 
     test('current orgId is set based on data returned from fetch', () => {
-      console.log(expectedElements.billing);
       expect((expectedElements.billing as HTMLAnchorElement).href).toBe(
         `https://cloud.mongodb.com/v2#/org/${
           dataFixtures!.currentOrganization?.orgId

--- a/packages/mongo-nav/src/helpers/OrgNavLink.tsx
+++ b/packages/mongo-nav/src/helpers/OrgNavLink.tsx
@@ -30,7 +30,7 @@ const linkText = css`
       transform: scale(0.8, 1);
       transition: 150ms ease-in-out;
       height: 3px;
-      border-radius: 50px;
+      border-radius: 200px;
     }
   }
 
@@ -46,12 +46,6 @@ const linkText = css`
 const activeLink = css`
   font-weight: bold;
   color: ${uiColors.green.base};
-
-  &:hover {
-    span:after {
-      background-color: ${uiColors.green.light2};
-    }
-  }
 `;
 
 const navItemFocusStyle = css`
@@ -76,6 +70,7 @@ const displayFlex = css`
 const resetButtonStyles = css`
   border: none;
   background-color: transparent;
+  cursor: pointer;
 
   &:focus {
     outline: none;

--- a/packages/mongo-nav/src/helpers/OrgNavLink.tsx
+++ b/packages/mongo-nav/src/helpers/OrgNavLink.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
-import { HTMLElementProps } from '@leafygreen-ui/lib';
 import { useUsingKeyboardContext } from '@leafygreen-ui/leafygreen-provider';
 import { textLoadingStyle, anchorOverrides } from '../styles';
 
@@ -68,12 +67,29 @@ const navItemFocusStyle = css`
   }
 `;
 
-interface OrgNavLinkProps extends HTMLElementProps<'a'> {
+const displayFlex = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const resetButtonStyles = css`
+  border: none;
+  background-color: transparent;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+interface OrgNavLinkProps {
   isActive?: boolean;
   href?: string;
   children?: React.ReactNode;
   className?: string;
   loading?: boolean;
+  withIcon?: boolean;
+  onClick?: React.MouseEventHandler;
 }
 
 function OrgNavLink({
@@ -82,15 +98,19 @@ function OrgNavLink({
   href,
   children,
   className,
+  withIcon,
   ...rest
 }: OrgNavLinkProps) {
   const { usingKeyboard: showFocus } = useUsingKeyboardContext();
 
+  const Component = href ? 'a' : 'button';
+
   return (
-    <a
+    <Component
       href={href}
       aria-disabled={loading}
       className={cx(
+        resetButtonStyles,
         anchorOverrides,
         orgNavAnchorOverrides,
         linkText,
@@ -108,11 +128,14 @@ function OrgNavLink({
           css`
             position: relative;
           `,
+          {
+            [displayFlex]: withIcon,
+          },
         )}
       >
         {children}
       </span>
-    </a>
+    </Component>
   );
 }
 

--- a/packages/mongo-nav/src/helpers/OrgNavLink.tsx
+++ b/packages/mongo-nav/src/helpers/OrgNavLink.tsx
@@ -88,7 +88,7 @@ interface OrgNavLinkProps {
   children?: React.ReactNode;
   className?: string;
   loading?: boolean;
-  isAccessManager?: boolean;
+  isButton?: boolean;
   onClick?: React.MouseEventHandler;
 }
 
@@ -98,12 +98,12 @@ function OrgNavLink({
   href,
   children,
   className,
-  isAccessManager,
+  isButton,
   ...rest
 }: OrgNavLinkProps) {
   const { usingKeyboard: showFocus } = useUsingKeyboardContext();
 
-  const Component = isAccessManager ? 'button' : 'a';
+  const Component = isButton ? 'button' : 'a';
 
   return (
     <Component
@@ -129,7 +129,7 @@ function OrgNavLink({
             position: relative;
           `,
           {
-            [displayFlex]: isAccessManager,
+            [displayFlex]: isButton,
           },
         )}
       >

--- a/packages/mongo-nav/src/helpers/OrgNavLink.tsx
+++ b/packages/mongo-nav/src/helpers/OrgNavLink.tsx
@@ -88,7 +88,7 @@ interface OrgNavLinkProps {
   children?: React.ReactNode;
   className?: string;
   loading?: boolean;
-  withIcon?: boolean;
+  isAccessManager?: boolean;
   onClick?: React.MouseEventHandler;
 }
 
@@ -98,12 +98,12 @@ function OrgNavLink({
   href,
   children,
   className,
-  withIcon,
+  isAccessManager,
   ...rest
 }: OrgNavLinkProps) {
   const { usingKeyboard: showFocus } = useUsingKeyboardContext();
 
-  const Component = withIcon ? 'a' : 'button';
+  const Component = isAccessManager ? 'button' : 'a';
 
   return (
     <Component
@@ -129,7 +129,7 @@ function OrgNavLink({
             position: relative;
           `,
           {
-            [displayFlex]: withIcon,
+            [displayFlex]: isAccessManager,
           },
         )}
       >

--- a/packages/mongo-nav/src/on-element-click-provider/OnElementClick.spec.tsx
+++ b/packages/mongo-nav/src/on-element-click-provider/OnElementClick.spec.tsx
@@ -7,7 +7,6 @@ const defaultElements = {
   [NavElement.OrgNavLeaf]: 'org-nav-leaf',
   [NavElement.OrgNavOrgSettings]: 'org-trigger-settings',
   [NavElement.OrgNavAccessManager]: 'org-nav-access-manager',
-  // [NavElement.OrgNavDropdown]: 'org-nav-dropdown',
   [NavElement.OrgNavSupport]: 'org-nav-support',
   [NavElement.OrgNavBilling]: 'org-nav-billing',
   [NavElement.OrgNavAllClusters]: 'org-nav-all-clusters-link',

--- a/packages/mongo-nav/src/on-element-click-provider/OnElementClick.spec.tsx
+++ b/packages/mongo-nav/src/on-element-click-provider/OnElementClick.spec.tsx
@@ -6,7 +6,7 @@ import { NavElement } from '../types';
 const defaultElements = {
   [NavElement.OrgNavLeaf]: 'org-nav-leaf',
   [NavElement.OrgNavOrgSettings]: 'org-trigger-settings',
-  [NavElement.OrgNavAccessManager]: 'org-nav-access-manager',
+  [NavElement.OrgNavAccessManagerDropdown]: 'org-nav-access-manager-dropdown',
   [NavElement.OrgNavSupport]: 'org-nav-support',
   [NavElement.OrgNavBilling]: 'org-nav-billing',
   [NavElement.OrgNavAllClusters]: 'org-nav-all-clusters-link',
@@ -64,13 +64,13 @@ describe('packages/mongo-nav/on-element-click-provider', () => {
     testForCallback(
       NavElement.OrgNavDropdownOrgAccessManager,
       'org-nav-dropdown-org-access-manager',
-      'org-nav-access-manager',
+      'org-nav-access-manager-dropdown',
     );
 
     testForCallback(
       NavElement.OrgNavDropdownProjectAccessManager,
       'org-nav-dropdown-project-access-manager',
-      'org-nav-access-manager',
+      'org-nav-access-manager-dropdown',
     );
   });
 

--- a/packages/mongo-nav/src/on-element-click-provider/OnElementClick.spec.tsx
+++ b/packages/mongo-nav/src/on-element-click-provider/OnElementClick.spec.tsx
@@ -8,7 +8,7 @@ const defaultElements = {
   [NavElement.OrgNavLeaf]: 'org-nav-leaf',
   [NavElement.OrgNavOrgSettings]: 'org-trigger-settings',
   [NavElement.OrgNavAccessManager]: 'org-nav-access-manager',
-  [NavElement.OrgNavDropdown]: 'org-nav-dropdown',
+  // [NavElement.OrgNavDropdown]: 'org-nav-dropdown',
   [NavElement.OrgNavSupport]: 'org-nav-support',
   [NavElement.OrgNavBilling]: 'org-nav-billing',
   [NavElement.OrgNavAllClusters]: 'org-nav-all-clusters-link',
@@ -66,13 +66,13 @@ describe('packages/mongo-nav/on-element-click-provider', () => {
     testForCallback(
       NavElement.OrgNavDropdownOrgAccessManager,
       'org-nav-dropdown-org-access-manager',
-      'org-nav-dropdown',
+      'org-nav-access-manager',
     );
 
     testForCallback(
       NavElement.OrgNavDropdownProjectAccessManager,
       'org-nav-dropdown-project-access-manager',
-      'org-nav-dropdown',
+      'org-nav-access-manager',
     );
   });
 

--- a/packages/mongo-nav/src/org-nav/OrgNav.spec.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.spec.tsx
@@ -47,7 +47,9 @@ describe('packages/mongo-nav/src/org-nav', () => {
   const setExpectedElements = () => {
     const { queryByTestId = () => null } = queries;
     expectedElements.paymentStatus = queryByTestId('org-nav-payment-status');
-    expectedElements.accessManager = queryByTestId('org-nav-access-manager');
+    expectedElements.accessManagerDropdown = queryByTestId(
+      'org-nav-access-manager-dropdown',
+    );
     expectedElements.accessManagerOrg = queryByTestId(
       'org-nav-dropdown-org-access-manager',
     );
@@ -249,7 +251,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
     );
 
     it('shows project access as disabled', () => {
-      fireEvent.click(expectedElements.accessManager!);
+      fireEvent.click(expectedElements.accessManagerDropdown!);
       setExpectedElements();
 
       expect(expectedElements.accessManagerProject).toBeInTheDocument();
@@ -345,7 +347,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
           currentProjectName: 'Test Project',
           currentProjectId: 'test-project-id',
         });
-        fireEvent.click(expectedElements.accessManager as HTMLElement);
+        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
         setExpectedElements();
 
         expect(
@@ -363,7 +365,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
           onPremEnabled: true,
           showProjectNav: false,
         });
-        fireEvent.click(expectedElements.accessManager as HTMLElement);
+        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
         setExpectedElements();
 
         expect(
@@ -382,7 +384,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
           currentProjectName: 'Test Project',
           currentProjectId: 'test-project-id',
         });
-        fireEvent.click(expectedElements.accessManager as HTMLElement);
+        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
         setExpectedElements();
 
         expect(
@@ -399,7 +401,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
         renderComponent({
           showProjectNav: false,
         });
-        fireEvent.click(expectedElements.accessManager as HTMLElement);
+        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
         setExpectedElements();
 
         expect(

--- a/packages/mongo-nav/src/org-nav/OrgNav.spec.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.spec.tsx
@@ -24,13 +24,12 @@ interface LinkNameToUrls {
 // data
 const { account, currentOrganization, organizations } = dataFixtures;
 const {
-  orgNav: { accessManager, support, billing, allClusters, admin },
+  orgNav: { support, billing, allClusters, admin },
 } = urlFixtures;
 
 // this avoids having to explicitly type orgNav with nullable fields
 // and then extend it to allow string indexes
 const linkNamesToUrls: LinkNameToUrls = {
-  accessManager,
   support,
   billing,
   allClusters,
@@ -50,7 +49,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
     const { queryByTestId = () => null } = queries;
     expectedElements.paymentStatus = queryByTestId('org-nav-payment-status');
     expectedElements.accessManager = queryByTestId('org-nav-access-manager');
-    expectedElements.accessManagerDropdown = queryByTestId('org-nav-dropdown');
+    // expectedElements.accessManagerDropdown = queryByTestId('org-nav-dropdown');
     expectedElements.accessManagerOrg = queryByTestId(
       'org-nav-dropdown-org-access-manager',
     );
@@ -252,7 +251,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
     );
 
     it('shows project access as disabled', () => {
-      fireEvent.click(expectedElements.accessManagerDropdown!);
+      fireEvent.click(expectedElements.accessManager!);
       setExpectedElements();
 
       expect(expectedElements.accessManagerProject).toBeInTheDocument();
@@ -348,7 +347,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
           currentProjectName: 'Test Project',
           currentProjectId: 'test-project-id',
         });
-        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
+        fireEvent.click(expectedElements.accessManager as HTMLElement);
         setExpectedElements();
 
         expect(
@@ -366,7 +365,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
           onPremEnabled: true,
           showProjectNav: false,
         });
-        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
+        fireEvent.click(expectedElements.accessManager as HTMLElement);
         setExpectedElements();
 
         expect(
@@ -385,7 +384,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
           currentProjectName: 'Test Project',
           currentProjectId: 'test-project-id',
         });
-        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
+        fireEvent.click(expectedElements.accessManager as HTMLElement);
         setExpectedElements();
 
         expect(
@@ -402,7 +401,7 @@ describe('packages/mongo-nav/src/org-nav', () => {
         renderComponent({
           showProjectNav: false,
         });
-        fireEvent.click(expectedElements.accessManagerDropdown as HTMLElement);
+        fireEvent.click(expectedElements.accessManager as HTMLElement);
         setExpectedElements();
 
         expect(

--- a/packages/mongo-nav/src/org-nav/OrgNav.spec.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.spec.tsx
@@ -48,7 +48,6 @@ describe('packages/mongo-nav/src/org-nav', () => {
     const { queryByTestId = () => null } = queries;
     expectedElements.paymentStatus = queryByTestId('org-nav-payment-status');
     expectedElements.accessManager = queryByTestId('org-nav-access-manager');
-    // expectedElements.accessManagerDropdown = queryByTestId('org-nav-dropdown');
     expectedElements.accessManagerOrg = queryByTestId(
       'org-nav-dropdown-org-access-manager',
     );

--- a/packages/mongo-nav/src/org-nav/OrgNav.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.tsx
@@ -287,7 +287,7 @@ function OrgNav({
             onClick={onElementClick(NavElement.OrgNavAccessManager, () =>
               setAccessManagerOpen(curr => !curr),
             )}
-            withIcon={true}
+            isAccessManager={true}
           >
             Access Manager
             <AccessManagerIcon

--- a/packages/mongo-nav/src/org-nav/OrgNav.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.tsx
@@ -233,6 +233,8 @@ function OrgNav({
     );
   }
 
+  const AccessManagerIcon = accessManagerOpen ? CaretUpIcon : CaretDownIcon;
+
   return (
     <nav
       className={navContainer}
@@ -280,26 +282,19 @@ function OrgNav({
       {!disabled && !isMobile && (
         <>
           <OrgNavLink
-            href={current && orgNav.accessManager}
             isActive={activeNav === ActiveNavElement.OrgNavAccessManager}
             loading={!current}
             data-testid="org-nav-access-manager"
-            onClick={onElementClick(NavElement.OrgNavAccessManager)}
-          >
-            Access Manager
-          </OrgNavLink>
-
-          <IconButton
-            aria-label="Dropdown"
-            active={accessManagerOpen}
-            disabled={!current}
-            data-testid="org-nav-dropdown"
-            onClick={onElementClick(NavElement.OrgNavDropdown, () =>
+            onClick={onElementClick(NavElement.OrgNavAccessManager, () =>
               setAccessManagerOpen(curr => !curr),
             )}
           >
-            {accessManagerOpen ? <CaretUpIcon /> : <CaretDownIcon />}
-
+            Access Manager
+            <AccessManagerIcon
+              className={css`
+                margin-left: 8px;
+              `}
+            />
             {current && (
               <Menu
                 open={accessManagerOpen}
@@ -341,7 +336,7 @@ function OrgNav({
                 </MenuItem>
               </Menu>
             )}
-          </IconButton>
+          </OrgNavLink>
 
           <OrgNavLink
             href={current && orgNav.support}

--- a/packages/mongo-nav/src/org-nav/OrgNav.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.tsx
@@ -281,13 +281,16 @@ function OrgNav({
       {!disabled && !isMobile && (
         <>
           <OrgNavLink
-            isActive={activeNav === ActiveNavElement.OrgNavAccessManager}
+            isActive={
+              activeNav === ActiveNavElement.OrgNavAccessManagerDropdown
+            }
             loading={!current}
-            data-testid="org-nav-access-manager"
-            onClick={onElementClick(NavElement.OrgNavAccessManager, () =>
-              setAccessManagerOpen(curr => !curr),
+            data-testid="org-nav-access-manager-dropdown"
+            onClick={onElementClick(
+              NavElement.OrgNavAccessManagerDropdown,
+              () => setAccessManagerOpen(curr => !curr),
             )}
-            isAccessManager={true}
+            isButton={true}
           >
             Access Manager
             <AccessManagerIcon
@@ -313,7 +316,9 @@ function OrgNav({
                   data-testid="org-nav-dropdown-org-access-manager"
                   description={current.orgName}
                   size="large"
-                  active={activeNav === ActiveNavElement.OrgNavAccessManager}
+                  active={
+                    activeNav === ActiveNavElement.OrgNavAccessManagerDropdown
+                  }
                   onClick={onElementClick(
                     NavElement.OrgNavDropdownOrgAccessManager,
                     () => setAccessManagerOpen(false),

--- a/packages/mongo-nav/src/org-nav/OrgNav.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@leafygreen-ui/tooltip';
 import Badge, { Variant } from '@leafygreen-ui/badge';
-import IconButton from '@leafygreen-ui/icon-button';
 import CaretUpIcon from '@leafygreen-ui/icon/dist/CaretUp';
 import CaretDownIcon from '@leafygreen-ui/icon/dist/CaretDown';
 import UserMenu from '../user-menu';
@@ -288,12 +287,20 @@ function OrgNav({
             onClick={onElementClick(NavElement.OrgNavAccessManager, () =>
               setAccessManagerOpen(curr => !curr),
             )}
+            withIcon={true}
           >
             Access Manager
             <AccessManagerIcon
-              className={css`
-                margin-left: 8px;
-              `}
+              className={cx(
+                css`
+                  margin-left: 8px;
+                `,
+                {
+                  [css`
+                    color: ${uiColors.gray.dark1};
+                  `]: !accessManagerOpen,
+                },
+              )}
             />
             {current && (
               <Menu

--- a/packages/mongo-nav/src/types.ts
+++ b/packages/mongo-nav/src/types.ts
@@ -12,7 +12,6 @@ const NavElement = {
   OrgNavOrgSelectTrigger: 'orgNavOrgSelectTrigger',
   OrgNavOrgSelectSearch: 'orgNavOrgSelectSearch',
   OrgNavViewAllOrganizations: 'orgNavViewAllOrganizations',
-  // OrgNavDropdown: 'orgNavDropdown',
   OrgNavDropdownOrgAccessManager: 'orgNavDropdownOrgAccessManager',
   OrgNavDropdownProjectAccessManager: 'orgNavDropdownProjectAccessManager',
   ProjectNavProjectSelectTrigger: 'projectNavProjectSelectTrigger',

--- a/packages/mongo-nav/src/types.ts
+++ b/packages/mongo-nav/src/types.ts
@@ -12,7 +12,7 @@ const NavElement = {
   OrgNavOrgSelectTrigger: 'orgNavOrgSelectTrigger',
   OrgNavOrgSelectSearch: 'orgNavOrgSelectSearch',
   OrgNavViewAllOrganizations: 'orgNavViewAllOrganizations',
-  OrgNavDropdown: 'orgNavDropdown',
+  // OrgNavDropdown: 'orgNavDropdown',
   OrgNavDropdownOrgAccessManager: 'orgNavDropdownOrgAccessManager',
   OrgNavDropdownProjectAccessManager: 'orgNavDropdownProjectAccessManager',
   ProjectNavProjectSelectTrigger: 'projectNavProjectSelectTrigger',

--- a/packages/mongo-nav/src/types.ts
+++ b/packages/mongo-nav/src/types.ts
@@ -2,7 +2,7 @@ import { RecursivePartial } from '@leafygreen-ui/lib';
 
 const NavElement = {
   OrgNavOrgSettings: 'orgNavOrgSettings',
-  OrgNavAccessManager: 'orgNavAccessManager',
+  OrgNavAccessManagerDropdown: 'orgNavAccessManagerDropdown',
   OrgNavSupport: 'orgNavSupport',
   OrgNavBilling: 'orgNavBilling',
   OrgNavAdmin: 'orgNavAdmin',
@@ -52,7 +52,7 @@ export { NavElement };
 
 const ActiveNavElement = {
   OrgNavOrgSettings: NavElement.OrgNavOrgSettings,
-  OrgNavAccessManager: NavElement.OrgNavAccessManager,
+  OrgNavAccessManagerDropdown: NavElement.OrgNavAccessManagerDropdown,
   OrgNavSupport: NavElement.OrgNavSupport,
   OrgNavBilling: NavElement.OrgNavBilling,
   OrgNavAdmin: NavElement.OrgNavAdmin,


### PR DESCRIPTION
## ✍️ Proposed changes

- Removes href from Access Manager in OrgNav, and instead clicking Access Manager triggers the dropdown
- Removes IconButton wrapping around Access Manager dropdown

cc: @nellem23 

🎟 _Jira ticket:_ [PD-698](https://jira.mongodb.org/browse/PD-698)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

![Screen Shot 2020-06-23 at 10 55 50 AM](https://user-images.githubusercontent.com/26016393/85419514-2e725280-b540-11ea-9c99-5c2927b59883.png)
![Screen Shot 2020-06-23 at 10 55 54 AM](https://user-images.githubusercontent.com/26016393/85419515-2e725280-b540-11ea-958a-b0154f5046a6.png)
![Screen Shot 2020-06-23 at 10 55 56 AM](https://user-images.githubusercontent.com/26016393/85419516-2f0ae900-b540-11ea-862e-5f8cb4cb13bb.png)
