### PR TITLE
PD-2361: Remove isDeselection

### DIFF
--- a/.changeset/poor-bears-press.md
+++ b/.changeset/poor-bears-press.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/select': patch
+---
+
+Remove `isDeselection` from `InternalOption`

--- a/packages/select/src/Option.tsx
+++ b/packages/select/src/Option.tsx
@@ -64,7 +64,6 @@ export interface InternalProps extends HTMLElementProps<'li', HTMLLIElement> {
   disabled: boolean;
   onClick: React.MouseEventHandler;
   onFocus: React.FocusEventHandler;
-  isDeselection: boolean;
   hasGlyphs: boolean;
   triggerScrollIntoView: boolean;
 }

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -423,7 +423,6 @@ export default function Select({
         disabled={false}
         onClick={getOptionClickHandler(null, false)}
         onFocus={getOptionFocusHandler(null, false)}
-        isDeselection
         hasGlyphs={false}
         triggerScrollIntoView={selected && canTriggerScrollIntoView}
       >
@@ -455,7 +454,6 @@ export default function Select({
             focused: option === focusedOption,
             disabled,
             children: option.props.children,
-            isDeselection: false,
             hasGlyphs,
             onClick: getOptionClickHandler(option, disabled),
             onFocus: getOptionFocusHandler(option, disabled),


### PR DESCRIPTION
<!--
Thanks for contributing to LeafyGreen!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/leafygreen-ui/blob/main/DEVELOPER.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [PD-2361](https://jira.mongodb.org/browse/PD-2361:)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Style change (purely visual updates; if this is the case, attach a screenshot below!)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->

## 💬 Further comments

This prop was not being used inside `Option` so it was included in `...rest` and then passed to an `Li` element cause react to show a warning.

## Feedback Levels

Please try to mark your comments with one of these levels

1. Praise (👏 🚀 🔥 🍾)
2. Opinions, Ideas, Suggestions (💡 👀)
3. Let’s discuss @ Code review (🤷 🤔 🧐 )
4. Doesn’t meet agreed upon standards (😬 ⚠️ ‼️)
5. Missing an edge case (🛑 🙅 ❌)
6. Missing core functionality (⛔️ ☣️ 🚧 🌋 💀)

(Note: Use ⌘-⌃-␣ to open the Emoji keyboard!)
