### PR TITLE
LG-3020: Unset text-decoration in Link component

### DIFF
--- a/.changeset/itchy-phones-punch.md
+++ b/.changeset/itchy-phones-punch.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/typography': minor
+---
+
+Overwrites default text-decoration property on Link component

--- a/packages/typography/src/Link/Link.styles.ts
+++ b/packages/typography/src/Link/Link.styles.ts
@@ -5,6 +5,14 @@ import { fontFamilies } from '@leafygreen-ui/tokens';
 
 export const anchorClassName = createUniqueClassName();
 
+export const overwriteDefaultStyles = css`
+  &:hover,
+  &:focus,
+  &:visited {
+    text-decoration: none;
+  }
+`;
+
 export const linkStyles = css`
   font-family: ${fontFamilies.default};
   display: inline-flex;

--- a/packages/typography/src/Link/Link.tsx
+++ b/packages/typography/src/Link/Link.tsx
@@ -21,6 +21,7 @@ import {
   linkModeStyles,
   linkStyles,
   openInNewTabStyles,
+  overwriteDefaultStyles,
   underlineModeStyles,
   underlineStyles,
 } from './Link.styles';
@@ -110,6 +111,7 @@ const Link = InferredPolymorphic<LinkProps, 'span'>(
       <Component
         className={cx(
           anchorClassName,
+          overwriteDefaultStyles,
           bodyTypeScaleStyles[baseFontSize],
           linkStyles,
           linkModeStyles[theme],


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [LG-3020](https://jira.mongodb.org/browse/LG-3020)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
