### PR TITLE
PD-443: Traps focus in modal component

### DIFF
--- a/.changeset/chatty-sloths-search.md
+++ b/.changeset/chatty-sloths-search.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/modal': patch
+---
+
+Traps focus in Modal component, per WAI-Aria authoring practices

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "react-transition-group": "^4.4.1",
+    "react-focus-lock": "^2.5.0",
     "@leafygreen-ui/hooks": "^6.0.0",
     "@leafygreen-ui/icon": "^9.0.0",
     "@leafygreen-ui/icon-button": "^9.0.1",

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -1,5 +1,6 @@
 import React, { SetStateAction, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
+import FocusLock from 'react-focus-lock';
 import { Transition } from 'react-transition-group';
 import { transparentize } from 'polished';
 import facepaint from 'facepaint';
@@ -96,8 +97,8 @@ const modalSizes: { readonly [K in ModalSize]: string } = {
 
   large: css`
     ${mq({
-      width: ['720px', '720px', '960px'],
-    })}
+    width: ['720px', '720px', '960px'],
+  })}
   `,
 };
 
@@ -192,7 +193,7 @@ interface ModalProps {
 function Modal({
   open = false,
   size = ModalSize.Default,
-  setOpen = () => {},
+  setOpen = () => { },
   shouldClose = () => true,
   closeOnBackdropClick = true,
   children,
@@ -245,31 +246,33 @@ function Modal({
               [visibleBackdrop]: state === 'entered',
             })}
           >
-            <div className={scrollContainer} ref={setScrollContainerNode}>
-              <div
-                aria-modal="true"
-                role="dialog"
-                tabIndex={-1}
-                className={cx(
-                  modalContentStyle,
-                  modalSizes[size],
-                  {
-                    [visibleModalContentStyle]: state === 'entered',
-                  },
-                  contentClassName,
-                )}
-              >
-                <IconButton
-                  onClick={handleClose}
-                  aria-label="Close modal"
-                  className={closeButton}
+            <FocusLock returnFocus>
+              <div className={scrollContainer} ref={setScrollContainerNode}>
+                <div
+                  aria-modal="true"
+                  role="dialog"
+                  tabIndex={-1}
+                  className={cx(
+                    modalContentStyle,
+                    modalSizes[size],
+                    {
+                      [visibleModalContentStyle]: state === 'entered',
+                    },
+                    contentClassName,
+                  )}
                 >
-                  <XIcon />
-                </IconButton>
+                  <IconButton
+                    onClick={handleClose}
+                    aria-label="Close modal"
+                    className={closeButton}
+                  >
+                    <XIcon />
+                  </IconButton>
 
-                {children}
+                  {children}
+                </div>
               </div>
-            </div>
+            </FocusLock>
           </div>
         </Portal>
       )}

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -97,8 +97,8 @@ const modalSizes: { readonly [K in ModalSize]: string } = {
 
   large: css`
     ${mq({
-    width: ['720px', '720px', '960px'],
-  })}
+      width: ['720px', '720px', '960px'],
+    })}
   `,
 };
 
@@ -193,7 +193,7 @@ interface ModalProps {
 function Modal({
   open = false,
   size = ModalSize.Default,
-  setOpen = () => { },
+  setOpen = () => {},
   shouldClose = () => true,
   closeOnBackdropClick = true,
   children,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14840,7 +14840,7 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@^2.1.0:
+react-focus-lock@^2.1.0, react-focus-lock@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
   integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==


### PR DESCRIPTION
## ✍️ Proposed changes

- Finally traps focus in Modal component
- Uses react-focus-lock (which is used by Reach and Storybook)

🎟 _Jira ticket:_ [PD-443](https://jira.mongodb.org/browse/PD-443)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
