### PR TITLE
Fixes bug in Code component, empty panel rendering without copyable

### DIFF
--- a/.changeset/rich-suits-warn.md
+++ b/.changeset/rich-suits-warn.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/code': patch
+---
+
+Removes empty panel rendered when copyable is false

--- a/packages/code/src/Code.spec.tsx
+++ b/packages/code/src/Code.spec.tsx
@@ -92,6 +92,14 @@ describe('packages/Code', () => {
     });
   });
 
+  describe('panel', () => {
+    test('is not rendered when language switcher is not present and when copyable is false', () => {
+      expect(container).not.toContain(
+        screen.queryByTestId('leafygreen-code-panel'),
+      );
+    });
+  });
+
   describe('when rendered as a language switcher', () => {
     let offsetParentSpy: jest.SpyInstance;
     beforeAll(() => {

--- a/packages/code/src/Code.tsx
+++ b/packages/code/src/Code.tsx
@@ -274,7 +274,9 @@ function Code({
           {renderedSyntaxComponent}
         </pre>
 
-        {!showWindowChrome && (
+        {/* Can make this a more robust check in the future */}
+        {/* Right now the panel will only be rendered with copyable or a language switcher */}
+        {!showWindowChrome && (copyable || !!currentLanguage) && (
           <Panel
             language={currentLanguage}
             languageOptions={languageOptions}

--- a/packages/code/src/Panel.tsx
+++ b/packages/code/src/Panel.tsx
@@ -92,8 +92,13 @@ function Panel({
 }: PanelProps) {
   const mode = darkMode ? Mode.Dark : Mode.Light;
 
+  console.log('inside panel');
+
   return (
-    <div className={getPanelStyles(mode, !!language, isMultiline)}>
+    <div
+      className={getPanelStyles(mode, !!language, isMultiline)}
+      data-testid="leafygreen-code-panel"
+    >
       {language !== undefined &&
         languageOptions !== undefined &&
         onChange !== undefined && (

--- a/packages/code/src/Panel.tsx
+++ b/packages/code/src/Panel.tsx
@@ -92,8 +92,6 @@ function Panel({
 }: PanelProps) {
   const mode = darkMode ? Mode.Dark : Mode.Light;
 
-  console.log('inside panel');
-
   return (
     <div
       className={getPanelStyles(mode, !!language, isMultiline)}


### PR DESCRIPTION
Before: 
<img width="1183" alt="Screen Shot 2021-04-27 at 3 41 45 pm" src="https://user-images.githubusercontent.com/26016393/116247414-d2b4bf00-a738-11eb-906f-0ccd89f1a871.png">

After:
<img width="407" alt="Screen Shot 2021-04-27 at 9 12 55 AM" src="https://user-images.githubusercontent.com/26016393/116247420-d5171900-a738-11eb-835e-f56e2ea82ef8.png">
