### PR TITLE
PD-1900 Select truncation

### DIFF
--- a/.changeset/odd-ants-cheat.md
+++ b/.changeset/odd-ants-cheat.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/select': patch
+---
+
+Fixes a bug where long values, when selected, would overflow outside the Select trigger.

--- a/packages/select/src/MenuButton.tsx
+++ b/packages/select/src/MenuButton.tsx
@@ -12,12 +12,12 @@ import { useForwardedRef } from './utils';
 import { State } from '.';
 
 const menuButtonStyleOverrides = css`
-  text-transform: unset;
-  font-weight: 400;
   // Override button defaults
   > *:last-child {
     grid-template-columns: 1fr 16px;
     padding: 0 12px;
+    justify-content: flex-start;
+
     > svg {
       justify-self: right;
       width: 16px;
@@ -71,6 +71,7 @@ const menuButtonTextWrapperStyle = css`
   align-items: center;
   flex-grow: 1;
   gap: ${spacing[1]}px;
+  overflow: hidden;
 `;
 
 const menuButtonTextStyle = css`
@@ -172,8 +173,8 @@ const MenuButton = React.forwardRef<HTMLElement, Props>(function MenuButton(
   const buttonClassName = __INTERNAL__menuButtonSlot__
     ? ''
     : cx(
-        menuButtonStyleOverrides, // TODO: Refresh - remove overrides
-        menuButtonModeOverrides[mode], // TODO: Refresh - remove overrides
+        menuButtonStyleOverrides,
+        menuButtonModeOverrides[mode],
         {
           [menuButtonDeselectedStyles[mode]]: deselected,
           [menuButtonDisabledStyles[mode]]: disabled,

--- a/packages/select/src/Select.story.tsx
+++ b/packages/select/src/Select.story.tsx
@@ -13,6 +13,10 @@ export default {
     placeholder: 'Select',
     disabled: false,
     children: [
+      <Option key="long" value="long">
+        Cras mattis consectetur purus sit amet fermentum. Maecenas sed diam eget
+        risus varius blandit sit amet non magna.
+      </Option>,
       <OptionGroup key="Common" label="Common">
         <Option value="dog">Dog</Option>
         <Option value="cat">Cat</Option>
@@ -51,6 +55,7 @@ export const Uncontrolled = ({ className, ...args }: SelectProps) => (
     className={cx(
       css`
         min-width: 200px;
+        max-width: 400px;
       `,
       className,
     )}


### PR DESCRIPTION
## ✍️ Proposed changes

Fixes a bug where long values, when selected, would overflow outside the Select trigger.

🎟 _Jira ticket:_ [PD-1900](https://jira.mongodb.org/browse/PD-1900)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Style change (purely visual updates; if this is the case, attach a screenshot below!)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

Select the long value in the "Uncontrolled" Select story

<img width="501" alt="Screen Shot 2022-06-27 at 4 48 36 PM" src="https://user-images.githubusercontent.com/2414030/176033119-0101c309-72fd-4c1a-b4c8-95e11c66faec.png">
