### PR TITLE
PD-940: Copyable Updates

### DIFF
--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -173,7 +173,7 @@ export default function Copyable({
     }
 
     // Forward darkMode prop for future versions of Button that support it
-    // const buttonRestProps: {} = { darkMode };
+    const buttonRestProps = 'darkMode' in Button.propTypes! ? { darkMode } : {};
 
     const trigger = (
       <Button
@@ -181,6 +181,7 @@ export default function Copyable({
         variant={buttonVariant}
         className={buttonStyle}
         onClick={() => setCopied(true)}
+        {...buttonRestProps}
       >
         <CopyIcon size="large" className={iconStyle} />
         Copy

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -70,12 +70,14 @@ const codeStyle = css`
   display: inline-flex;
   align-items: center;
   height: 100%;
-  width: 100%;
+  // Button is 75px wide. Need to set a smaller width so that we're able to scroll when text overflows.
+  width: calc(100% - 75px);
   padding-left: 12px;
   border: 1px solid;
   border-radius: 4px;
   font-size: 14px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
 `;
 
@@ -87,7 +89,6 @@ const buttonWrapperStyle = css`
   display: inline-block;
   height: 100%;
   position: absolute;
-  z-index: 1;
   right: 0;
   top: 0;
 
@@ -129,7 +130,7 @@ const iconStyle = css`
 interface CopyableProps {
   darkMode?: boolean;
   children: string;
-  label: string;
+  label?: string;
   description?: string;
   className?: string;
   copyable?: boolean;
@@ -175,7 +176,7 @@ export default function Copyable({
     }
 
     // Forward darkMode prop for future versions of Button that support it
-    const buttonRestProps: {} = { darkMode };
+    // const buttonRestProps: {} = { darkMode };
 
     const trigger = (
       <Button
@@ -183,7 +184,6 @@ export default function Copyable({
         variant={buttonVariant}
         className={buttonStyle}
         onClick={() => setCopied(true)}
-        {...buttonRestProps}
       >
         <CopyIcon size="large" className={iconStyle} />
         Copy
@@ -273,7 +273,7 @@ Copyable.propTypes = {
   darkMode: PropTypes.bool,
   size: PropTypes.oneOf(Object.values(Size)),
   children: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   description: PropTypes.string,
   className: PropTypes.string,
   copyable: PropTypes.bool,

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -70,14 +70,11 @@ const codeStyle = css`
   display: inline-flex;
   align-items: center;
   height: 100%;
-  // Button is 75px wide. Need to set a smaller width so that we're able to scroll when text overflows.
-  width: calc(100% - 75px);
+  width: 100%;
   padding-left: 12px;
   border: 1px solid;
   border-radius: 4px;
   font-size: 14px;
-  overflow-x: auto;
-  overflow-y: hidden;
   white-space: nowrap;
 `;
 

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -76,6 +76,7 @@ const codeStyle = css`
   border-radius: 4px;
   font-size: 14px;
   white-space: nowrap;
+  overflow: hidden;
 `;
 
 const largeCodeStyle = css`

--- a/website/components/CodeDocs.tsx
+++ b/website/components/CodeDocs.tsx
@@ -6,6 +6,7 @@ import ActivityFeedIcon from '@leafygreen-ui/icon/dist/ActivityFeed';
 import Button from '@leafygreen-ui/button';
 import Card from '@leafygreen-ui/card';
 import Code from '@leafygreen-ui/code';
+import Copyable from '@leafygreen-ui/copyable';
 import Modal from '@leafygreen-ui/modal';
 import { Tabs, Tab } from '@leafygreen-ui/tabs';
 import { Subtitle, Body } from '@leafygreen-ui/typography';
@@ -104,11 +105,11 @@ function MobileInstall({ component, version, changelog }: InstallProps) {
           <Body weight="medium" className={mt3}>
             Yarn
           </Body>
-          <Code language="js">{`yarn add @leafygreen-ui/${component}`}</Code>
+          <Copyable>{`yarn add @leafygreen-ui/${component}`}</Copyable>
           <Body weight="medium" className={mt3}>
             NPM
           </Body>
-          <Code language="js">{`npm install @leafygreen-ui/${component}`}</Code>
+          <Copyable>{`npm install @leafygreen-ui/${component}`}</Copyable>
         </div>
       </GridItem>
       <GridItem sm={12}>
@@ -136,7 +137,7 @@ function DesktopInstall({ component, changelog, version }: InstallProps) {
             <Body weight="medium" className={mb1}>
               Yarn
             </Body>
-            <Code language="js">{`yarn add @leafygreen-ui/${component}`}</Code>
+            <Copyable>{`yarn add @leafygreen-ui/${component}`}</Copyable>
           </div>
         </GridItem>
         <GridItem md={5} lg={5}>
@@ -148,7 +149,7 @@ function DesktopInstall({ component, changelog, version }: InstallProps) {
           <Body weight="medium" className={mb1}>
             NPM
           </Body>
-          <Code language="js">{`npm install @leafygreen-ui/${component}`}</Code>
+          <Copyable>{`npm install @leafygreen-ui/${component}`}</Copyable>
         </GridItem>
       </GridContainer>
     </>


### PR DESCRIPTION
## ✍️ Proposed changes

- Makes label optional (since InlineCode is not a form element, this shouldn't break any rules of accessibility)
- Makes Component scrollable on the x-axis
- Removes explicitly setting z-index which was causing problems with stacking contexts in .design
- Updates CodeDocs to use Copyable component

Note: didn't create a changeset yet, because we didn't release Copyable yet (right?) so was hoping we could just publish these with the initial release

🎟 _Jira ticket:_ [PD-940](https://jira.mongodb.org/browse/PD-940)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
