### PR TITLE
PD-918: Fixes keyboard navigation bug in Tabs component

### DIFF
--- a/.changeset/big-llamas-exist.md
+++ b/.changeset/big-llamas-exist.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tabs': patch
+---
+
+Previously, if multiple `<Tabs />` were rendered, only the first on the page would be navigable via keyboard. Now, the currently focused `<Tabs />` will be navigable via keyboard, regardless of location on page.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@testing-library/jest-dom": "^5.4.0",
     "@testing-library/react": "^10.0.3",
     "@testing-library/react-hooks": "^3.2.1",
+    "@testing-library/user-event": "^12.1.8",
     "@types/facepaint": "^1.2.1",
     "@types/highlight.js": "^9.12.3",
     "@types/jest": "^26.0.0",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -23,7 +23,6 @@
     "@leafygreen-ui/lib": "^6.0.1",
     "@leafygreen-ui/palette": "^3.0.1",
     "@leafygreen-ui/tokens": "^0.5.0",
-    "@leafygreen-ui/hooks": "^5.0.1",
     "@leafygreen-ui/box": "^3.0.1",
     "@leafygreen-ui/leafygreen-provider": "^2.0.1",
     "lodash": "^4.17.20"

--- a/packages/tabs/src/Tabs.spec.tsx
+++ b/packages/tabs/src/Tabs.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { Tabs, Tab } from './index';
 
 const setSelected = jest.fn();

--- a/packages/tabs/src/Tabs.spec.tsx
+++ b/packages/tabs/src/Tabs.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Tabs, Tab } from './index';
 
 const setSelected = jest.fn();
@@ -148,6 +148,47 @@ describe('packages/tab', () => {
 
       const activeTab = getByText('Test Content 1');
       expect(activeTab).toBeVisible();
+    });
+  });
+
+  describe('when there are two sets of tabs on the page', () => {
+    beforeEach(() => {
+      render(
+        <>
+          <Tabs>
+            <Tab default name="Tab Set 1-A">
+              Content 1-A
+            </Tab>
+            <Tab name="Tab Set 1-B">Content 1-B</Tab>
+          </Tabs>
+          <Tabs>
+            <Tab default name="Tab Set 2-A">
+              Content 2-A
+            </Tab>
+            <Tab name="Tab Set 2-B">Content 2-B</Tab>
+          </Tabs>
+        </>,
+      );
+    });
+
+    test('only the current Tabs set is toggled when the arrow keys are pressed', () => {
+      const tabSet2A = screen.getByText('Tab Set 2-A');
+
+      const tabSet1AContent = screen.getByText('Content 1-A');
+      const tabSet2AContent = screen.getByText('Content 2-A');
+      expect(tabSet1AContent).toBeInTheDocument();
+      expect(tabSet2AContent).toBeInTheDocument();
+
+      tabSet2A.focus();
+
+      fireEvent.keyDown(tabSet2A, {
+        key: 'ArrowRight',
+        keyCode: 37,
+      });
+
+      expect(tabSet1AContent).toBeInTheDocument();
+      const tabSet2BContent = screen.getByText('Content 2-B');
+      expect(tabSet2BContent).toBeInTheDocument();
     });
   });
 });

--- a/packages/tabs/src/Tabs.spec.tsx
+++ b/packages/tabs/src/Tabs.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Tabs, Tab } from './index';
 
 const setSelected = jest.fn();
@@ -186,9 +187,7 @@ describe('packages/tab', () => {
         keyCode: 37,
       });
 
-      expect(tabSet1AContent).toBeInTheDocument();
-      const tabSet2BContent = screen.getByText('Content 2-B');
-      expect(tabSet2BContent).toBeInTheDocument();
+      expect(screen.getByText('Tab Set 2-B')).toHaveFocus();
     });
   });
 });

--- a/packages/tabs/src/Tabs.story.tsx
+++ b/packages/tabs/src/Tabs.story.tsx
@@ -59,6 +59,27 @@ storiesOf('Tabs', module)
             Hello 3
           </Tab>
         </Tabs>
+        <div>hi</div>
+        <Tabs
+          darkMode={darkMode}
+          className={css`
+            background-color: ${!darkMode ? 'white' : uiColors.gray.dark3};
+            padding: 20px;
+          `}
+        >
+          <Tab
+            default={boolean('default', true)}
+            name={text('name', 'Brooke Scarlett Yalof')}
+          >
+            {text('Tab Content', 'Hello 1')}
+          </Tab>
+          <Tab name="Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue">
+            Hello 2
+          </Tab>
+          <Tab disabled={boolean('disabled', true)} name="David Scott McCarthy">
+            Hello 3
+          </Tab>
+        </Tabs>
       </LeafyGreenProvider>
     );
   })

--- a/packages/tabs/src/Tabs.story.tsx
+++ b/packages/tabs/src/Tabs.story.tsx
@@ -59,6 +59,27 @@ storiesOf('Tabs', module)
             Hello 3
           </Tab>
         </Tabs>
+        <div>hi </div>
+        <Tabs
+          darkMode={darkMode}
+          className={css`
+            background-color: ${!darkMode ? 'white' : uiColors.gray.dark3};
+            padding: 20px;
+          `}
+        >
+          <Tab
+            default={boolean('default', true)}
+            name={text('name', 'Brooke Scarlett Yalof')}
+          >
+            {text('Tab Content', 'Hello 1')}
+          </Tab>
+          <Tab name="Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue">
+            Hello 2
+          </Tab>
+          <Tab disabled={boolean('disabled', true)} name="David Scott McCarthy">
+            Hello 3
+          </Tab>
+        </Tabs>
       </LeafyGreenProvider>
     );
   })

--- a/packages/tabs/src/Tabs.story.tsx
+++ b/packages/tabs/src/Tabs.story.tsx
@@ -59,27 +59,6 @@ storiesOf('Tabs', module)
             Hello 3
           </Tab>
         </Tabs>
-        <div>hi </div>
-        <Tabs
-          darkMode={darkMode}
-          className={css`
-            background-color: ${!darkMode ? 'white' : uiColors.gray.dark3};
-            padding: 20px;
-          `}
-        >
-          <Tab
-            default={boolean('default', true)}
-            name={text('name', 'Brooke Scarlett Yalof')}
-          >
-            {text('Tab Content', 'Hello 1')}
-          </Tab>
-          <Tab name="Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue Robert Arnold Audroue">
-            Hello 2
-          </Tab>
-          <Tab disabled={boolean('disabled', true)} name="David Scott McCarthy">
-            Hello 3
-          </Tab>
-        </Tabs>
       </LeafyGreenProvider>
     );
   })

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -150,9 +150,7 @@ function Tabs({
   };
 
   const handleArrowKeyPress = (e: KeyboardEvent) => {
-    const isFocusedTabs = tabsRef?.current?.contains(document.activeElement);
-
-    if (isFocusedTabs && !(e.metaKey || e.ctrlKey)) {
+    if (!(e.metaKey || e.ctrlKey)) {
       if (e.keyCode === keyMap.ArrowRight) {
         const [enabledIndexes, current] = getEnabledIndexes();
         setSelected(enabledIndexes[(current + 1) % enabledIndexes.length]);
@@ -166,8 +164,6 @@ function Tabs({
       }
     }
   };
-
-  useEventListener('keydown', handleArrowKeyPress);
 
   const tabs = React.Children.map(children, (child, index) => {
     if (!isComponentType<'Tab'>(child, 'Tab')) {
@@ -215,6 +211,7 @@ function Tabs({
                 [modeColors[mode].activeStyle]: selected,
                 [cx(modeColors[mode].disabledColor, disabledStyle)]: disabled,
               })}
+              onKeyDown={handleArrowKeyPress}
               onClick={
                 !disabled
                   ? (event: React.MouseEvent) => handleChange(event, index)

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { uiColors } from '@leafygreen-ui/palette';
 import { keyMap, isComponentType } from '@leafygreen-ui/lib';
-import { useEventListener } from '@leafygreen-ui/hooks';
 import TabTitle from './TabTitle';
 import omit from 'lodash/omit';
 

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -120,6 +120,7 @@ function Tabs({
   as = 'button',
   ...rest
 }: TabsProps) {
+  const tabsRef = React.useRef<HTMLDivElement>(null);
   const childrenArray = React.Children.toArray(children) as Array<
     React.ReactElement
   >;
@@ -149,7 +150,9 @@ function Tabs({
   };
 
   const handleArrowKeyPress = (e: KeyboardEvent) => {
-    if (!(e.metaKey || e.ctrlKey)) {
+    const isFocusedTabs = tabsRef?.current?.contains(document.activeElement);
+
+    if (isFocusedTabs && !(e.metaKey || e.ctrlKey)) {
       if (e.keyCode === keyMap.ArrowRight) {
         const [enabledIndexes, current] = getEnabledIndexes();
         setSelected(enabledIndexes[(current + 1) % enabledIndexes.length]);
@@ -183,6 +186,7 @@ function Tabs({
   return (
     <div {...rest} className={className}>
       <div
+        ref={tabsRef}
         className={cx(listStyle, modeColors[mode].underlineColor)}
         role="tablist"
         tabIndex={0}

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -120,7 +120,6 @@ function Tabs({
   as = 'button',
   ...rest
 }: TabsProps) {
-  const tabsRef = React.useRef<HTMLDivElement>(null);
   const childrenArray = React.Children.toArray(children) as Array<
     React.ReactElement
   >;
@@ -182,7 +181,6 @@ function Tabs({
   return (
     <div {...rest} className={className}>
       <div
-        ref={tabsRef}
         className={cx(listStyle, modeColors[mode].underlineColor)}
         role="tablist"
         tabIndex={0}

--- a/packages/tabs/tsconfig.json
+++ b/packages/tabs/tsconfig.json
@@ -14,9 +14,6 @@
       "path": "../lib"
     },
     {
-      "path": "../hooks"
-    },
-    {
       "path": "../palette"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4021,6 +4021,13 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.22.3"
 
+"@testing-library/user-event@^12.1.8":
+  version "12.1.8"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.8.tgz#52b419455a3da2ac7ac17b77f8fd621c3700ec12"
+  integrity sha512-UUcTuT8HyDwGaRXgNgvMS1uOlreLv9+WsXi1FNj3mmumnB2d3hv2cov0RAd99lx8QI2CtAAOELxoihGj8x/nWg==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
## ✍️ Proposed changes

- Fixes keyboard navigation bug in Tabs component: Previously, if multiple `<Tabs />` were rendered, only the first on the page would be navigable via keyboard. Now, the currently focused `<Tabs />` will be navigable via keyboard, regardless of location on page.

🎟 _Jira ticket:_ [PD-918](https://jira.mongodb.org/browse/PD-918)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
