### PR TITLE
chore(card): Update focus ring color and animation timing to match other leafygreen components

### DIFF
--- a/.changeset/shiny-tips-flash.md
+++ b/.changeset/shiny-tips-flash.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/card': patch
+---
+
+Update focus ring color and animation timing to match other leafygreen components

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -34,8 +34,7 @@ const lightHoverBoxShadow = `0 2px 6px -2px ${transparentize(
   uiColors.black,
 )}`;
 const darkHoverBoxShadow = `0 2px 12px -2px ${transparentize(0.1, '#000')}`;
-const lightFocusBoxShadow = `0 0 0 3px ${uiColors.blue.light1}`;
-const darkFocusBoxShadow = `0 0 0 3px ${uiColors.blue.base}`;
+const focusBoxShadow = `0 0 0 3px ${uiColors.focus}`;
 
 const colorSet: Record<Mode, ColorSet> = {
   [Mode.Light]: {
@@ -50,7 +49,7 @@ const colorSet: Record<Mode, ColorSet> = {
 
       &:focus {
         outline: none;
-        box-shadow: ${lightBaseBoxShadow}, ${lightFocusBoxShadow};
+        box-shadow: ${lightBaseBoxShadow}, ${focusBoxShadow};
       }
 
       &:hover {
@@ -58,7 +57,7 @@ const colorSet: Record<Mode, ColorSet> = {
         box-shadow: ${lightHoverBoxShadow};
 
         &:focus {
-          box-shadow: ${lightHoverBoxShadow}, ${lightFocusBoxShadow};
+          box-shadow: ${lightHoverBoxShadow}, ${focusBoxShadow};
         }
       }
     `,
@@ -75,14 +74,14 @@ const colorSet: Record<Mode, ColorSet> = {
 
       &:focus {
         outline: none;
-        box-shadow: ${darkBaseBoxShadow}, ${darkFocusBoxShadow};
+        box-shadow: ${darkBaseBoxShadow}, ${focusBoxShadow};
       }
 
       &:hover {
         box-shadow: ${darkHoverBoxShadow};
 
         &:focus {
-          box-shadow: ${darkHoverBoxShadow}, ${darkFocusBoxShadow};
+          box-shadow: ${darkHoverBoxShadow}, ${focusBoxShadow};
         }
       }
     `,
@@ -92,7 +91,7 @@ const colorSet: Record<Mode, ColorSet> = {
 const containerStyle = css`
   position: relative;
   border-radius: 7px;
-  transition: border 300ms ease-in-out, box-shadow 300ms ease-in-out;
+  transition: border 150ms ease-in-out, box-shadow 150ms ease-in-out;
 `;
 
 interface CardProps {


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ No ticket, but I can open one if needed. Change based on this [slack discussion](https://mongodb.slack.com/archives/CFFA5BS79/p1638898731232900?thread_ts=1638787473.222300&cid=CFFA5BS79)

## 🛠 Types of changes

Aligns focuscolor and transition timing to match other components in the repo

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

You can run the storybook locally, make Card focusable and look at the new style color.

## 💬 Further comments

This is how it looks now

![Kapture 2021-12-10 at 12 10 47](https://user-images.githubusercontent.com/5036933/145565190-7fc3bac8-73af-4435-a98b-0219555fd1f0.gif)
