### PR TITLE
Wraps text when content overflows Tooltip container

### DIFF
--- a/.changeset/stupid-books-tease.md
+++ b/.changeset/stupid-books-tease.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tooltip': patch
+---
+
+Wraps text when it overflows the Tooltip container

--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -68,6 +68,7 @@ const baseStyles = css`
   border-radius: 3px;
   box-shadow: 0px 2px 4px ${transparentize(0.85, uiColors.black)};
   cursor: default;
+  overflow-wrap: break-word;
 `;
 
 const positionRelative = css`


### PR DESCRIPTION
Before: 
<img width="228" alt="Screen Shot 2020-11-17 at 11 59 33 AM" src="https://user-images.githubusercontent.com/26016393/99421638-99943b00-28cc-11eb-98b7-e282e1ba3d52.png">

After:
<img width="221" alt="Screen Shot 2020-11-17 at 11 59 48 AM" src="https://user-images.githubusercontent.com/26016393/99421654-9dc05880-28cc-11eb-91ab-de7ba2216b8c.png">

