### PR TITLE
`tsc` exit code [LG-3561]

### DIFF
--- a/.changeset/gentle-masks-greet.md
+++ b/.changeset/gentle-masks-greet.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/build': patch
+---
+
+Updates ts build script to return the same exit code as `tsc`

--- a/tools/build/src/typescript/build-ts.spec.ts
+++ b/tools/build/src/typescript/build-ts.spec.ts
@@ -2,9 +2,12 @@ import xSpawn from 'cross-spawn';
 
 import { buildTypescript } from './build-ts';
 type SpawnType = ReturnType<typeof xSpawn.spawn>;
+const onCb = (_e: string) => {};
 
 const spawnSpy = jest.spyOn(xSpawn, 'spawn');
-spawnSpy.mockImplementation((...args) => ({} as SpawnType));
+spawnSpy.mockImplementation(
+  (..._args) => ({ on: onCb } as unknown as SpawnType),
+);
 
 describe('tools/build/build-ts', () => {
   test('runs with no options', () => {

--- a/tools/build/src/typescript/build-ts.ts
+++ b/tools/build/src/typescript/build-ts.ts
@@ -18,5 +18,7 @@ export function buildTypescript() {
   spawn('tsc', ['--build', tsConfigPath], {
     cwd: packageDir,
     stdio: 'inherit',
+  }).on('exit', code => {
+    process.exit(code ?? undefined);
   });
 }


### PR DESCRIPTION
## ✍️ Proposed changes

Fixes an issue where TS errors would not cause the build to fail.

🎟 _Jira ticket:_ https://jira.mongodb.org/browse/LG-3516

## 🧪 How to test changes

Make a blatant TS error. Run `yarn build` expect the build to fail
