### PR TITLE
TS & ESlint configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,2 @@
-// For VSCode extensions
-const eslint = require('@lg-tools/lint/config/eslint.config');
-module.exports = eslint;
+const config = require('@lg-tools/lint/config/eslint.config');
+module.exports = { ...config };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "prettier.configPath": "node_modules/@lg-tools/lint/config/prettier.config.js",
   "eslint.lintTask.enable": true,
-  "eslint.lintTask.options": "--config tools/lint/eslint.config.js",
-  "eslint.format.enable": true
+  "eslint.lintTask.options": "--config ./tools/lint/eslint.config.js",
+  "eslint.format.enable": true,
+  "eslint.runtime": "node",
+  "eslint.workingDirectories": ["./"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,20 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@lg-tools/build/config/package.tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "noEmit": true,
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
-    "incremental": true,
-    "target": "ES5",
-    "jsx": "react",
-    "allowJs": true,
-    "pretty": true,
-    "strictNullChecks": true,
-    "noUnusedLocals": false,
-    "esModuleInterop": true,
-    "strict": true,
-    "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
+    "noEmit": true,
+    "incremental": true,
+    "allowJs": true,
     "baseUrl": ".",
-    "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "@leafygreen-ui/icon/dist/*": ["./packages/icon/src/generated/*"],
+      "@leafygreen-ui/*": ["packages/*/src"],
+      "@lg-tools/*": ["tools/*/src"]
+    }
   },
+  "include": ["./packages", "./tools", "./scripts"],
   "exclude": ["node_modules", "**/dist"]
 }


### PR DESCRIPTION
## ✍️ Proposed changes

Updates TS & ESLint configs so VSCode can validate & auto-import properly

## 🧪 How to test changes


• Intentionally break a lint rule. VSCode should show a red squiggle
• Start typing a local import name & accept auto-import suggestion. Should import from `./` instead of `src/`
