### PR TITLE
PD-1418: Updates Tooltip within Copyable

### DIFF
--- a/.changeset/cyan-turkeys-run.md
+++ b/.changeset/cyan-turkeys-run.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/copyable': patch
+---
+
+Fixes Copyable Tooltip when used within a Modal

--- a/.changeset/cyan-turkeys-run.md
+++ b/.changeset/cyan-turkeys-run.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/copyable': patch
 ---
 
-Fixes Copyable Tooltip when used within a Modal
+Tooltips in association with Copyable component now appear as a direct DOM child—not within a portal—in order to support usage within a Modal

--- a/.changeset/cyan-turkeys-run.md
+++ b/.changeset/cyan-turkeys-run.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/copyable': patch
 ---
 
-Tooltips in association with Copyable component now appear as a direct DOM child—not within a portal—in order to support usage within a Modal
+Exposes a `shouldTooltipUsePortal` prop on Copyable, to control whether the "Copied!" Tooltip is rendered as a direct DOM child, or within a portal, in order to support usage within a Modal

--- a/packages/copyable/README.md
+++ b/packages/copyable/README.md
@@ -77,12 +77,13 @@ npm install @leafygreen-ui/copyable
 
 ## Properties
 
-| Prop          | Type                   | Description                                                   | Default     |
-| ------------- | ---------------------- | ------------------------------------------------------------- | ----------- |
-| `label`       | `string`               | Label text for the copyable contents.                         |             |
-| `description` | `string`               | Further text to describe the contents.                        | `undefined` |
-| `className`   | `string`               | className applied to the container of the code element        |             |
-| `children`    | `string`               | The text that will be copied.                                 |             |
-| `darkMode`    | `boolean`              | Determines whether or not the component appears in dark mode. | `false`     |
-| `size`        | `'default'`, `'large'` | Display size of the copyable text.                            | `'default'` |
-| `copyable`    | `boolean`              | Whether or not a copy button should be shown.                 | `true`      |
+| Prop                        | Type                   | Description                                                    | Default     |
+| --------------------------- | ---------------------- | -------------------------------------------------------------- | ----------- |
+| `label`                     | `string`               | Label text for the copyable contents.                          |             |
+| `description`               | `string`               | Further text to describe the contents.                         | `undefined` |
+| `className`                 | `string`               | className applied to the container of the code element         |             |
+| `children`                  | `string`               | The text that will be copied.                                  |             |
+| `darkMode`                  | `boolean`              | Determines whether or not the component appears in dark mode.  | `false`     |
+| `size`                      | `'default'`, `'large'` | Display size of the copyable text.                             | `'default'` |
+| `copyable`                  | `boolean`              | Whether or not a copy button should be shown.                  | `true`      |
+| `shouldTooltipUsePortal`    | `boolean`              | Whether or not the "Copied!" tooltip should use a React portal | `true`      |

--- a/packages/copyable/README.md
+++ b/packages/copyable/README.md
@@ -77,13 +77,13 @@ npm install @leafygreen-ui/copyable
 
 ## Properties
 
-| Prop                        | Type                   | Description                                                    | Default     |
-| --------------------------- | ---------------------- | -------------------------------------------------------------- | ----------- |
-| `label`                     | `string`               | Label text for the copyable contents.                          |             |
-| `description`               | `string`               | Further text to describe the contents.                         | `undefined` |
-| `className`                 | `string`               | className applied to the container of the code element         |             |
-| `children`                  | `string`               | The text that will be copied.                                  |             |
-| `darkMode`                  | `boolean`              | Determines whether or not the component appears in dark mode.  | `false`     |
-| `size`                      | `'default'`, `'large'` | Display size of the copyable text.                             | `'default'` |
-| `copyable`                  | `boolean`              | Whether or not a copy button should be shown.                  | `true`      |
-| `shouldTooltipUsePortal`    | `boolean`              | Whether or not the "Copied!" tooltip should use a React portal | `true`      |
+| Prop                     | Type                   | Description                                                    | Default     |
+| ------------------------ | ---------------------- | -------------------------------------------------------------- | ----------- |
+| `label`                  | `string`               | Label text for the copyable contents.                          |             |
+| `description`            | `string`               | Further text to describe the contents.                         | `undefined` |
+| `className`              | `string`               | className applied to the container of the code element         |             |
+| `children`               | `string`               | The text that will be copied.                                  |             |
+| `darkMode`               | `boolean`              | Determines whether or not the component appears in dark mode.  | `false`     |
+| `size`                   | `'default'`, `'large'` | Display size of the copyable text.                             | `'default'` |
+| `copyable`               | `boolean`              | Whether or not a copy button should be shown.                  | `true`      |
+| `shouldTooltipUsePortal` | `boolean`              | Whether or not the "Copied!" tooltip should use a React portal | `true`      |

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -130,7 +130,7 @@ interface CopyableProps {
   className?: string;
   copyable?: boolean;
   size?: Size;
-  shouldTooltipUsePortal?: boolean
+  shouldTooltipUsePortal?: boolean;
 }
 
 export default function Copyable({
@@ -141,7 +141,7 @@ export default function Copyable({
   className,
   copyable = true,
   size = Size.Default,
-  shouldTooltipUsePortal = true
+  shouldTooltipUsePortal = true,
 }: CopyableProps) {
   const mode = darkMode ? Mode.Dark : Mode.Light;
   const colorSet = colorSets[mode];

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -130,7 +130,7 @@ interface CopyableProps {
   className?: string;
   copyable?: boolean;
   size?: Size;
-  shouldTooltipUsePortal: boolean
+  shouldTooltipUsePortal?: boolean
 }
 
 export default function Copyable({

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -178,6 +178,7 @@ export default function Copyable({
         justify={Justify.Middle}
         trigger={trigger}
         triggerEvent={TriggerEvent.Click}
+        usePortal={false}
       >
         Copied!
       </Tooltip>

--- a/packages/copyable/src/Copyable.tsx
+++ b/packages/copyable/src/Copyable.tsx
@@ -130,6 +130,7 @@ interface CopyableProps {
   className?: string;
   copyable?: boolean;
   size?: Size;
+  shouldTooltipUsePortal: boolean
 }
 
 export default function Copyable({
@@ -140,6 +141,7 @@ export default function Copyable({
   className,
   copyable = true,
   size = Size.Default,
+  shouldTooltipUsePortal = true
 }: CopyableProps) {
   const mode = darkMode ? Mode.Dark : Mode.Light;
   const colorSet = colorSets[mode];
@@ -178,7 +180,7 @@ export default function Copyable({
         justify={Justify.Middle}
         trigger={trigger}
         triggerEvent={TriggerEvent.Click}
-        usePortal={false}
+        usePortal={shouldTooltipUsePortal}
       >
         Copied!
       </Tooltip>


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

Resolves Tooltip presentation issues when using a Copyable within a Modal

🎟 _Jira ticket:_ [PD-1418](https://jira.mongodb.org/browse/PD-1418)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->

Use a Copyable within a Modal with `z-index > 0`:
Create a temporary Story within `Copyable.story.tsx` 
```js
  .add('Within Modal', () => {
    const darkMode = boolean('Dark mode', false)
    return (
      <Modal
        open={true}
        size='default'
        darkMode={darkMode}
        style={{ zIndex: 1 }}
      >
        <Copyable
          label={text('Label', 'Label')}
          description={text('Description', '') || undefined}
          darkMode={darkMode}
          shouldTooltipUsePortal={false}
        >
          {text('Text', 'npm install @leafygreen-ui/copyable')}
        </Copyable>
      </Modal>
    )
  })
```

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

### Before
![Before](https://user-images.githubusercontent.com/2414030/121572807-8eccff00-c9f2-11eb-98b3-63f823032849.gif)

### After
![After](https://user-images.githubusercontent.com/2414030/121572837-94c2e000-c9f2-11eb-9dff-097ad409e0b9.gif)

