### PR TITLE
Document Polymorphic styled support

### DIFF
--- a/.changeset/odd-ravens-refuse.md
+++ b/.changeset/odd-ravens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/polymorphic': patch
+---
+
+Adds additional styled test, and documents `styled` props best practice

--- a/packages/polymorphic/README.md
+++ b/packages/polymorphic/README.md
@@ -129,6 +129,21 @@ const StyledInferred = styled(MyInferredComponent)`
 ` as InferredPolymorphicComponentType;
 ```
 
+### With styled props (and Typescript)
+
+Since Polymorphic components are strictly typed, to use styled props with Typescript
+you will need to define the additional props you expect to use within styled, and pass these into styled as generic type.
+
+```tsx
+interface StyledProps {
+  color: string;
+}
+
+const MyStyledComponent = styled(MyComponent)<StyledProps>`
+  color: ${props => props.color};
+` as PolymorphicComponentType;
+```
+
 Note: TSDocs will not compile for styled polymorphs. This can be remedied by creating a wrapper around the styled function that explicitly returns a PolymorphicComponentType
 
 ## Supported (but not recommended) usage

--- a/packages/polymorphic/src/Example/examples.spec.tsx
+++ b/packages/polymorphic/src/Example/examples.spec.tsx
@@ -237,6 +237,34 @@ describe('Polymorphic/Example Higher-order Components', () => {
           expect(getByTestId('styled').tagName.toLowerCase()).toBe('span');
           expect(getByTestId('styled')).toHaveStyle(`color: #ff69b4;`);
         });
+
+        test('With styled props', () => {
+          // We need to define the additional props that styled should expect
+          interface StyledProps {
+            color: string;
+            size: string;
+          }
+
+          const StyledExample = styled(ExampleComponent)<StyledProps>`
+            color: ${props => props.color};
+            font-size: ${props => props.size}px;
+          `;
+
+          const { getByTestId } = render(
+            <StyledExample
+              title="Title"
+              data-testid="styled"
+              color="#ff69b4"
+              size="16"
+            >
+              Some text
+            </StyledExample>,
+          );
+          expect(getByTestId('styled')).toBeInTheDocument();
+          expect(getByTestId('styled').tagName.toLowerCase()).toBe('div');
+          expect(getByTestId('styled')).toHaveStyle(`color: #ff69b4;`);
+          expect(getByTestId('styled')).toHaveStyle(`font-size: 16px;`);
+        });
       });
     });
   });


### PR DESCRIPTION
## ✍️ Proposed changes

Adds a test, and documents how to use `emotion/styled` with Polymorphic.

Since Polymorphic components are strictly typed, to use styled props with Typescript you will need to define the additional props you expect to use within styled, and pass these into styled as generic type.

See a generic example here: https://codesandbox.io/s/wizardly-mayer-ktynkt?file=/src/App.tsx

```tsx
interface StyledProps {
  color: string;
}

const MyStyledComponent = styled(MyComponent)<StyledProps>`
  color: ${props => props.color};
` as PolymorphicComponentType;
```