### PR TITLE
PD-1131: Removes hover state from currently selected Tabs

### DIFF
--- a/.changeset/fluffy-gorillas-wave.md
+++ b/.changeset/fluffy-gorillas-wave.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tabs': patch
+---
+
+Disables hover state on selected tabs

--- a/packages/tabs/src/TabTitle.tsx
+++ b/packages/tabs/src/TabTitle.tsx
@@ -177,7 +177,7 @@ const TabTitle: ExtendableBox<BaseTabTitleProps, 'button'> = ({
         [listTitleSelected]: selected,
         [modeColors[mode].listTitleFocus]: showFocus,
         [textOverflowStyles]: showEllipsis,
-        [modeColors[mode].listTitleHover]: !disabled,
+        [modeColors[mode].listTitleHover]: !disabled && !selected,
       },
       className,
     ),


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [PD-1131](https://jira.mongodb.org/browse/PD-1131)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
