### PR TITLE
PD-741: SSR fixes, TypeScript <3.8 compatibility fix

### DIFF
--- a/.changeset/four-timers-smile.md
+++ b/.changeset/four-timers-smile.md
@@ -2,6 +2,7 @@
 '@leafygreen-ui/popover': patch
 '@leafygreen-ui/portal': patch
 '@leafygreen-ui/tooltip': patch
+'@leafygreen-ui/lib': patch
 ---
 
 Restore TS <3.8 compatibility that was broken from using the `import type` syntax.

--- a/.changeset/four-timers-smile.md
+++ b/.changeset/four-timers-smile.md
@@ -1,0 +1,7 @@
+---
+'@leafygreen-ui/popover': patch
+'@leafygreen-ui/portal': patch
+'@leafygreen-ui/tooltip': patch
+---
+
+Restore TS <3.8 compatibility that was broken from using the `import type` syntax.

--- a/.changeset/hungry-bananas-promise.md
+++ b/.changeset/hungry-bananas-promise.md
@@ -1,0 +1,6 @@
+---
+'@leafygreen-ui/menu': patch
+'@leafygreen-ui/popover': patch
+---
+
+Remove usage of `Element` in Node target builds that was preventing rendering the component in SSR contexts.

--- a/packages/lib/src/index.spec.ts
+++ b/packages/lib/src/index.spec.ts
@@ -1,4 +1,4 @@
-import type { OneOf } from './index';
+import { OneOf } from './index';
 
 describe('packages/lib', () => {
   describe('OneOf', () => {

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -399,7 +399,10 @@ Menu.propTypes = {
   className: PropTypes.string,
   align: PropTypes.oneOf(Object.values(Align)),
   justify: PropTypes.oneOf(Object.values(Justify)),
-  refEl: PropTypes.shape({ current: __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any }),
+  refEl: PropTypes.shape({
+    current:
+      __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any,
+  }),
   usePortal: PropTypes.bool,
   trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   open: PropTypes.bool,

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -388,12 +388,18 @@ function Menu({
 
 Menu.displayName = 'Menu';
 
+// __TARGET__ is a global variable that indicates the webpack build target.
+//
+// We're typing this here because doing it globally was proving problematic.
+// We should solve for this if we need to use __TARGET__ elsewhere.
+declare const __TARGET__: 'web' | 'node';
+
 Menu.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   align: PropTypes.oneOf(Object.values(Align)),
   justify: PropTypes.oneOf(Object.values(Justify)),
-  refEl: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  refEl: PropTypes.shape({ current: __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any }),
   usePortal: PropTypes.bool,
   trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   open: PropTypes.bool,

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -242,6 +242,12 @@ const MenuItem: ExtendableBox<BaseMenuItemProps, 'button'> = React.forwardRef(
 // @ts-expect-error Property 'displayName' does not exist on type 'OverrideComponentCast<BaseMenuItemProps>'.
 MenuItem.displayName = 'MenuItem';
 
+// __TARGET__ is a global variable that indicates the webpack build target.
+//
+// We're typing this here because doing it globally was proving problematic.
+// We should solve for this if we need to use __TARGET__ elsewhere.
+declare const __TARGET__: 'web' | 'node';
+
 // @ts-expect-error: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37660
 MenuItem.propTypes = {
   href: PropTypes.string,
@@ -251,7 +257,7 @@ MenuItem.propTypes = {
   disabled: PropTypes.bool,
   active: PropTypes.bool,
   children: PropTypes.node,
-  ref: PropTypes.shape({ current: PropTypes.instanceOf(Element).isRequired }),
+  refEl: PropTypes.shape({ current: __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any }),
 };
 
 export default MenuItem;

--- a/packages/menu/src/MenuItem.tsx
+++ b/packages/menu/src/MenuItem.tsx
@@ -257,7 +257,10 @@ MenuItem.propTypes = {
   disabled: PropTypes.bool,
   active: PropTypes.bool,
   children: PropTypes.node,
-  refEl: PropTypes.shape({ current: __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any }),
+  refEl: PropTypes.shape({
+    current:
+      __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any,
+  }),
 };
 
 export default MenuItem;

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -244,13 +244,20 @@ function Popover({
 
 Popover.displayName = 'Popover';
 
+
+// __TARGET__ is a global variable that indicates the webpack build target.
+//
+// We're typing this here because doing it globally was proving problematic.
+// We should solve for this if we need to use __TARGET__ elsewhere.
+declare const __TARGET__: 'web' | 'node';
+
 Popover.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   active: PropTypes.bool,
   className: PropTypes.string,
   align: PropTypes.oneOf(Object.values(Align)),
   justify: PropTypes.oneOf(Object.values(Justify)),
-  refEl: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  refEl: PropTypes.shape({ current: __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any }),
   usePortal: PropTypes.bool,
   portalClassName: PropTypes.string,
   spacing: PropTypes.number,

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -244,7 +244,6 @@ function Popover({
 
 Popover.displayName = 'Popover';
 
-
 // __TARGET__ is a global variable that indicates the webpack build target.
 //
 // We're typing this here because doing it globally was proving problematic.
@@ -257,7 +256,10 @@ Popover.propTypes = {
   className: PropTypes.string,
   align: PropTypes.oneOf(Object.values(Align)),
   justify: PropTypes.oneOf(Object.values(Justify)),
-  refEl: PropTypes.shape({ current: __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any }),
+  refEl: PropTypes.shape({
+    current:
+      __TARGET__ === 'web' ? PropTypes.instanceOf(Element) : PropTypes.any,
+  }),
   usePortal: PropTypes.bool,
   portalClassName: PropTypes.string,
   spacing: PropTypes.number,

--- a/packages/popover/src/types.ts
+++ b/packages/popover/src/types.ts
@@ -1,4 +1,4 @@
-import type { OneOf } from '@leafygreen-ui/lib';
+import { OneOf } from '@leafygreen-ui/lib';
 import React from 'react';
 
 /**

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -1,4 +1,4 @@
-import type { OneOf } from '@leafygreen-ui/lib';
+import { OneOf } from '@leafygreen-ui/lib';
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { createPortal } from 'react-dom';

--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -1,4 +1,4 @@
-import type { OneOf } from '@leafygreen-ui/lib';
+import { OneOf } from '@leafygreen-ui/lib';
 import React, { useState, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Popover, {

--- a/scripts/jestSetup.js
+++ b/scripts/jestSetup.js
@@ -15,3 +15,5 @@ global.IntersectionObserver = class {
   unobserve() {}
   disconnect() {}
 };
+
+global.__TARGET__ = 'web'

--- a/scripts/jestSetup.js
+++ b/scripts/jestSetup.js
@@ -16,4 +16,4 @@ global.IntersectionObserver = class {
   disconnect() {}
 };
 
-global.__TARGET__ = 'web'
+global.__TARGET__ = 'web';


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/master/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Usages of Menu and Popover were breaking SSR contexts due to the usage of `Element`. within their PropTypes. This PR conditionally uses Element based on the build target, and otherwise uses `PropTypes.any`.

Additionally, this PR restores the compatibility of some components with TypeScript <3.8 by removing usages of the `import type` syntax introduced in 3.8.

🎟 _Jira ticket:_ [PD-741](https://jira.mongodb.org/browse/PD-741)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~
- [x] I have run `yarn changeset` and documented my changes
