### PR TITLE
LG-2958: SearchInput documentation updates

### DIFF
--- a/packages/search-input/README.md
+++ b/packages/search-input/README.md
@@ -34,7 +34,7 @@ import {
   onChange={() => {
     console.log('SB: Change');
   }}
-  {...props}
+  aria-label="some label"
 >
   <SearchResult
     onClick={() => {
@@ -98,4 +98,4 @@ import {
 | ---------- | ----------------------- | -------------------------------------------------------------- | ------- |
 | `children` | `React.ReactNode`       | Must be `<SearchResult/>` or `<SearchResultGroup/>`.           |         |
 | `label`    | `string`                | Title for the group of options.                                |         |
-| `...`      | native `div` attributes | Any other properties will be spread on the root `div` element. |
+| `...`      | native `div` attributes | Any other properties will be spread on the root `div` element. |         |

--- a/packages/search-input/README.md
+++ b/packages/search-input/README.md
@@ -20,14 +20,82 @@ npm install @leafygreen-ui/search-input
 
 ## Example
 
-**Output HTML**
+```js
+import {
+  SearchInput,
+  SearchResult,
+  SearchResultGroup,
+} from '@leafygreen-ui/search-input';
+
+<SearchInput
+  className={css`
+    width: 200px;
+  `}
+  onChange={() => {
+    console.log('SB: Change');
+  }}
+  {...props}
+>
+  <SearchResult
+    onClick={() => {
+      console.log('SB: Click Apple');
+    }}
+    description="This is a description"
+  >
+    Apple
+  </SearchResult>
+  <SearchResult>Banana</SearchResult>
+  <SearchResult as="a" href="#" description="This is a link">
+    Carrot
+  </SearchResult>
+  <SearchResult description="This is a very very long description. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.">
+    Dragonfruit
+  </SearchResult>
+  <SearchResultGroup label="Peppers">
+    <SearchResult description="A moderately hot chili pepper used to flavor dishes">
+      Cayenne
+    </SearchResult>
+    <SearchResult>Ghost pepper</SearchResult>
+    <SearchResult>Habanero</SearchResult>
+    <SearchResult>Jalapeño</SearchResult>
+    <SearchResult>Red pepper</SearchResult>
+    <SearchResult>Scotch bonnet</SearchResult>
+  </SearchResultGroup>
+</SearchInput>;
+```
 
 ## Properties
 
-| Prop            | Type                                          | Description                                                    | Default |
-| --------------- | --------------------------------------------- | -------------------------------------------------------------- | ------- |
-| aria-labelledby | string                                        | Screen-reader label element.                                   |         |
-| state           | "none" \| "loading"                           | The current state of the SearchInput                           | "none"  |
-| darkMode        | boolean                                       | determines whether or not the component appears in dark theme. | false   |
-| sizeVariant     | `'xsmall'`, `'small'`, `'default'`, `'large'` | determines the font size and padding.                          | default |
-| disabled        | boolean                                       | Determines whether the field is currently disabled.            | false   |
+| Prop              | Type                                   | Description                                                                                          | Default   |
+| ----------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------- |
+| `darkMode`        | `boolean`                              | Determines whether or not the component appears in dark theme.                                       | `false`   |
+| `state`           | `'none'`, `'loading'`,                 | The current state of the SearchInput.                                                                | `none`    |
+| `size`            | `'small'`, `'default'`, `'large'`      | Determines the font size, padding and spacing.                                                       | `default` |
+| `disabled`        | `boolean`                              | Determines whether the field is currently disabled.                                                  | `false`   |
+| `value`           | `string`                               | The current value of the text box.                                                                   | `''`      |
+| `placeholder`     | `string`                               | The placeholder text shown in the input field before the user begins typing.                         | `Search`  |
+| `aria-labelledby` | `string`                               | A value for `aria-labelledby`. Allows use of the component with an external `<label>` element.       |           |
+| `aria-label`      | `string`                               | A value for `aria-label`. Allows use of the component without a `label`.                             |           |
+| `onChange`        | `ChangeEventHandler<HTMLInputElement>` | Callback fired when the input value changes. Use this callback to filter the `SearchResult` options. |           |
+| `onSubmit`        | `FormEventHandler<HTMLFormElement>`    | Callback fired when a search result is clicked, or the enter key is pressed.                         | `''`      |
+| `...`             | native `form` attributes               | Any other properties will be spread on the root `form` element.                                      |           |
+
+# SearchResult
+
+## Props
+
+| Prop          | Type                      | Description                                | Default |
+| ------------- | ------------------------- | ------------------------------------------ | ------- |
+| `children`    | `React.ReactNode`         | The value of the result.                   |         |
+| `description` | `React.ReactNode`         | Optional description text.                 |         |
+| `onClick`     | `React.MouseEventHandler` | Callback fired when the option is clicked. |         |
+
+# SearchResultGroup
+
+## Props
+
+| Prop       | Type                    | Description                                                    | Default |
+| ---------- | ----------------------- | -------------------------------------------------------------- | ------- |
+| `children` | `React.ReactNode`       | Must be `<SearchResult/>` or `<SearchResultGroup/>`.           |         |
+| `label`    | `string`                | Title for the group of options.                                |         |
+| `...`      | native `div` attributes | Any other properties will be spread on the root `div` element. |

--- a/packages/search-input/README.md
+++ b/packages/search-input/README.md
@@ -84,11 +84,17 @@ import {
 
 ## Props
 
-| Prop          | Type                      | Description                                | Default |
-| ------------- | ------------------------- | ------------------------------------------ | ------- |
-| `children`    | `React.ReactNode`         | The value of the result.                   |         |
-| `description` | `React.ReactNode`         | Optional description text.                 |         |
-| `onClick`     | `React.MouseEventHandler` | Callback fired when the option is clicked. |         |
+| Prop          | Type                      | Description                                                                                                                                                | Default |
+| ------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `children`    | `React.ReactNode`         | The value of the result.                                                                                                                                   |         |
+| `description` | `React.ReactNode`         | Optional description text.                                                                                                                                 |         |
+| `onClick`     | `React.MouseEventHandler` | Callback fired when the option is clicked.                                                                                                                 |         |
+| `as`          | `React.ElementType`       | The component or element to render as.                                                                                                                     | `li`    |
+| `disabled`    | `boolean`                 | Prevents the option from being selectable.                                                                                                                 | `false` |
+| `highlighted` | `boolean`                 | Defines the currently highlighted option element for keyboard navigation. Not to be confused with selected, which identifies the currently selected option | `false` |
+| `selected`    | `boolean`                 | Whether the component is selected, regardless of keyboard navigation                                                                                       | `false` |
+| `href`        | `string`                  | `href` is required for Anchor tags                                                                                                                         |         |
+| `...`         | native `as` attributes    | Any other properties will be spread on the root `as` element.                                                                                              |
 
 # SearchResultGroup
 

--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.tsx
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.tsx
@@ -20,6 +20,9 @@ import { SearchResultsMenuProps } from './SearchResultsMenu.types';
 
 const MAX_MENU_HEIGHT = 256;
 
+/**
+ * @internal
+ */
 export const SearchResultsMenu = React.forwardRef<
   HTMLUListElement,
   SearchResultsMenuProps

--- a/scripts/utils/tsDocParser.ts
+++ b/scripts/utils/tsDocParser.ts
@@ -33,7 +33,10 @@ const TSDocOptions: ParserOptions = {
   shouldRemoveUndefinedFromOptional: false,
   skipChildrenPropWithoutDoc: false,
   /** Ensures the Polymorphic component gets documented */
-  customComponentTypes: ['PolymorphicComponentType'],
+  customComponentTypes: [
+    'PolymorphicComponentType',
+    'InferredPolymorphicComponentType',
+  ],
   propFilter: (prop, component) => {
     return (
       !skipComponents.includes(component.name) &&
@@ -129,6 +132,7 @@ export function parseTSDoc(
           props: parseProps(props, displayName),
         } as CustomComponentDoc;
       });
+
     const docs: Array<CustomComponentDoc> = uniqBy(parsedDocs, 'displayName');
 
     console.log(chalk.gray(`Parsed TSDoc for:`, chalk.bold(componentName)));

--- a/scripts/utils/tsDocParser.ts
+++ b/scripts/utils/tsDocParser.ts
@@ -132,7 +132,6 @@ export function parseTSDoc(
           props: parseProps(props, displayName),
         } as CustomComponentDoc;
       });
-
     const docs: Array<CustomComponentDoc> = uniqBy(parsedDocs, 'displayName');
 
     console.log(chalk.gray(`Parsed TSDoc for:`, chalk.bold(componentName)));


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [LG-2958](https://jira.mongodb.org/browse/LG-2958)

- Updated README
- `SearchResults` props were missing on .design. This is because the tsDocParser was ignoring the `InferredPolymorphicComponentType` type.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
