### PR TITLE
yarn global add node-gyp

### DIFF
--- a/.github/workflows/react17.yml
+++ b/.github/workflows/react17.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install node-gyp
+        run: yarn global add node-gyp
+
       - name: Set react types resolution
         uses: sergeysova/jq-action@v2
         with:


### PR DESCRIPTION
## ✍️ Proposed changes

Globally installs node-gyp when running CI for React 17
