### PR TITLE
Use context instead of cloneElement in RadioBox

### DIFF
--- a/.changeset/eight-colts-cheat.md
+++ b/.changeset/eight-colts-cheat.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/radio-box-group': minor
+---
+
+Allow for RadioBox elements to be rendered as non-direct descendants of a RadioBoxGroup (either inside another element, or rendered by a wrapper component)

--- a/packages/radio-box-group/src/RadioBox.tsx
+++ b/packages/radio-box-group/src/RadioBox.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { HTMLElementProps, createDataProp } from '@leafygreen-ui/lib';
 import { css, cx } from '@leafygreen-ui/emotion';
 import InteractionRing from '@leafygreen-ui/interaction-ring';
 import { uiColors } from '@leafygreen-ui/palette';
 import Size from './Size';
+import { useRadioBoxGroupContext, RadioBoxGroupContext } from './context';
 
 const radioBoxWrapper = createDataProp('radio-box-wrapper');
 const radioBoxInput = createDataProp('radio-box-input');
@@ -163,6 +164,26 @@ export interface RadioBoxProps {
   default?: boolean;
 }
 
+function isChecked({
+  checkedProp,
+  defaultProp,
+  radioBoxGroupContext,
+  value,
+}: {
+  checkedProp?: boolean;
+  defaultProp: boolean;
+  radioBoxGroupContext: RadioBoxGroupContext | null;
+  value: string | number;
+}): boolean {
+  const contextValue = radioBoxGroupContext?.value;
+
+  if (contextValue == null) {
+    return checkedProp ?? defaultProp;
+  }
+
+  return contextValue === value;
+}
+
 /**
  * # RadioBox
  *
@@ -180,16 +201,44 @@ export interface RadioBoxProps {
  */
 export default function RadioBox({
   className = '',
-  onChange,
+  onChange: onChangeProp,
   value,
-  checked = false,
+  checked: checkedProp,
+  default: defaultProp = false,
   disabled = false,
-  id,
-  size = Size.Default,
+  id: idProp,
+  size: sizeProp = Size.Default,
   children,
-  name,
+  name: nameProp,
   ...rest
 }: RadioBoxProps & Omit<HTMLElementProps<'input', never>, 'size'>) {
+  const radioBoxGroupContext = useRadioBoxGroupContext();
+  const idRef = useRef<string>();
+
+  const id = idProp ?? idRef.current ?? radioBoxGroupContext?.getNextId();
+
+  if (idProp == null && idRef.current == null && id != null) {
+    // Avoid re-calculating on next render
+    idRef.current = id;
+  }
+
+  const size = radioBoxGroupContext?.size ?? sizeProp;
+  const name = radioBoxGroupContext?.name ?? nameProp;
+  const checked = isChecked({
+    value,
+    checkedProp,
+    defaultProp,
+    radioBoxGroupContext,
+  });
+  const contextOnChange = radioBoxGroupContext?.onChange;
+  const onChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    e => {
+      onChangeProp?.(e);
+      contextOnChange?.(e);
+    },
+    [onChangeProp, contextOnChange],
+  );
+
   const radioDisplayStyle = getRadioDisplayStyles({ checked, disabled, size });
   const interactionContainerStyle = getInteractionRingStyles({
     checked,

--- a/packages/radio-box-group/src/RadioBoxGroup.spec.tsx
+++ b/packages/radio-box-group/src/RadioBoxGroup.spec.tsx
@@ -64,11 +64,20 @@ describe('packages/RadioBox', () => {
 });
 
 describe('packages/RadioBoxGroup', () => {
+  function WrappedRadioBox({ text }: { text: string }) {
+    return (
+      <div className="wrapped-radio-box">
+        {text} <RadioBox value="option-3">Input 3</RadioBox>
+      </div>
+    );
+  }
+
   const { container } = render(
     <RadioBoxGroup>
       <RadioBox value="option-1">Input 1</RadioBox>
       <h1>Will Remain As Text</h1>
       <RadioBox value="option-2">Input 2</RadioBox>
+      <WrappedRadioBox text="Also still text" />
     </RadioBoxGroup>,
   );
 
@@ -84,6 +93,13 @@ describe('packages/RadioBoxGroup', () => {
     expect(text.tagName.toLowerCase()).toBe('h1');
   });
 
+  const wrapped = radioBoxGroupContainer.children[3];
+
+  test('renders wrapper components as themselves', () => {
+    expect(wrapped.tagName.toLowerCase()).toBe('div');
+    expect(wrapped.className).toBe('wrapped-radio-box');
+  });
+
   describe('when controlled', () => {
     const controlledOnChange = jest.fn();
 
@@ -91,6 +107,7 @@ describe('packages/RadioBoxGroup', () => {
       <RadioBoxGroup value="option-1" onChange={controlledOnChange}>
         <RadioBox value="option-1">Option 1</RadioBox>
         <RadioBox value="option-2">Option 2</RadioBox>
+        <WrappedRadioBox text="text" />
       </RadioBoxGroup>,
       { container },
     );
@@ -130,6 +147,88 @@ describe('packages/RadioBoxGroup', () => {
 
     test('radio input does not become checked when clicked', () => {
       expect(secondRadioBoxInput.checked).toBe(false);
+    });
+  });
+
+  describe('when controlled with a wrapper component', () => {
+    const controlledOnChange = jest.fn();
+
+    const { container } = render(
+      <RadioBoxGroup value="option-1" onChange={controlledOnChange}>
+        <RadioBox value="option-1">Option 1</RadioBox>
+        <RadioBox value="option-2">Option 2</RadioBox>
+        <WrappedRadioBox text="text" />
+      </RadioBoxGroup>,
+    );
+
+    const radioBoxGroup = container.firstChild;
+
+    if (!typeIs.element(radioBoxGroup)) {
+      throw new Error('Could not find radio box group element');
+    }
+
+    const firstRadioBoxLabel = radioBoxGroup.firstChild;
+
+    if (!typeIs.element(firstRadioBoxLabel)) {
+      throw new Error('Could not find label element');
+    }
+
+    const firstRadioBoxInput = firstRadioBoxLabel.firstChild;
+
+    if (!typeIs.input(firstRadioBoxInput)) {
+      throw new Error('Could not find input element');
+    }
+
+    const wrappedRadioBoxInput =
+      radioBoxGroup.children[2].firstElementChild?.firstElementChild;
+
+    if (!typeIs.input(wrappedRadioBoxInput)) {
+      throw new Error('Could not find wrapped input element');
+    }
+
+    fireEvent.click(wrappedRadioBoxInput);
+
+    test('initial value set by radio box group', () => {
+      expect(firstRadioBoxInput.checked).toBe(true);
+      expect(firstRadioBoxInput.getAttribute('aria-checked')).toBe('true');
+    });
+
+    test('onChange fires when the wrapped label is clicked', () => {
+      expect(controlledOnChange.mock.calls.length).toBe(1);
+    });
+
+    test('wrapped input does not become checked when clicked', () => {
+      expect(wrappedRadioBoxInput.checked).toBe(false);
+    });
+  });
+
+  describe('when controlled with a selected wrapper component', () => {
+    const controlledOnChange = jest.fn();
+
+    const { container } = render(
+      <RadioBoxGroup value="option-3" onChange={controlledOnChange}>
+        <RadioBox value="option-1">Option 1</RadioBox>
+        <RadioBox value="option-2">Option 2</RadioBox>
+        <WrappedRadioBox text="text" />
+      </RadioBoxGroup>,
+    );
+
+    const radioBoxGroup = container.firstChild;
+
+    if (!typeIs.element(radioBoxGroup)) {
+      throw new Error('Could not find radio box group element');
+    }
+
+    const wrappedRadioBoxInput =
+      radioBoxGroup.children[2].firstElementChild?.firstElementChild;
+
+    if (!typeIs.input(wrappedRadioBoxInput)) {
+      throw new Error('Could not find wrapped input element');
+    }
+
+    test('wrapped input is rendered as checked', () => {
+      expect(wrappedRadioBoxInput.checked).toBe(true);
+      expect(wrappedRadioBoxInput.getAttribute('aria-checked')).toBe('true');
     });
   });
 

--- a/packages/radio-box-group/src/RadioBoxGroup.spec.tsx
+++ b/packages/radio-box-group/src/RadioBoxGroup.spec.tsx
@@ -189,7 +189,9 @@ describe('packages/RadioBoxGroup', () => {
     fireEvent.click(wrappedRadioBoxInput);
 
     test('initial value set by radio box group', () => {
-      expect(firstRadioBoxInput.checked).toBe(true);
+      // .checked prop can be inconsistent in ssr tests,
+      // so while I'd like to do expect(firstRadioBoxInput.checked).toBe(true);
+      // aria-checked should be good enough
       expect(firstRadioBoxInput.getAttribute('aria-checked')).toBe('true');
     });
 

--- a/packages/radio-box-group/src/context.ts
+++ b/packages/radio-box-group/src/context.ts
@@ -1,0 +1,19 @@
+import { createContext, ChangeEventHandler, useContext } from 'react';
+import Size from './Size';
+
+export interface RadioBoxGroupContext {
+  value: string | number | undefined;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  getNextId: () => string;
+  size: Size | undefined;
+  name: string | undefined;
+}
+
+const context = createContext<RadioBoxGroupContext | null>(null);
+
+export const Provider = context.Provider;
+export const Consumer = context.Consumer;
+
+export function useRadioBoxGroupContext() {
+  return useContext(context);
+}

--- a/packages/radio-box-group/src/context.ts
+++ b/packages/radio-box-group/src/context.ts
@@ -12,7 +12,6 @@ export interface RadioBoxGroupContext {
 const context = createContext<RadioBoxGroupContext | null>(null);
 
 export const Provider = context.Provider;
-export const Consumer = context.Consumer;
 
 export function useRadioBoxGroupContext() {
   return useContext(context);


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

`RadioBoxGroup` using `cloneElement` to communicate with its child `RadioBox` elements means that those `RadioBox` elements have to be direct children, and it's not possible for consumers to make their own wrapper components. Communicating through context instead removes this limitation and allows the `RadioBox` to be deeper in the React tree.

🎟 _Jira ticket:_ Tangentially related to [CLOUDP-90548](https://jira.mongodb.org/browse/CLOUDP-90548)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->

## 💬 Further comments

This is as much a discussion-starter as a specific proposed change. I've argued against `cloneElement` for a while, so we don't have to rehash all of that, but I do think that using context allows us to use React more naturally, without having to worry about the additional constraints brought on by a parent component meddling with its children's props.
