### PR TITLE
Pass through test options

### DIFF
--- a/.changeset/seven-bananas-serve.md
+++ b/.changeset/seven-bananas-serve.md
@@ -1,0 +1,6 @@
+---
+'@lg-tools/test': minor
+'@lg-tools/cli': minor
+---
+
+Adds pass-through arguments to `lg test` command. You can now pass through any command accepted by the `jest` cli

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -11,7 +11,7 @@ import { Command } from 'commander';
 const cli = new Command('lg');
 cli
   .description('Command line tools for the LeafyGreen UI library by MongoDB')
-  .enablePositionalOptions();
+  .enablePositionalOptions(true);
 
 /** Create */
 cli
@@ -79,17 +79,14 @@ cli
   .command('test')
   .description('Tests leafygreen-ui packages with unified config.')
   // TODO: Files argument
+  .argument('[pass-through...]', 'Pass-through options for `jest`')
   .option('--watch', 'Watch all files you intend to test', false)
   .option('--ci', 'Runs tests with CI configuration', false)
   .option(
     '--config',
     'Specify a jest config file. By default will look for `jest.config.js` at the root, or use `@lg-tools/test/config`',
   )
-  .option(
-    '-t, --testNamePattern <regex>',
-    'Alias of jest --testNamePattern. Run only tests with a name that matches the regex.',
-    undefined,
-  )
+  .allowUnknownOption(true)
   .action(test);
 
 /** Update */

--- a/tools/test/src/index.ts
+++ b/tools/test/src/index.ts
@@ -6,13 +6,15 @@ import path from 'path';
 export interface TestCommandOptions {
   watch: boolean;
   ci: boolean;
-  testNamePattern?: string;
   config?: string;
 }
 
-export const test = (options: TestCommandOptions) => {
+export const test = (
+  passThrough: Array<string> | string | undefined,
+  options: TestCommandOptions,
+) => {
   const rootDir = process.cwd();
-  const { watch, testNamePattern, ci, config: configParam } = options;
+  const { watch, ci, config: configParam } = options;
   const ciFlags = [
     '--no-cache',
     '--ci',
@@ -20,6 +22,11 @@ export const test = (options: TestCommandOptions) => {
     '--reporters=default',
     '--reporters=jest-junit',
   ];
+  const passThroughOptions = passThrough
+    ? typeof passThrough === 'string'
+      ? [passThrough]
+      : passThrough
+    : [];
 
   const localConfigFile = path.resolve(rootDir, 'jest.config.js');
   const defaultConfigFile = path.resolve(__dirname, '../config/jest.config.js');
@@ -33,13 +40,11 @@ export const test = (options: TestCommandOptions) => {
   spawn(
     'jest',
     [
-      `--config`,
-      configFile,
-      `--rootDir`,
-      rootDir,
+      ...[`--config`, configFile],
+      ...[`--rootDir`, rootDir],
       watch ? '--watch' : '',
-      testNamePattern ? `--testNamePattern=${testNamePattern}` : '',
       ...(ci ? ciFlags : []),
+      ...passThroughOptions,
     ],
     {
       env: {
@@ -49,4 +54,6 @@ export const test = (options: TestCommandOptions) => {
       stdio: 'inherit',
     },
   );
+
+  spawn('echo', [configFile]);
 };

--- a/tools/test/src/index.ts
+++ b/tools/test/src/index.ts
@@ -42,10 +42,9 @@ export const test = (
     ...[`--config`, configFile],
     ...[`--rootDir`, rootDir],
     watch ? '--watch' : '',
-    ...(ci ? ciFlags : []),
-    ...passThroughOptions,
     verbose ? '--verbose' : '',
     ...(ci ? ciFlags : []),
+    ...passThroughOptions,
   ].filter(v => v !== '');
 
   spawn('jest', commandArgs, {

--- a/tools/test/src/test.spec.ts
+++ b/tools/test/src/test.spec.ts
@@ -21,7 +21,7 @@ describe('tools/test', () => {
   });
 
   test('runs basic command', () => {
-    lgTest({
+    lgTest(undefined, {
       watch: false,
       ci: false,
     });
@@ -33,7 +33,7 @@ describe('tools/test', () => {
   });
 
   test('runs with watch flag', () => {
-    lgTest({
+    lgTest(undefined, {
       watch: true,
       ci: false,
     });
@@ -45,7 +45,7 @@ describe('tools/test', () => {
   });
 
   test('runs in ci mode', () => {
-    lgTest({
+    lgTest(undefined, {
       watch: false,
       ci: true,
     });
@@ -64,10 +64,9 @@ describe('tools/test', () => {
   });
 
   test('runs for only specific tests', () => {
-    lgTest({
+    lgTest('--testNamePattern=button', {
       watch: false,
       ci: true,
-      testNamePattern: 'button',
     });
     expect(spawnSpy).toHaveBeenCalledWith(
       'jest',


### PR DESCRIPTION
## ✍️ Proposed changes

Adds pass-through arguments to `lg test` command. You can now pass through any command accepted by the `jest` cli 

## 🧪 How to test changes

```bash
> lg test <any cli option>
```
Jest CLI options: https://jestjs.io/docs/cli
