### PR TITLE
Have Portal render synchronously while still not breaking SSR

### DIFF
--- a/.changeset/beige-trains-relax.md
+++ b/.changeset/beige-trains-relax.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/portal': patch
+---
+
+Use useLayoutEffect hook internally to fix tests broken by Portal showing async behavior

--- a/packages/portal/src/Portal.tsx
+++ b/packages/portal/src/Portal.tsx
@@ -1,5 +1,5 @@
 import { OneOf } from '@leafygreen-ui/lib';
-import React, { useEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { createPortal } from 'react-dom';
 
@@ -17,7 +17,7 @@ function usePortalContainer(customContainer?: HTMLElement) {
   //  - A component's initial hydrated render should match the server render
   const [container, setContainer] = useState<HTMLElement | undefined>();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (customContainer) {
       setContainer(customContainer);
     } else {
@@ -38,7 +38,7 @@ function usePortalContainer(customContainer?: HTMLElement) {
 function Portal(props: PortalProps) {
   const container = usePortalContainer(props.container ?? undefined);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (container && !props.container) {
       container.className = props.className ?? '';
     }


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

In Portal v2.2.0, there was a change made to support SSR by not rendering until the second render (using `useEffect`). Unfortunately, this had the effect of breaking a bunch of tests in mms when I tried to update the library, because it made multiple components downstream async that had previously been synchronous. This PR fixes the issue by using `useLayoutEffect`, which still allows rendering it in SSR to be a no-op, but triggers the second render immediately while still in the same thread, so it acts as a synchronous render in tests.

🎟 _Jira ticket:_ _none_ (should I file one?)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
