### PR TITLE
PD-1514 : Fix issue in MongoNav when clicking tooltips

### DIFF
--- a/.changeset/proud-ants-design.md
+++ b/.changeset/proud-ants-design.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/mongo-nav': patch
+---
+
+Fixes issue where clicking tooltips in the MongoNav would cause the page to navigate if they were a child of a link.


### PR DESCRIPTION
## ✍️ Proposed changes

Prevents default when tooltips contained within an anchor tag would be clicked. This fixes an issue where clicking tooltips would navigate you to a different page.

Also removes the cursor: pointer for the gov banner.

Changes can be viewed here: https://github.com/10gen/leafygreen-ui-mongo-nav/pull/25

🎟 _Jira ticket:_ [PD-1514](https://jira.mongodb.org/browse/PD-1514)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~
- [x] I have run `yarn changeset` and documented my changes

## 🧪 How to test changes

Hover on the logo, Project Alerts, Activity Feed, and Invite User links. Clicking the tooltips that appear should not cause you to navigate. Clicking on the links themselves should continue to navigate the user.
