### PR TITLE
LG-2848: combobox autoscroll fix

### DIFF
--- a/.changeset/few-icons-eat.md
+++ b/.changeset/few-icons-eat.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/combobox': patch
+---
+
+Switch to `useAutoScroll` hook to auto scroll the focused option

--- a/packages/combobox/src/Combobox/Combobox.story.tsx
+++ b/packages/combobox/src/Combobox/Combobox.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ComponentStory } from '@storybook/react';
 
 import Button from '@leafygreen-ui/button';
@@ -102,6 +102,18 @@ export default StoryMeta({
   },
 });
 
+const intervalMS = 2000;
+
+function createRandomItems(count: number): Array<string> {
+  const newItems: Array<string> = [];
+
+  for (let i = 0; i < count; i++) {
+    newItems.push(`Item - ${i}`);
+  }
+
+  return newItems;
+}
+
 const ComboboxOptions = [
   <ComboboxOption
     key="apple"
@@ -179,11 +191,33 @@ const ComboboxOptions = [
   </ComboboxGroup>,
 ];
 
-const Template: ComponentStory<typeof Combobox> = args => (
-  <div className={wrapperStyle}>
-    <Combobox {...args} />
-  </div>
-);
+const Template: ComponentStory<typeof Combobox> = args => {
+  const [changingItems, setChangingItems] = useState<Array<string>>(
+    createRandomItems(5),
+  );
+
+  useEffect(() => {
+    const updateItems = setInterval(() => {
+      const count = Math.floor(Math.random() * 20) + 1;
+      setChangingItems(createRandomItems(count));
+    }, intervalMS);
+
+    return () => {
+      clearInterval(updateItems);
+    };
+  }, []);
+  return (
+    <div className={wrapperStyle}>
+      <div style={{ height: 200, overflow: 'scroll' }}>
+        {changingItems.map(item => (
+          <div key={item}>{item}</div>
+        ))}
+      </div>
+
+      <Combobox {...args} />
+    </div>
+  );
+};
 
 export const SingleSelect = Template.bind({});
 SingleSelect.args = {

--- a/packages/combobox/src/Combobox/Combobox.story.tsx
+++ b/packages/combobox/src/Combobox/Combobox.story.tsx
@@ -102,18 +102,6 @@ export default StoryMeta({
   },
 });
 
-const intervalMS = 2000;
-
-function createRandomItems(count: number): Array<string> {
-  const newItems: Array<string> = [];
-
-  for (let i = 0; i < count; i++) {
-    newItems.push(`Item - ${i}`);
-  }
-
-  return newItems;
-}
-
 const ComboboxOptions = [
   <ComboboxOption
     key="apple"
@@ -192,28 +180,8 @@ const ComboboxOptions = [
 ];
 
 const Template: ComponentStory<typeof Combobox> = args => {
-  const [changingItems, setChangingItems] = useState<Array<string>>(
-    createRandomItems(5),
-  );
-
-  useEffect(() => {
-    const updateItems = setInterval(() => {
-      const count = Math.floor(Math.random() * 20) + 1;
-      setChangingItems(createRandomItems(count));
-    }, intervalMS);
-
-    return () => {
-      clearInterval(updateItems);
-    };
-  }, []);
   return (
     <div className={wrapperStyle}>
-      <div style={{ height: 200, overflow: 'scroll' }}>
-        {changingItems.map(item => (
-          <div key={item}>{item}</div>
-        ))}
-      </div>
-
       <Combobox {...args} />
     </div>
   );

--- a/packages/combobox/src/Combobox/Combobox.story.tsx
+++ b/packages/combobox/src/Combobox/Combobox.story.tsx
@@ -179,13 +179,11 @@ const ComboboxOptions = [
   </ComboboxGroup>,
 ];
 
-const Template: ComponentStory<typeof Combobox> = args => {
-  return (
-    <div className={wrapperStyle}>
-      <Combobox {...args} />
-    </div>
-  );
-};
+const Template: ComponentStory<typeof Combobox> = args => (
+  <div className={wrapperStyle}>
+    <Combobox {...args} />
+  </div>
+);
 
 export const SingleSelect = Template.bind({});
 SingleSelect.args = {

--- a/packages/combobox/src/Combobox/Combobox.story.tsx
+++ b/packages/combobox/src/Combobox/Combobox.story.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { ComponentStory } from '@storybook/react';
 
 import Button from '@leafygreen-ui/button';

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -626,7 +626,9 @@ export function Combobox<M extends boolean>({
         }
       }
     }
-  }, [highlightedOption, getOptionRef]);
+    // getOptionRef should be in the dependency array but it triggered every time the component rerenders causing the menu to scroll all the way to the top when the menu is open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightedOption]);
 
   /**
    * Rendering

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 
 import { cx } from '@leafygreen-ui/emotion';
 import {
+  useAutoScroll,
   useBackdropClick,
   useDynamicRefs,
   useIdAllocator,
@@ -610,25 +611,11 @@ export function Combobox<M extends boolean>({
     }
   }, [inputValue, isOpen, prevValue, updateHighlightedOption]);
 
-  // TODO: Replace this with hooks/useAutoScroll
   // When the focused option changes, update the menu scroll if necessary
-  useEffect(() => {
-    if (highlightedOption) {
-      const focusedElementRef = getOptionRef(highlightedOption);
-
-      if (focusedElementRef && focusedElementRef.current && menuRef.current) {
-        const { offsetTop: optionTop } = focusedElementRef.current;
-        const { scrollTop: menuScroll, offsetHeight: menuHeight } =
-          menuRef.current;
-
-        if (optionTop > menuHeight || optionTop < menuScroll) {
-          menuRef.current.scrollTop = optionTop;
-        }
-      }
-    }
-    // getOptionRef should be in the dependency array but it triggered every time the component rerenders causing the menu to scroll all the way to the top when the menu is open.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [highlightedOption]);
+  useAutoScroll(
+    highlightedOption ? getOptionRef(highlightedOption) : undefined,
+    menuRef,
+  );
 
   /**
    * Rendering


### PR DESCRIPTION
## ✍️ Proposed changes

The issue was that the `getOptionRef` dependency inside the useEffect hook was triggering the ueEffect on every rerender. Switching to the `useAutoScroll` hook fixed this issue since `getOptionRef` is no longer a dependency.

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [LG-2848](https://jira.mongodb.org/browse/LG-2848)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
