### PR TITLE
export props used by Tabs

### DIFF
--- a/.changeset/nine-trees-jog.md
+++ b/.changeset/nine-trees-jog.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tabs': minor
+---
+
+Export Props used by Tabs

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -122,7 +122,7 @@ export interface TabsProps {
 
 type AriaLabels = 'aria-label' | 'aria-labelledby';
 
-type AccessibleTabsProps = Either<TabsProps, AriaLabels>;
+export type AccessibleTabsProps = Either<TabsProps, AriaLabels>;
 
 /**
  * # Tabs

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -1,3 +1,3 @@
-export { default as Tabs } from './Tabs';
+export { default as Tabs, AccessibleTabsProps as TabsProps } from './Tabs';
 export { default as Tab } from './Tab';
 export type { TabProps } from './Tab';

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -1,3 +1,4 @@
-export { default as Tabs, AccessibleTabsProps as TabsProps } from './Tabs';
+export { default as Tabs } from './Tabs';
+export type { AccessibleTabsProps as TabsProps } from './Tabs'
 export { default as Tab } from './Tab';
 export type { TabProps } from './Tab';

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -1,4 +1,4 @@
 export { default as Tabs } from './Tabs';
-export type { AccessibleTabsProps as TabsProps } from './Tabs'
+export type { AccessibleTabsProps as TabsProps } from './Tabs';
 export { default as Tab } from './Tab';
 export type { TabProps } from './Tab';


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes
This PR exports the types used by `Tabs` so that consumers can use it. It exports AccessibleTabsProps aliased as TabsProps as that is the true type use by Tabs. Lmk if that sounds right or if we should just export the plain `TabsProps` as defined in Tabs or not do the alias.

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

Since this is a simple export I don't think we need unit tests. LMK if you think otherwise. I'm happy to add something.

## 🧪 How to test changes
This change can be tested by building the Tabs package and using the newly exported type.

