### PR TITLE
CLOUDP-78527: Add missing data-testid attributes to OrgNav

### DIFF
--- a/.changeset/hip-impalas-live.md
+++ b/.changeset/hip-impalas-live.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Adds missing data-testid attributes to All Clusters and Admin links in OrgNav

--- a/packages/mongo-nav/src/org-nav/OrgNav.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.tsx
@@ -165,12 +165,14 @@ function NavLinks({
     href?: string;
     navId: NavElement;
     text: string;
+    testid: string;
   }> = [];
 
   navLinks.push({
     href: urls.allClusters,
     navId: ActiveNavElement.OrgNavAllClusters,
     text: 'All Clusters',
+    testid: "org-nav-all-clusters-link",
   });
 
   if (admin) {
@@ -178,19 +180,20 @@ function NavLinks({
       href: urls.admin,
       navId: ActiveNavElement.OrgNavAdmin,
       text: 'Admin',
+      testid: "org-nav-admin-link",
     });
   }
 
   let items: Array<React.ReactNode>;
 
   if (showMoreDropdownMenu) {
-    items = navLinks.map(({ href, navId, text }) => (
-      <MenuItem size="large" key={navId} href={href}>
+    items = navLinks.map(({ href, navId, text, testid }) => (
+      <MenuItem size="large" key={navId} href={href} data-testid={testid}>
         <div className={css(`font-size: 16px;`)}>{text}</div>
       </MenuItem>
     ));
   } else {
-    items = navLinks.map(({ href, navId, text }) => (
+    items = navLinks.map(({ href, navId, text, testid }) => (
       <OrgNavLink
         href={href}
         loading={loading}
@@ -198,6 +201,7 @@ function NavLinks({
         className={rightLinkMargin}
         key={navId}
         onClick={onElementClick(navId)}
+        data-testid={testid}
       >
         {text}
       </OrgNavLink>

--- a/packages/mongo-nav/src/org-nav/OrgNav.tsx
+++ b/packages/mongo-nav/src/org-nav/OrgNav.tsx
@@ -172,7 +172,7 @@ function NavLinks({
     href: urls.allClusters,
     navId: ActiveNavElement.OrgNavAllClusters,
     text: 'All Clusters',
-    testid: "org-nav-all-clusters-link",
+    testid: 'org-nav-all-clusters-link',
   });
 
   if (admin) {
@@ -180,7 +180,7 @@ function NavLinks({
       href: urls.admin,
       navId: ActiveNavElement.OrgNavAdmin,
       text: 'Admin',
-      testid: "org-nav-admin-link",
+      testid: 'org-nav-admin-link',
     });
   }
 


### PR DESCRIPTION
A regression in the `OrgNav` component causes the `data-testid` attribute to be missing from the `All Clusters` link and the `Admin` link. This is resulting in test failures for anything that was looking up these `data-testid` attributes.

🎟 _Jira ticket:_ [CLOUDP-78527](https://jira.mongodb.org/browse/CLOUDP-78527)

## 🛠 Types of changes

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes