### PR TITLE
LG-3213: Allows null to be passed to SegmentedControl 

### DIFF
--- a/.changeset/nervous-geese-wink.md
+++ b/.changeset/nervous-geese-wink.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/segmented-control': minor
+---
+
+Allows `null` to be passed as children to SegmentedControl component, per React standard

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -145,6 +145,10 @@ export const SegmentedControl = forwardRef<
   const renderedChildren: React.ReactNode = useMemo(
     () =>
       React.Children.map(children, (child, index) => {
+        if (child == null) {
+          return child;
+        }
+
         if (!isComponentType(child, 'SegmentedControlOption')) {
           errorOnce(
             `Error in Segmented Control: ${child} is not a SegmentedControlOption`,


### PR DESCRIPTION
## ✍️ Proposed changes

Per React standard, null should be allowed to be passed as children to React components. https://legacy.reactjs.org/blog/2014/07/17/react-v0.11.html#rendering-to-null

🎟 _Jira ticket:_ [LG-3213](https://jira.mongodb.org/browse/LG-3213)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
