### PR TITLE
Fixes changeset version script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: yarn version
+          version: yarn changeset version
           publish: yarn publish:packages
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "test": "npm-run-all --serial test:*",
     "test:local": "jest --env jsdom --config jest.config.js",
     "test:ssr": "jest --env jsdom --config ssr.jest.config.js",
-    "version": "yarn changeset version",
     "watch": "yarn build -- -- --watch"
   },
   "devDependencies": {


### PR DESCRIPTION
Using `yarn changeset version` instead of `yarn version` (which just outputs the version of yarn)