### PR TITLE
PD-1002: Preserve right padding when icons are visible in a disabled text input

### DIFF
--- a/.changeset/calm-cobras-cough.md
+++ b/.changeset/calm-cobras-cough.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/text-input': patch
+---
+
+Preserves right padding when icons are visible in a disabled text input

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -218,12 +218,17 @@ const colorSets: Record<Mode, ColorSets> = {
   },
 } as const;
 
-function getStatefulInputStyles(state: State, optional: boolean, mode: Mode) {
+function getStatefulInputStyles(
+  state: State,
+  optional: boolean,
+  mode: Mode,
+  disabled: boolean,
+) {
   switch (state) {
     case State.Valid: {
       return css`
         padding-right: 30px;
-        border-color: ${colorSets[mode].validBorder};
+        border-color: ${!disabled ? colorSets[mode].validBorder : 'inherit'};
       `;
     }
 
@@ -231,7 +236,7 @@ function getStatefulInputStyles(state: State, optional: boolean, mode: Mode) {
       return cx(
         css`
           padding-right: 30px;
-          border-color: ${colorSets[mode].errorBorder};
+          border-color: ${!disabled ? colorSets[mode].errorBorder : 'inherit'};
         `,
         {
           [css`
@@ -368,8 +373,8 @@ const TextInput: React.ComponentType<React.PropsWithRef<
                     }
                   }
                 `,
+                getStatefulInputStyles(state, optional, mode, disabled),
                 {
-                  [getStatefulInputStyles(state, optional, mode)]: !disabled,
                   [css`
                     &:focus {
                       border: 1px solid ${colorSets[mode].inputBackgroundColor};

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -219,10 +219,7 @@ const colorSets: Record<Mode, ColorSets> = {
 } as const;
 
 function getStatefulInputStyles(
-  state: State,
-  optional: boolean,
-  mode: Mode,
-  disabled: boolean,
+  { state, optional, mode, disabled }: { state: State; optional: boolean; mode: Mode; disabled: boolean; },
 ) {
   switch (state) {
     case State.Valid: {
@@ -357,7 +354,7 @@ const TextInput: React.ComponentType<React.PropsWithRef<
                   &:disabled {
                     color: ${colorSets[mode].disabledColor};
                     background-color: ${colorSets[mode]
-                      .disabledBackgroundColor};
+                    .disabledBackgroundColor};
 
                     &:-webkit-autofill {
                       &,
@@ -366,14 +363,14 @@ const TextInput: React.ComponentType<React.PropsWithRef<
                         appearance: none;
                         border: 1px solid ${colorSets[mode].defaultBorder};
                         -webkit-text-fill-color: ${colorSets[mode]
-                          .disabledColor};
+                    .disabledColor};
                         -webkit-box-shadow: 0 0 0px 1000px
                           ${colorSets[mode].disabledBackgroundColor} inset;
                       }
                     }
                   }
                 `,
-                getStatefulInputStyles(state, optional, mode, disabled),
+                getStatefulInputStyles({ state, optional, mode, disabled }),
                 {
                   [css`
                     &:focus {

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -218,9 +218,17 @@ const colorSets: Record<Mode, ColorSets> = {
   },
 } as const;
 
-function getStatefulInputStyles(
-  { state, optional, mode, disabled }: { state: State; optional: boolean; mode: Mode; disabled: boolean; },
-) {
+function getStatefulInputStyles({
+  state,
+  optional,
+  mode,
+  disabled,
+}: {
+  state: State;
+  optional: boolean;
+  mode: Mode;
+  disabled: boolean;
+}) {
   switch (state) {
     case State.Valid: {
       return css`
@@ -354,7 +362,7 @@ const TextInput: React.ComponentType<React.PropsWithRef<
                   &:disabled {
                     color: ${colorSets[mode].disabledColor};
                     background-color: ${colorSets[mode]
-                    .disabledBackgroundColor};
+                      .disabledBackgroundColor};
 
                     &:-webkit-autofill {
                       &,
@@ -363,7 +371,7 @@ const TextInput: React.ComponentType<React.PropsWithRef<
                         appearance: none;
                         border: 1px solid ${colorSets[mode].defaultBorder};
                         -webkit-text-fill-color: ${colorSets[mode]
-                    .disabledColor};
+                          .disabledColor};
                         -webkit-box-shadow: 0 0 0px 1000px
                           ${colorSets[mode].disabledBackgroundColor} inset;
                       }


### PR DESCRIPTION
Preserve right padding when icons are visible in a disabled text input

<img width="374" alt="Screen Shot 2021-01-06 at 3 35 36 PM" src="https://user-images.githubusercontent.com/26016393/103817653-158d4280-5035-11eb-8048-470f14e1fa01.png">
<img width="381" alt="Screen Shot 2021-01-06 at 3 35 42 PM" src="https://user-images.githubusercontent.com/26016393/103817654-158d4280-5035-11eb-9115-b9387e55cfbd.png">

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [PD-1002](https://jira.mongodb.org/browse/PD-1002)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
