### PR TITLE
PD-2031 Menu focus behavior

### DIFF
--- a/packages/menu/src/Menu.spec.tsx
+++ b/packages/menu/src/Menu.spec.tsx
@@ -7,9 +7,11 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { Menu, MenuSeparator, MenuItem, SubMenu } from '.';
+import userEvent from '@testing-library/user-event';
 
 const menuTestId = 'menu-test-id';
 const className = 'menu-item-class-name';
+const trigger = <button>trigger</button>;
 const onClick = jest.fn();
 
 function renderMenu(props = {}) {
@@ -96,6 +98,65 @@ describe('packages/menu', () => {
       fireEvent.click(button);
 
       await waitForElementToBeRemoved(menuItem);
+    });
+  });
+
+  describe('Mouse interaction', () => {
+    test('Clicking trigger opens menu', () => {
+      const { getByRole, getByTestId } = renderMenu({
+        trigger,
+      });
+      const button = getByRole('button');
+
+      userEvent.click(button);
+      const menu = getByTestId(menuTestId);
+
+      waitFor(() => {
+        expect(menu).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Keyboard Interaction', () => {
+    describe('Escape key', () => {
+      test('Closes menu', async () => {
+        const { getByRole, getByTestId } = renderMenu({
+          trigger,
+        });
+        const button = getByRole('button');
+
+        userEvent.click(button);
+        const menu = getByTestId(menuTestId);
+        userEvent.type(menu, '{esc}');
+
+        await waitForElementToBeRemoved(menu);
+        expect(menu).not.toBeInTheDocument();
+      });
+      test('Returns focus to trigger {usePortal: true}', async () => {
+        const { getByRole, getByTestId } = renderMenu({
+          trigger,
+          usePortal: true,
+        });
+        const button = getByRole('button');
+        userEvent.click(button);
+        const menu = getByTestId(menuTestId);
+        userEvent.type(menu, '{esc}');
+        await waitForElementToBeRemoved(menu);
+        expect(button).toHaveFocus();
+      });
+
+      test('Returns focus to trigger {usePortal: false}', async () => {
+        const { getByRole, getByTestId } = renderMenu({
+          trigger,
+          usePortal: false,
+        });
+        const button = getByRole('button');
+        userEvent.click(button);
+        const menu = getByTestId(menuTestId);
+        userEvent.type(menu, '{esc}');
+        await waitForElementToBeRemoved(menu);
+        expect(button).toHaveFocus();
+      });
     });
   });
 });

--- a/packages/menu/src/Menu.tsx
+++ b/packages/menu/src/Menu.tsx
@@ -202,7 +202,7 @@ function Menu({
 
   const [popoverNode, setPopoverNode] = useState<HTMLUListElement | null>(null);
 
-  const setFocus = (el: HTMLElement) => {
+  const setFocus = (el: HTMLElement | null) => {
     if (el == null) {
       return;
     }
@@ -286,6 +286,7 @@ function Menu({
 
       case keyMap.Escape:
         handleClose();
+        setFocus((refEl || triggerRef)?.current); // Focus the trigger on close
         break;
 
       case keyMap.Space:


### PR DESCRIPTION
## ✍️ Proposed changes

When a menu is closed with the `escape` key, the trigger will regain focus

🎟 _Jira ticket:_ [PD-2031](https://jira.mongodb.org/browse/PD-2031)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Style change (purely visual updates; if this is the case, attach a screenshot below!)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

## Feedback Levels

Please try to mark your comments with one of these levels

1. Praise (👏 🚀 🔥 🍾)
2. Opinions, Ideas, Suggestions (💡 👀)
3. Let’s discuss @ Code review (🤷 🤔 🧐 )
4. Doesn’t meet agreed upon standards (😬 ⚠️ ‼️)
5. Missing an edge case (🛑 🙅 ❌)
6. Missing core functionality (⛔️ ☣️ 🚧 🌋 💀)

(Note: Use ⌘-⌃-␣ to open the Emoji keyboard!)
