### PR TITLE
PD-975: Adds as prop to h1, h2, h3 and subtitle

### DIFF
--- a/.changeset/selfish-eels-grab.md
+++ b/.changeset/selfish-eels-grab.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/typography': minor
+---
+
+`H1`, `H2`, `H3` and `Subtitle` components now accept an `as` prop, such that we can keep styles consistent via `Component`, but the actual heading level that should be rendered can change based on context. This was done to support making MongoDB an accessible platform, as headings should only decrease by one level (i.e. from `<h1>` to `<h2>`) but the styles don't always need to appear as such. 

--- a/packages/typography/src/Typography.tsx
+++ b/packages/typography/src/Typography.tsx
@@ -25,13 +25,9 @@ const h1 = css`
 
 type H1Props = HTMLElementProps<'h1'>;
 
-function H1({ children, className, ...rest }: H1Props) {
-  return (
-    <h1 {...rest} className={cx(sharedStyles, h1, className)}>
-      {children}
-    </h1>
-  );
-}
+const H1: ExtendableBox<H1Props> = ({ className, ...rest }: { className?: string }) => {
+  return <Box as="h1" className={cx(sharedStyles, h1, className)} {...rest} />;
+};
 
 H1.displayName = 'H1';
 
@@ -43,13 +39,9 @@ const h2 = css`
 
 type H2Props = HTMLElementProps<'h2'>;
 
-function H2({ children, className, ...rest }: H2Props) {
-  return (
-    <h2 {...rest} className={cx(sharedStyles, h2, className)}>
-      {children}
-    </h2>
-  );
-}
+const H2: ExtendableBox<H2Props> = ({ className, ...rest }: { className?: string }) => {
+  return <Box as="h2" className={cx(sharedStyles, h2, className)} {...rest} />;
+};
 
 H2.displayName = 'H2';
 
@@ -62,13 +54,9 @@ const h3 = css`
 
 type H3Props = HTMLElementProps<'h3'>;
 
-function H3({ children, className, ...rest }: H3Props) {
-  return (
-    <h3 {...rest} className={cx(sharedStyles, h3, className)}>
-      {children}
-    </h3>
-  );
-}
+const H3: ExtendableBox<H3Props> = ({ className, ...rest }: { className?: string }) => {
+  return <Box as="h3" className={cx(sharedStyles, h3, className)} {...rest} />;
+};
 
 H3.displayName = 'H3';
 
@@ -80,13 +68,9 @@ const subtitle = css`
 
 type SubtitleProps = HTMLElementProps<'h6'>;
 
-function Subtitle({ children, className, ...rest }: SubtitleProps) {
-  return (
-    <h6 {...rest} className={cx(sharedStyles, subtitle, className)}>
-      {children}
-    </h6>
-  );
-}
+const Subtitle: ExtendableBox<SubtitleProps> = ({ className, ...rest }: { className?: string }) => {
+  return <Box as="h6" className={cx(sharedStyles, subtitle, className)} {...rest} />;
+};
 
 Subtitle.displayName = 'Subtitle';
 

--- a/packages/typography/src/Typography.tsx
+++ b/packages/typography/src/Typography.tsx
@@ -25,7 +25,12 @@ const h1 = css`
 
 type H1Props = HTMLElementProps<'h1'>;
 
-const H1: ExtendableBox<H1Props> = ({ className, ...rest }: { className?: string }) => {
+const H1: ExtendableBox<H1Props> = ({
+  className,
+  ...rest
+}: {
+  className?: string;
+}) => {
   return <Box as="h1" className={cx(sharedStyles, h1, className)} {...rest} />;
 };
 
@@ -39,7 +44,12 @@ const h2 = css`
 
 type H2Props = HTMLElementProps<'h2'>;
 
-const H2: ExtendableBox<H2Props> = ({ className, ...rest }: { className?: string }) => {
+const H2: ExtendableBox<H2Props> = ({
+  className,
+  ...rest
+}: {
+  className?: string;
+}) => {
   return <Box as="h2" className={cx(sharedStyles, h2, className)} {...rest} />;
 };
 
@@ -54,7 +64,12 @@ const h3 = css`
 
 type H3Props = HTMLElementProps<'h3'>;
 
-const H3: ExtendableBox<H3Props> = ({ className, ...rest }: { className?: string }) => {
+const H3: ExtendableBox<H3Props> = ({
+  className,
+  ...rest
+}: {
+  className?: string;
+}) => {
   return <Box as="h3" className={cx(sharedStyles, h3, className)} {...rest} />;
 };
 
@@ -68,8 +83,15 @@ const subtitle = css`
 
 type SubtitleProps = HTMLElementProps<'h6'>;
 
-const Subtitle: ExtendableBox<SubtitleProps> = ({ className, ...rest }: { className?: string }) => {
-  return <Box as="h6" className={cx(sharedStyles, subtitle, className)} {...rest} />;
+const Subtitle: ExtendableBox<SubtitleProps> = ({
+  className,
+  ...rest
+}: {
+  className?: string;
+}) => {
+  return (
+    <Box as="h6" className={cx(sharedStyles, subtitle, className)} {...rest} />
+  );
 };
 
 Subtitle.displayName = 'Subtitle';

--- a/packages/typography/src/Typography.tsx
+++ b/packages/typography/src/Typography.tsx
@@ -25,7 +25,7 @@ const h1 = css`
 
 type H1Props = HTMLElementProps<'h1'>;
 
-const H1: ExtendableBox<H1Props> = ({
+const H1: ExtendableBox<H1Props, 'h1'> = ({
   className,
   ...rest
 }: {
@@ -44,7 +44,7 @@ const h2 = css`
 
 type H2Props = HTMLElementProps<'h2'>;
 
-const H2: ExtendableBox<H2Props> = ({
+const H2: ExtendableBox<H2Props, 'h2'> = ({
   className,
   ...rest
 }: {
@@ -64,7 +64,7 @@ const h3 = css`
 
 type H3Props = HTMLElementProps<'h3'>;
 
-const H3: ExtendableBox<H3Props> = ({
+const H3: ExtendableBox<H3Props, 'h3'> = ({
   className,
   ...rest
 }: {
@@ -83,7 +83,7 @@ const subtitle = css`
 
 type SubtitleProps = HTMLElementProps<'h6'>;
 
-const Subtitle: ExtendableBox<SubtitleProps> = ({
+const Subtitle: ExtendableBox<SubtitleProps, 'h6'> = ({
   className,
   ...rest
 }: {


### PR DESCRIPTION
`H1`, `H2`, `H3` and `Subtitle` components now accept an `as` prop, such that we can keep styles consistent via `Component`, but the actual heading level that should be rendered can change based on context. This was done to support making MongoDB an accessible platform, as headings should only decrease by one level (i.e. from `<h1>` to `<h2>`) but the styles don't always need to appear as such. 