### PR TITLE
Disable Search Menu snapshot

### DIFF
--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.story.tsx
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.story.tsx
@@ -93,5 +93,8 @@ export const Generated: StoryType<typeof SearchResultsMenu> = () => <></>;
 Generated.parameters = {
   chromatic: {
     delay: transitionDuration.slowest,
+    // This test is flaky
+    // FIXME: componentize & test the menu contents
+    disableSnapshot: true,
   },
 };


### PR DESCRIPTION
## ✍️ Proposed changes

The Search Results Menu snapshot is flaky (popover placement at the time of snapshot is inconsistent)

See https://mongodb.chromatic.com/test?appId=642700aa3e49e32bdbf0b0fc&id=649215455914b03356db629b

Disabling snapshot to reduce test noise