### PR TITLE
PD-983: Copyable border radius polish

### DIFF
--- a/.changeset/heavy-tools-lay.md
+++ b/.changeset/heavy-tools-lay.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/copyable': patch
+---
+
+Sets top and bottom border-radius to 4px from 0px

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -248,11 +248,6 @@ export default function Copyable({
               border-color: ${colorSet.code.border};
             `,
             { [largeCodeStyle]: size === Size.Large },
-            {
-              [css`
-                border-radius: 0 4px 4px 0;
-              `]: showCopyButton,
-            },
           )}
         >
           {children}


### PR DESCRIPTION
Updates border radius from 0px to 4px

Before:
<img width="183" alt="Screen Shot 2020-12-16 at 4 16 08 PM" src="https://user-images.githubusercontent.com/26016393/102407731-8ef7bf00-3fba-11eb-8290-2e564ed5fe29.png">

After:
<img width="444" alt="Screen Shot 2020-12-16 at 4 18 22 PM" src="https://user-images.githubusercontent.com/26016393/102407757-9a4aea80-3fba-11eb-811d-d8e332e659bd.png">

