### PR TITLE
CLOUDP-79746: Allowing text input error message to expand its container

### DIFF
--- a/.changeset/twelve-melons-grow.md
+++ b/.changeset/twelve-melons-grow.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/text-input': patch
+---
+
+CLOUDP-79746: Allowing text input error message to expand its container

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A set of CSS styles and React components built with design in mind.
 
 ## Developer Setup
 
-1. Node >= 6.11.5 required.
+1. Node >= 14.0.0 required.
 
    via [homebrew](https://brew.sh/) with `brew install node`
 

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -173,7 +173,7 @@ const optionalStyle = css`
 
 const errorMessageStyle = css`
   font-size: 14px;
-  height: 20px;
+  min-height: 20px;
   padding-top: 4px;
   font-weight: normal;
 `;


### PR DESCRIPTION
## ✍️ Proposed changes

I ran into an issue where a `TextInput`'s error text was exceeding the hard-coded 20px height allotted to it.  Converting the `height` to a `min-height` still reduces how much the form height will bounce around, while still allowing for elasticity in extreme cases like the one I'm up against.

🎟 _Jira ticket: [CLOUDP-79746](https://jira.mongodb.org/browse/CLOUDP-79746)

I also did a drive-by to update the docs to reference the correct minimum version of Node required for this project.

## 🛠 Types of changes

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
