### PR TITLE
Removes call to use React's useId if found

### DIFF
--- a/.changeset/hot-adults-whisper.md
+++ b/.changeset/hot-adults-whisper.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/hooks': patch
+---
+
+Removes call to use React 18's useId hook if found

--- a/.changeset/silent-tools-share.md
+++ b/.changeset/silent-tools-share.md
@@ -1,0 +1,25 @@
+---	
+'@leafygreen-ui/a11y': patch	
+'@leafygreen-ui/checkbox': patch	
+'@leafygreen-ui/combobox': patch	
+'@leafygreen-ui/copyable': patch	
+'@leafygreen-ui/expandable-card': patch	
+'@leafygreen-ui/guide-cue': patch	
+'@leafygreen-ui/modal': patch	
+'@leafygreen-ui/number-input': patch	
+'@leafygreen-ui/pagination': patch	
+'@leafygreen-ui/password-input': patch	
+'@leafygreen-ui/radio-box-group': patch	
+'@leafygreen-ui/radio-group': patch	
+'@leafygreen-ui/segmented-control': patch	
+'@leafygreen-ui/select': patch	
+'@leafygreen-ui/side-nav': patch	
+'@leafygreen-ui/table': patch	
+'@leafygreen-ui/tabs': patch	
+'@leafygreen-ui/text-area': patch	
+'@leafygreen-ui/text-input': patch	
+'@leafygreen-ui/toast': patch	
+'@leafygreen-ui/tooltip': patch	
+---	
+
+Bumps to use new `useIdAllocator` hook	

--- a/packages/hooks/src/useIdAllocator.ts
+++ b/packages/hooks/src/useIdAllocator.ts
@@ -1,6 +1,6 @@
 // Currently using Material UI useId hook until we can upgrade to React 18's useId
 // https://github.com/mui/material-ui/blob/master/packages/mui-utils/src/useId.ts
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface Params {
   prefix?: string;
@@ -28,17 +28,7 @@ function useGlobalId({ id: idOverride, prefix }: Params): string {
   return idOverride ? idOverride : `${prefix ?? 'lg'}-${defaultId}`;
 }
 
-// eslint-disable-next-line no-useless-concat -- Workaround for https://github.com/webpack/webpack/issues/14814
-const maybeReactUseId: undefined | (() => string) = (React as any)[
-  'useId' + ''
-];
-
 export default function useId({ prefix, id: idOverride }: Params): string {
-  if (maybeReactUseId !== undefined) {
-    const reactId = maybeReactUseId();
-    return idOverride ?? reactId;
-  }
-
   // eslint-disable-next-line react-hooks/rules-of-hooks -- `React.useId` is invariant at runtime.
   return useGlobalId({ id: idOverride, prefix });
 }


### PR DESCRIPTION
useIdAllocator not compat with React 18 in current version

Repro case here (install Modal locally versus from NPM): https://codesandbox.io/s/green-moon-0j46x2?file=/src/App.tsx