### PR TITLE
Remove payload from Repository Dispatch job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
           token: ${{ secrets.DESIGN_REPO_ACCESS_TOKEN }}
           repository: mongodb/design
           event-type: release-leafygreen-ui
-          client-payload: '${{ steps.changesets.outputs.publishedPackages }}'
 
       - name: Notify Slack channel of new releases
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
Only send a trigger, without a payload to the .design repo. 
In the other repo we'll determine what packages were updated

See also: https://github.com/mongodb/design/pull/197