### PR TITLE
Fix missing reference in Callout's tsconfig.json

### DIFF
--- a/packages/callout/tsconfig.json
+++ b/packages/callout/tsconfig.json
@@ -14,10 +14,13 @@
       "path": "../emotion"
     },
     {
+      "path": "../icon"
+    },
+    {
       "path": "../palette"
     },
     {
-      "path": "../icon"
+      "path": "../typography"
     },
     {
       "path": "../leafygreen-provider"


### PR DESCRIPTION

## ✍️ Proposed changes

Currently, we can't build TS for the repo because there's a missing tsconfig reference for callout, since we added a dependency on Typography.
