### PR TITLE
PD-1084: When a non-centered Option is clicked, the Select component will scroll to center that element instead of being selected.

### DIFF
--- a/.changeset/nasty-readers-travel.md
+++ b/.changeset/nasty-readers-travel.md
@@ -1,0 +1,6 @@
+---
+'@leafygreen-ui/select': patch
+---
+
+Fixes bug where when a non-centered `Option` is clicked, the component will scroll to center that element instead of being selected.
+Now, when an element is clicked, it becomes selected. When opening the dropdown later, the selected item should then be centered.

--- a/packages/select/src/Option.tsx
+++ b/packages/select/src/Option.tsx
@@ -89,10 +89,9 @@ export function InternalOption({
 
   useEffect(() => {
     if (shouldFocus) {
-      scrollIntoView();
       ref.current!.focus();
     }
-  }, [scrollIntoView, shouldFocus]);
+  }, [shouldFocus]);
 
   const styledChildren: React.ReactNode = (
     <span


### PR DESCRIPTION
## ✍️ Proposed changes

When a non-centered Option is clicked, the Select component will scroll to center that element instead of being selected.

🎟 _Jira ticket:_ [PD-1084](https://jira.mongodb.org/browse/PD-1084)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
