### PR TITLE
Fix Types for UserMenu

### DIFF
--- a/.changeset/brown-frogs-film.md
+++ b/.changeset/brown-frogs-film.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Fix bug in UserMenu types, such that only component-specific types are required

--- a/packages/mongo-nav/src/types.ts
+++ b/packages/mongo-nav/src/types.ts
@@ -229,7 +229,7 @@ export interface OnPremInterface {
   enabled?: boolean;
 }
 
-interface UserMenuURLS {
+export interface UserMenuURLS {
   cloud?: {
     userPreferences: string;
     organizations: string;

--- a/packages/mongo-nav/src/user-menu/UserMenu.spec.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.spec.tsx
@@ -218,4 +218,33 @@ describe('packages/mongo-nav/user-menu', () => {
       expect(queryByText('Two-Factor Authentication')).not.toBeInTheDocument();
     });
   });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  describe.skip('the types behave as expected', () => {
+    // eslint-disable-next-line jest/expect-expect
+    test('does not error when all URLS are passed to urls prop ', () => {
+      <UserMenu urls={urlFixtures} />;
+    });
+    // eslint-disable-next-line jest/expect-expect
+    test('does not error when only userMenu object is passed to urls prop', () => {
+      <UserMenu
+        urls={{
+          userMenu: {
+            cloud: {
+              userPreferences: 'string',
+              invitations: 'string',
+              mfa: 'string',
+              organizations: 'string',
+            },
+            university: {
+              universityPreferences: 'string',
+            },
+            support: {
+              userPreferences: 'string',
+            },
+          },
+        }}
+      />;
+    });
+  });
 });

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -520,5 +520,3 @@ UserMenu.propTypes = {
 };
 
 export default UserMenu;
-
-console.log('shmooo');

--- a/packages/mongo-nav/src/user-menu/UserMenu.tsx
+++ b/packages/mongo-nav/src/user-menu/UserMenu.tsx
@@ -20,6 +20,7 @@ import {
   AccountInterface,
   ActiveNavElement,
   URLS,
+  UserMenuURLS,
   HostsInterface,
   NavElement,
   Platform,
@@ -185,7 +186,7 @@ interface UserMenuProps {
    * Object that supplies URL overrides to UserMenu component.
    * Shape: { userMenu:{ cloud: { userPreferences, organizations, invitations, mfa }, university: { universityPreferences }, support: { userPreferences }, account: { homepage } }}
    */
-  urls?: URLS;
+  urls?: URLS | { userMenu: UserMenuURLS };
 
   /**
    * Object that supplies host overrides to UserMenu component.
@@ -519,3 +520,5 @@ UserMenu.propTypes = {
 };
 
 export default UserMenu;
+
+console.log('shmooo');


### PR DESCRIPTION
UserMenu should accept the URLS as-is from OrgNav or simply an object of the relevant URLS to UserMenu when used independently of MongoNav.