### PR TITLE
Fixes bug in Tab component

### DIFF
--- a/.changeset/proud-rockets-return.md
+++ b/.changeset/proud-rockets-return.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tabs': patch
+---
+
+Prevents onClick from being fired when Tab is clicked, as it should only be fired when the TabTitle is clicked

--- a/packages/tabs/src/Tab.tsx
+++ b/packages/tabs/src/Tab.tsx
@@ -68,7 +68,8 @@ function Tab({ selected, children, ariaControl, ...rest }: TabProps) {
   }
 
   // default and name are not an HTML properties
-  delete rest.default, delete rest.name;
+  // onClick applies to TabTitle component, not Tab component
+  delete rest.default, delete rest.name, delete rest.onClick;
 
   return (
     <div {...rest} aria-controls={ariaControl} id={ariaControl} role="tabpanel">


### PR DESCRIPTION
Duplicately applying `onClick` prop to `TabTitle` and `Tab` components. This PR removes extraneous function call on `Tab` component.