### PR TITLE
CLOUDP-123279: Call out font colors for Button Variant hover/active states

### DIFF
--- a/.changeset/tiny-comics-sell.md
+++ b/.changeset/tiny-comics-sell.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/button': patch
+---
+
+Explicitly sets font colors forall variant hover/active states

--- a/.changeset/tiny-comics-sell.md
+++ b/.changeset/tiny-comics-sell.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/button': patch
 ---
 
-Explicitly sets font colors forall variant hover/active states
+Explicitly sets font colors for all variant hover/active states

--- a/packages/button/src/styles.ts
+++ b/packages/button/src/styles.ts
@@ -52,6 +52,7 @@ const colorSet: Record<Mode, Record<Variant, string>> = {
 
       &:hover,
       &:active {
+        color: ${palette.gray.dark3};
         background-color: ${palette.white};
         box-shadow: 0 0 0 3px ${palette.gray.light2};
       }
@@ -78,6 +79,7 @@ const colorSet: Record<Mode, Record<Variant, string>> = {
 
       &:hover,
       &:active {
+        color: ${palette.green.dark2};
         background-color: ${transparentize(0.96, palette.green.base)};
         box-shadow: 0px 0px 0px 3px ${palette.green.light2};
       }
@@ -118,6 +120,7 @@ const colorSet: Record<Mode, Record<Variant, string>> = {
 
       &:hover,
       &:active {
+        color: ${palette.green.dark3};
         background-color: ${mix(0.96, palette.green.base, palette.green.dark3)};
         box-shadow: 0px 0px 0px 3px ${palette.green.light2};
       }
@@ -217,6 +220,7 @@ const colorSet: Record<Mode, Record<Variant, string>> = {
 
       &:hover,
       &:active {
+        color: ${palette.green.dark3};
         background-color: ${mix(
           0.96,
           palette.green.base,


### PR DESCRIPTION
## ✍️ Proposed changes

We noticed an issue where the Button should be using the same font color between normal and hover/active states, but our CSS is overriding the intended behavior here because the color isn't explicitly being called out. I noticed this because the linked ticket uses a `default` button which did not call this out, but using a `primary` button worked as expected.

Thus, we have css globally like
```
a,
a:hover,
a:active {
    color: blue;
}
```

which is sometimes unintentionally applying to LeafyGreen Button Variants that do not specify the hover and active states. This should not change anything else about how the button looks or behaves.

🎟 _Jira ticket:_ [CLOUDP-123279](https://jira.mongodb.org/browse/CLOUDP-123279)

## 🛠 Types of changes

- [ ] Tooling (updates to workspace config or internal tooling)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Style change (purely visual updates; if this is the case, attach a screenshot below!)

## ✅ Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

Check that the button still is looking good for hover/active states.

## Feedback Levels

Please try to mark your comments with one of these levels

1. Praise (👏 🚀 🔥 🍾)
2. Opinions, Ideas, Suggestions (💡 👀)
3. Let’s discuss @ Code review (🤷 🤔 🧐 )
4. Doesn’t meet agreed upon standards (😬 ⚠️ ‼️)
5. Missing an edge case (🛑 🙅 ❌)
6. Missing core functionality (⛔️ ☣️ 🚧 🌋 💀)

(Note: Use ⌘-⌃-␣ to open the Emoji keyboard!)
