### PR TITLE
LG-2489 Combobox overflow

### DIFF
--- a/.changeset/new-dots-fix.md
+++ b/.changeset/new-dots-fix.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/combobox': patch
+---
+
+Fixes a bug where the combobox textinput content would overflow the container

--- a/.changeset/new-dots-fix.md
+++ b/.changeset/new-dots-fix.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/combobox': patch
 ---
 
-Fixes a bug where the combobox textinput content would overflow the container
+Fixes a bug where the combobox Text Input content would overflow the container

--- a/packages/combobox/src/Combobox.story.tsx
+++ b/packages/combobox/src/Combobox.story.tsx
@@ -14,7 +14,6 @@ import {
 
 const wrapperStyle = css`
   width: 256px;
-  height: 100vh;
   padding-block: 64px;
 `;
 

--- a/packages/combobox/src/Combobox.styles.ts
+++ b/packages/combobox/src/Combobox.styles.ts
@@ -50,6 +50,9 @@ export const comboboxPadding: Record<Size, { x: number; y: number }> = {
   },
 };
 
+/** Width of the clear icon (in px) */
+export const clearButtonIconSize = 28
+
 /** Width of the dropdown caret icon (in px) */
 export const caretIconSize = spacing[3];
 
@@ -77,14 +80,16 @@ export const comboboxParentStyle = (size: Size): string => {
 };
 
 export const baseComboboxStyles = css`
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: 1fr ${caretIconSize}px;
   align-items: center;
   cursor: text;
   transition: 150ms ease-in-out;
   transition-property: background-color, box-shadow, border-color;
   border: 1px solid;
-  width: inherit;
+  width: 100%;
+  max-width: 100%;
   border-radius: 6px;
 `;
 
@@ -154,6 +159,10 @@ export const comboboxFocusStyle: Record<Theme, string> = {
   `,
 };
 
+export const comboboxSelectionStyles = css`
+  grid-template-columns: 1fr ${clearButtonIconSize}px ${caretIconSize}px;
+`
+
 export const inputWrapperStyle = ({
   overflow,
   size,
@@ -163,7 +172,7 @@ export const inputWrapperStyle = ({
 }) => {
   const baseWrapperStyle = css`
     flex-grow: 1;
-    width: inherit;
+    width: 100%;
   `;
 
   switch (overflow) {
@@ -202,7 +211,7 @@ export const inputWrapperStyle = ({
         display: flex;
         flex-wrap: wrap;
         gap: 4px;
-        overflow-x: visible;
+        overflow-x: hidden;
         min-height: ${inputHeight[size]}px;
       `;
     }
@@ -280,10 +289,8 @@ export const multiselectInputElementStyle = (
 ) => {
   const inputLength = inputValue?.length ?? 0;
   return css`
-    max-width: 100%;
     width: ${inputLength * maxCharWidth[size]}px;
-    // TODO: This doesn't quite work. Fix this
-    max-width: calc(100% - ${2 * caretIconSize}px);
+    max-width: 100%;
   `;
 };
 

--- a/packages/combobox/src/Combobox.styles.ts
+++ b/packages/combobox/src/Combobox.styles.ts
@@ -51,7 +51,7 @@ export const comboboxPadding: Record<Size, { x: number; y: number }> = {
 };
 
 /** Width of the clear icon (in px) */
-export const clearButtonIconSize = 28
+export const clearButtonIconSize = 28;
 
 /** Width of the dropdown caret icon (in px) */
 export const caretIconSize = spacing[3];
@@ -161,7 +161,7 @@ export const comboboxFocusStyle: Record<Theme, string> = {
 
 export const comboboxSelectionStyles = css`
   grid-template-columns: 1fr ${clearButtonIconSize}px ${caretIconSize}px;
-`
+`;
 
 export const inputWrapperStyle = ({
   overflow,

--- a/packages/combobox/src/Combobox.tsx
+++ b/packages/combobox/src/Combobox.tsx
@@ -67,6 +67,7 @@ import {
   errorMessageSizeStyle,
   labelDescriptionContainerStyle,
   inputElementThemeStyle,
+  comboboxSelectionStyles,
 } from './Combobox.styles';
 import { ComboboxMenu } from './ComboboxMenu/ComboboxMenu';
 
@@ -1232,6 +1233,7 @@ export function Combobox<M extends boolean>({
             comboboxThemeStyles[theme],
             comboboxSizeStyles(size),
             {
+              [comboboxSelectionStyles]: clearable && doesSelectionExist,
               [comboboxDisabledStyles[theme]]: disabled,
               [comboboxErrorStyles[theme]]: state === State.error,
               [comboboxFocusStyle[theme]]: isElementFocused(


### PR DESCRIPTION
## ✍️ Proposed changes

Fixes a bug where the combobox text input content would overflow the container. 

Note: this is hard to write a test for. This is something Chromatic would catch

🎟 _Jira ticket:_ [LG-2489](https://jira.mongodb.org/browse/LG-2489)

## 🛠 Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the applicable boxes.
-->

- [ ] Tooling (updates to workspace config or internal tooling)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Style change (purely visual updates; if this is the case, attach a screenshot below!)

## ✅ Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

<!--
The following only apply when building a new component
-->

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->

## 💬 Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Consider putting screenshots of your addition / change here if there are visual changes, and a gif if motion is a major component of it.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

## Feedback Levels

Please try to mark your comments with one of these levels

1. Praise (👏 🚀 🔥 🍾)
2. Opinions, Ideas, Suggestions (💡 👀)
3. Let’s discuss @ Code review (🤷 🤔 🧐 )
4. Doesn’t meet agreed upon standards (😬 ⚠️ ‼️)
5. Missing an edge case (🛑 🙅 ❌)
6. Missing core functionality (⛔️ ☣️ 🚧 🌋 💀)

(Note: Use ⌘-⌃-␣ to open the Emoji keyboard!)
