### PR TITLE
PD-1033: Visual heading text is not marked as heading in Confirmation Modal

### DIFF
--- a/.changeset/rude-goats-tell.md
+++ b/.changeset/rude-goats-tell.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/confirmation-modal': patch
+---
+
+Ensures that text that appears and functions like heading text is marked up as such

--- a/packages/confirmation-modal/src/ConfirmationModal.tsx
+++ b/packages/confirmation-modal/src/ConfirmationModal.tsx
@@ -106,7 +106,7 @@ const ConfirmationModal = ({
   return (
     <Modal {...modalProps} contentClassName={baseModalStyle} setOpen={onCancel}>
       <div className={contentStyle}>
-        <div className={titleStyle}>{title}</div>
+        <h1 className={titleStyle}>{title}</h1>
         {children}
         {textEntryConfirmation}
       </div>


### PR DESCRIPTION
## ✍️ Proposed changes

Updates visual heading from div to h1 tag in ConfirmationModal component

🎟 _Jira ticket:_ [PD-1033](https://jira.mongodb.org/browse/PD-1033)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
