### PR TITLE
Date Picker [LG-3756, LG-3771, LG-3774, LG-3768] Arrow keys in Date Input

### DIFF
--- a/.changeset/little-melons-beam.md
+++ b/.changeset/little-melons-beam.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/lib': minor
+---
+
+Updates Typescript signature of `createSyntheticEvent`

--- a/.changeset/proud-doors-smoke.md
+++ b/.changeset/proud-doors-smoke.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/lib': minor
+---
+
+Creates `rollover` utility function

--- a/.changeset/tall-mice-ring.md
+++ b/.changeset/tall-mice-ring.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/lib': patch
+---
+
+Updates `target` type in `createSyntheticEvent` to extend `EventTarget`

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -39,7 +39,8 @@
     "@leafygreen-ui/button": "^21.0.7",
     "mockdate": "^3.0.5",
     "storybook-mock-date-decorator": "^1.0.1",
-    "timezone-mock": "^1.3.6"
+    "timezone-mock": "^1.3.6",
+    "@jest/globals": "^29.6.2"
   },
   "resolutions": {
     "storybook-mock-date-decorator/@babel/runtime": "7.22.10",

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -783,13 +783,13 @@ describe('packages/date-picker', () => {
     });
 
     describe('Typing', () => {
-      test('opens the menu', async () => {
+      test('does not open the menu', async () => {
         const { yearInput, findMenuElements } = renderDatePicker();
         userEvent.tab();
         expect(yearInput).toHaveFocus();
         userEvent.keyboard('2');
         const { menuContainerEl } = await findMenuElements();
-        expect(menuContainerEl).toBeInTheDocument();
+        expect(menuContainerEl).not.toBeInTheDocument();
       });
 
       test('does not fire a value change handler', () => {

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -703,7 +703,25 @@ describe('packages/date-picker', () => {
        */
       describe('Arrow key', () => {
         describe('Input', () => {
-          test.todo('moves focus to segments');
+          test('right arrow moves focus through segments', () => {
+            const { yearInput, monthInput, dayInput } = renderDatePicker();
+            userEvent.click(yearInput);
+            userEvent.keyboard('{arrowright}');
+            expect(monthInput).toHaveFocus();
+
+            userEvent.keyboard('{arrowright}');
+            expect(dayInput).toHaveFocus();
+          });
+
+          test('left arrow moves focus back through segments', () => {
+            const { yearInput, monthInput, dayInput } = renderDatePicker();
+            userEvent.click(dayInput);
+            userEvent.keyboard('{arrowleft}');
+            expect(monthInput).toHaveFocus();
+
+            userEvent.keyboard('{arrowleft}');
+            expect(yearInput).toHaveFocus();
+          });
         });
         describe('Menu', () => {
           test('left arrow moves focus to the previous day', async () => {
@@ -743,110 +761,110 @@ describe('packages/date-picker', () => {
     });
 
     describe('Typing', () => {
-      describe('Typing into the input', () => {
-        test('opens the menu', async () => {
-          const { yearInput, findMenuElements } = renderDatePicker();
-          userEvent.tab();
-          expect(yearInput).toHaveFocus();
-          userEvent.keyboard('2');
-          const { menuContainerEl } = await findMenuElements();
-          expect(menuContainerEl).toBeInTheDocument();
-        });
+      test('opens the menu', async () => {
+        const { yearInput, findMenuElements } = renderDatePicker();
+        userEvent.tab();
+        expect(yearInput).toHaveFocus();
+        userEvent.keyboard('2');
+        const { menuContainerEl } = await findMenuElements();
+        expect(menuContainerEl).toBeInTheDocument();
+      });
 
-        test('does not fire a value change handler', () => {
-          const onDateChange = jest.fn();
-          const { yearInput } = renderDatePicker({
-            onDateChange,
+      test('does not fire a value change handler', () => {
+        const onDateChange = jest.fn();
+        const { yearInput } = renderDatePicker({
+          onDateChange,
+        });
+        userEvent.type(yearInput, '2023');
+        expect(onDateChange).not.toHaveBeenCalled();
+      });
+
+      test('fires a segment change handler', () => {
+        const onChange = jest.fn();
+        const { yearInput } = renderDatePicker({
+          onChange,
+        });
+        userEvent.type(yearInput, '2023');
+        expect(onChange).toHaveBeenCalledWith(
+          eventContainingTargetValue('2023'),
+        );
+      });
+
+      describe('auto-advances focus', () => {
+        describe('for ISO format', () => {
+          const dateFormat = 'iso8601';
+
+          test('when year value is explicit, focus advances to month', () => {
+            const { yearInput, monthInput } = renderDatePicker({
+              dateFormat,
+            });
+            userEvent.type(yearInput, '1999');
+            expect(monthInput).toHaveFocus();
           });
-          userEvent.type(yearInput, '2023');
-          expect(onDateChange).not.toHaveBeenCalled();
-        });
-
-        test('fires a segment change handler', () => {
-          const onChange = jest.fn();
-          const { yearInput } = renderDatePicker({
-            onChange,
+          test('when year value is ambiguous, focus does not advance', () => {
+            const { yearInput } = renderDatePicker({ dateFormat });
+            userEvent.type(yearInput, '2');
+            expect(yearInput).toHaveFocus();
           });
-          userEvent.type(yearInput, '2023');
-          expect(onChange).toHaveBeenCalledWith(
-            eventContainingTargetValue('2023'),
-          );
-        });
-
-        describe('auto-advance focus', () => {
-          describe('ISO format', () => {
-            const dateFormat = 'iso8601';
-            test('when year value is explicit, focus advances to month', () => {
-              const { yearInput, monthInput } = renderDatePicker({
-                dateFormat,
-              });
-              userEvent.type(yearInput, '1999');
-              expect(monthInput).toHaveFocus();
-            });
-            test('when year value is ambiguous, focus does not advance', () => {
-              const { yearInput } = renderDatePicker({ dateFormat });
-              userEvent.type(yearInput, '2');
-              expect(yearInput).toHaveFocus();
-            });
-            test('when year value is out-of-range, focus does not advance', () => {
-              const { yearInput } = renderDatePicker({ dateFormat });
-              userEvent.type(yearInput, '1945');
-              expect(yearInput).toHaveFocus();
-            });
-
-            test('when month value is explicit, focus advances to day', () => {
-              const { monthInput, dayInput } = renderDatePicker({
-                dateFormat,
-              });
-              userEvent.type(monthInput, '5');
-              expect(dayInput).toHaveFocus();
-            });
-            test('when month value is ambiguous, focus does not advance', () => {
-              const { monthInput } = renderDatePicker({
-                dateFormat,
-              });
-              userEvent.type(monthInput, '1');
-              expect(monthInput).toHaveFocus();
-            });
+          test('when year value is out-of-range, focus does not advance', () => {
+            const { yearInput } = renderDatePicker({ dateFormat });
+            userEvent.type(yearInput, '1945');
+            expect(yearInput).toHaveFocus();
           });
 
-          describe('en-US format', () => {
-            const dateFormat = 'en-US';
-            test('when month value is explicit, focus advances to day', () => {
-              const { monthInput, dayInput } = renderDatePicker({
-                dateFormat,
-              });
-              userEvent.type(monthInput, '5');
-              expect(dayInput).toHaveFocus();
+          test('when month value is explicit, focus advances to day', () => {
+            const { monthInput, dayInput } = renderDatePicker({
+              dateFormat,
             });
-            test('when month value is ambiguous, focus does not advance', () => {
-              const { monthInput } = renderDatePicker({ dateFormat });
-              userEvent.type(monthInput, '1');
-              expect(monthInput).toHaveFocus();
+            userEvent.type(monthInput, '5');
+            expect(dayInput).toHaveFocus();
+          });
+          test('when month value is ambiguous, focus does not advance', () => {
+            const { monthInput } = renderDatePicker({
+              dateFormat,
             });
+            userEvent.type(monthInput, '1');
+            expect(monthInput).toHaveFocus();
+          });
+        });
 
-            test('when day value is explicit, focus advances to year', () => {
-              const { dayInput, yearInput } = renderDatePicker({
-                dateFormat,
-              });
-              userEvent.type(dayInput, '5');
-              expect(yearInput).toHaveFocus();
-            });
-            test('when day value is ambiguous, focus does not advance', () => {
-              const { dayInput } = renderDatePicker({ dateFormat });
-              userEvent.type(dayInput, '2');
-              expect(dayInput).toHaveFocus();
-            });
+        describe('for en-US format', () => {
+          const dateFormat = 'en-US';
 
-            test('when year value is ambiguous, focus does not update', () => {
-              const { monthInput, dayInput, yearInput } = renderDatePicker({
-                dateFormat,
-              });
-              userEvent.type(monthInput, '5');
-              userEvent.type(dayInput, '5');
-              userEvent.type(yearInput, '2');
-              expect(yearInput).toHaveFocus();
+          test('when month value is explicit, focus advances to day', () => {
+            const { monthInput, dayInput } = renderDatePicker({
+              dateFormat,
             });
+            userEvent.type(monthInput, '5');
+            expect(dayInput).toHaveFocus();
+          });
+          test('when month value is ambiguous, focus does not advance', () => {
+            const { monthInput } = renderDatePicker({ dateFormat });
+            userEvent.type(monthInput, '1');
+            expect(monthInput).toHaveFocus();
+          });
+
+          test('when day value is explicit, focus advances to year', () => {
+            const { dayInput, yearInput } = renderDatePicker({
+              dateFormat,
+            });
+            userEvent.type(dayInput, '5');
+            expect(yearInput).toHaveFocus();
+          });
+          test('when day value is ambiguous, focus does not advance', () => {
+            const { dayInput } = renderDatePicker({ dateFormat });
+            userEvent.type(dayInput, '2');
+            expect(dayInput).toHaveFocus();
+          });
+
+          test('when year value is ambiguous, focus does not update', () => {
+            const { monthInput, dayInput, yearInput } = renderDatePicker({
+              dateFormat,
+            });
+            userEvent.type(monthInput, '5');
+            userEvent.type(dayInput, '5');
+            userEvent.type(yearInput, '2');
+            expect(yearInput).toHaveFocus();
           });
         });
       });

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
@@ -55,6 +55,27 @@ describe('packages/date-picker/date-picker-input', () => {
     jest.useFakeTimers().setSystemTime(testDate);
   });
 
+  describe('Typing', () => {
+    test('typing into a segment updates the segment value', () => {
+      const { dayInput } = renderDatePickerInput();
+      userEvent.type(dayInput, '26');
+      expect(dayInput.value).toBe('26');
+    });
+
+    test('segment value is not immediately formatted', () => {
+      const { dayInput } = renderDatePickerInput();
+      userEvent.type(dayInput, '2');
+      expect(dayInput.value).toBe('2');
+    });
+
+    test('value is formatted on segment blur', () => {
+      const { dayInput } = renderDatePickerInput();
+      userEvent.type(dayInput, '2');
+      userEvent.tab();
+      expect(dayInput.value).toBe('02');
+    });
+  });
+
   describe('Keyboard interaction', () => {
     // yyyy-mm-dd
     describe('Left Arrow', () => {

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { newUTC } from '../../shared';
 import {
   DatePickerProvider,
   DatePickerProviderProps,
@@ -46,12 +47,12 @@ const renderDatePickerInput = (
   };
 };
 
+const testDate = newUTC(2023, Month.December, 26);
+
 describe('packages/date-picker/date-picker-input', () => {
   beforeEach(() => {
     // Set the current time to midnight UTC on 2023-12-26
-    jest
-      .useFakeTimers()
-      .setSystemTime(new Date(Date.UTC(2023, Month.December, 26)));
+    jest.useFakeTimers().setSystemTime(testDate);
   });
 
   describe('Keyboard interaction', () => {
@@ -59,27 +60,36 @@ describe('packages/date-picker/date-picker-input', () => {
     describe('Left Arrow', () => {
       test('focuses the previous segment when the segment is empty', () => {
         const { yearInput, monthInput } = renderDatePickerInput();
-        userEvent.type(monthInput, '{arrowleft}');
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowleft}');
         expect(yearInput).toHaveFocus();
       });
 
       test('moves the cursor when the segment has a value', () => {
         const { monthInput } = renderDatePickerInput(null, {
-          value: new Date(),
+          value: testDate,
         });
-        userEvent.type(monthInput, '{arrowleft}');
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowleft}');
         expect(monthInput).toHaveFocus();
       });
 
-      test.todo(
-        'focuses the previous segment if the cursor is at the start of the input text',
-      );
+      // eslint-disable-next-line jest/no-disabled-tests
+      test.skip('focuses the previous segment if the cursor is at the start of the input text', () => {
+        const { yearInput, monthInput } = renderDatePickerInput(null, {
+          value: testDate,
+        });
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowleft}{arrowleft}{arrowleft}');
+        expect(yearInput).toHaveFocus();
+      });
     });
 
     describe('Right Arrow', () => {
       test('focuses the next segment when the segment is empty', () => {
         const { monthInput, dayInput } = renderDatePickerInput();
-        userEvent.type(monthInput, '{arrowright}');
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowright}');
         expect(dayInput).toHaveFocus();
       });
 
@@ -87,13 +97,20 @@ describe('packages/date-picker/date-picker-input', () => {
         const { monthInput } = renderDatePickerInput(null, {
           value: new Date(),
         });
-        userEvent.type(monthInput, '{arrowright}');
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowright}');
         expect(monthInput).toHaveFocus();
       });
 
-      test.todo(
-        'focuses the next segment if the cursor is at the end of the input text',
-      );
+      // eslint-disable-next-line jest/no-disabled-tests
+      test.skip('focuses the next segment if the cursor is at the start of the input text', () => {
+        const { dayInput, monthInput } = renderDatePickerInput(null, {
+          value: testDate,
+        });
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowright}{arrowright}{arrowright}');
+        expect(dayInput).toHaveFocus();
+      });
     });
 
     describe('Backspace key', () => {

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
@@ -74,8 +74,7 @@ describe('packages/date-picker/date-picker-input', () => {
         expect(monthInput).toHaveFocus();
       });
 
-      // eslint-disable-next-line jest/no-disabled-tests
-      test.skip('focuses the previous segment if the cursor is at the start of the input text', () => {
+      test('focuses the previous segment if the cursor is at the start of the input text', () => {
         const { yearInput, monthInput } = renderDatePickerInput(null, {
           value: testDate,
         });
@@ -87,29 +86,28 @@ describe('packages/date-picker/date-picker-input', () => {
 
     describe('Right Arrow', () => {
       test('focuses the next segment when the segment is empty', () => {
-        const { monthInput, dayInput } = renderDatePickerInput();
-        userEvent.click(monthInput);
-        userEvent.keyboard('{arrowright}');
-        expect(dayInput).toHaveFocus();
-      });
-
-      test('moves the cursor when the segment has a value', () => {
-        const { monthInput } = renderDatePickerInput(null, {
-          value: new Date(),
-        });
-        userEvent.click(monthInput);
+        const { yearInput, monthInput } = renderDatePickerInput();
+        userEvent.click(yearInput);
         userEvent.keyboard('{arrowright}');
         expect(monthInput).toHaveFocus();
       });
 
-      // eslint-disable-next-line jest/no-disabled-tests
-      test.skip('focuses the next segment if the cursor is at the start of the input text', () => {
-        const { dayInput, monthInput } = renderDatePickerInput(null, {
+      test('focuses the next segment if the cursor is at the start of the input text', () => {
+        const { yearInput, monthInput } = renderDatePickerInput(null, {
           value: testDate,
         });
-        userEvent.click(monthInput);
-        userEvent.keyboard('{arrowright}{arrowright}{arrowright}');
-        expect(dayInput).toHaveFocus();
+        userEvent.click(yearInput);
+        userEvent.keyboard('{arrowright}');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('moves the cursor when the segment has a value', () => {
+        const { yearInput } = renderDatePickerInput(null, {
+          value: new Date(),
+        });
+        userEvent.click(yearInput);
+        userEvent.keyboard('{arrowleft}{arrowright}');
+        expect(yearInput).toHaveFocus();
       });
     });
 

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
@@ -133,5 +133,57 @@ describe('packages/date-picker/date-picker-input', () => {
         expect(yearInput).toHaveFocus();
       });
     });
+
+    describe('Up Arrow', () => {
+      test('keeps the focus in the current segment', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowup}');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('keeps the focus in the current segment even if the value is valid', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowup}{arrowup}{arrowup}');
+        expect(monthInput).toHaveValue('03');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('Resets the value to the min value when the new value is greater than the max value', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowup}');
+        expect(monthInput).toHaveValue('01');
+        userEvent.keyboard(
+          '{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}',
+        );
+        expect(monthInput).toHaveValue('01');
+      });
+    });
+
+    describe('Down Arrow', () => {
+      test('keeps the focus in the current segment', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowdown}');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('keeps the focus in the current segment even if the value is valid', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowdown}{arrowdown}{arrowdown}');
+        expect(monthInput).toHaveValue('10');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('Resets the value to the max value when the new value is less than the min value', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowdown}');
+        expect(monthInput).toHaveValue('12');
+      });
+    });
   });
 });

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -190,9 +190,6 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
 
       if (isValidSegmentName(segment)) {
         if (!usingArrowKeys) {
-          // if the segment was changed by typing, open the menu
-          openMenu();
-
           if (
             isValidValueForSegment(segment, segmentValue) &&
             isExplicitSegmentValue(segment, segmentValue)

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -156,10 +156,6 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
         case keyMap.Tab:
           // Behavior handled by parent or menu
           break;
-
-        default:
-          // any other keydown should open the menu
-          openMenu();
       }
 
       // call any handler that was passed in
@@ -186,15 +182,20 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
 
     /**
      * Called when any segment changes
+     * If up/down arrows are pressed, don't move to the next segment
      */
     const handleSegmentChange: ChangeEventHandler<HTMLInputElement> = e => {
       const segment = e.target.dataset['segment'];
       const segmentValue = e.target.value;
+      const areUpDownKeys =
+        // @ts-ignore FIXME:
+        e.key === keyMap.ArrowDown || e.key === keyMap.ArrowUp;
 
       if (isValidSegmentName(segment)) {
         if (
           isValidValueForSegment(segment, segmentValue) &&
-          isExplicitSegmentValue(segment, segmentValue)
+          isExplicitSegmentValue(segment, segmentValue) &&
+          !areUpDownKeys
         ) {
           const nextSegment = getRelativeSegment('next', {
             segment: segmentRefs[segment],

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -189,19 +189,25 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
         meta?.key === keyMap.ArrowDown || meta?.key === keyMap.ArrowUp;
 
       if (isValidSegmentName(segment)) {
-        if (
-          isValidValueForSegment(segment, segmentValue) &&
-          isExplicitSegmentValue(segment, segmentValue) &&
-          !usingArrowKeys
-        ) {
-          const nextSegment = getRelativeSegment('next', {
-            segment: segmentRefs[segment],
-            formatParts,
-            segmentRefs,
-          });
+        if (!usingArrowKeys) {
+          // if the segment was changed by typing, open the menu
+          openMenu();
 
-          nextSegment?.current?.focus();
-        } else if (!isValidValueForSegment(segment, segmentValue) && isDirty) {
+          if (
+            isValidValueForSegment(segment, segmentValue) &&
+            isExplicitSegmentValue(segment, segmentValue)
+          ) {
+            const nextSegment = getRelativeSegment('next', {
+              segment: segmentRefs[segment],
+              formatParts,
+              segmentRefs,
+            });
+
+            nextSegment?.current?.focus();
+          }
+        }
+
+        if (!isValidValueForSegment(segment, segmentValue) && isDirty) {
           handleValidation?.(value);
         }
       }
@@ -214,7 +220,6 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
           changeEvent,
           target,
         );
-
         onSegmentChange?.(reactEvent);
       }
     };

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -91,14 +91,15 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
       if (!isSegment) return;
 
       const isSegmentEmpty = isZeroLike(target.value);
-      const cursorPosition = target.selectionEnd;
+
+      const { selectionStart, selectionEnd } = target;
 
       switch (key) {
         case keyMap.ArrowLeft: {
           // if input is empty,
           // or the cursor is at the beginning of the input
           // set focus to prev. input (if it exists)
-          if (isSegmentEmpty || cursorPosition === 0) {
+          if (isSegmentEmpty || selectionStart === 0) {
             const segmentToFocus = getRelativeSegment('prev', {
               segment: target,
               formatParts,
@@ -116,7 +117,7 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
           // if input is empty,
           // or the cursor is at the end of the input
           // set focus to next. input (if it exists)
-          if (isSegmentEmpty || cursorPosition === target.value.length) {
+          if (isSegmentEmpty || selectionEnd === target.value.length) {
             const segmentToFocus = getRelativeSegment('next', {
               segment: target,
               formatParts,

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -5,11 +5,11 @@ import React, {
   KeyboardEventHandler,
   MouseEventHandler,
 } from 'react';
-import { DateInputSegmentChangeEventHandler } from 'src/shared/components/DateInput/DateInputSegment/DateInputSegment.types';
 
 import { createSyntheticEvent, keyMap } from '@leafygreen-ui/lib';
 
 import { DateFormField, DateInputBox } from '../../shared/components/DateInput';
+import { DateInputSegmentChangeEventHandler } from '../../shared/components/DateInput/DateInputSegment';
 import { useDatePickerContext } from '../../shared/components/DatePickerContext';
 import {
   isElementInputSegment,

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
@@ -99,9 +99,9 @@ describe('packages/date-picker/shared/date-input-box', () => {
         undefined,
         testContext,
       );
-      expect(dayInput).toHaveValue(null);
-      expect(monthInput).toHaveValue(null);
-      expect(yearInput).toHaveValue(null);
+      expect(dayInput).toHaveValue('');
+      expect(monthInput).toHaveValue('');
+      expect(yearInput).toHaveValue('');
     });
 
     test('renders a filled text box when value is passed', () => {

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
@@ -192,40 +192,6 @@ describe('packages/date-picker/shared/date-input-box', () => {
       userEvent.tab();
       expect(dayInput.value).toBe('02');
     });
-
-    // TODO:
-    // eslint-disable-next-line jest/no-disabled-tests
-    describe.skip('Auto-focus', () => {
-      test('typing a complete segment value focuses the next segment', () => {
-        const { yearInput, monthInput } = renderDateInputBox(
-          undefined,
-          testContext,
-        );
-        userEvent.type(yearInput, '1993');
-        expect(monthInput).toHaveFocus();
-      });
-
-      test('typing an incomplete segment does not focus the next segment', () => {
-        const { monthInput } = renderDateInputBox(undefined, testContext);
-        userEvent.type(monthInput, '1');
-        expect(monthInput).toHaveFocus();
-      });
-
-      test('typing an incomplete value focuses the next segment if there are no valid second characters', () => {
-        const { monthInput, dayInput } = renderDateInputBox(
-          undefined,
-          testContext,
-        );
-        userEvent.type(monthInput, '2'); // There are no months that start with 2#
-        expect(dayInput).toHaveFocus();
-      });
-
-      test('value is formatted on auto-focus', () => {
-        const { monthInput } = renderDateInputBox(undefined, testContext);
-        userEvent.type(monthInput, '2'); // There are no months that start with 2#
-        expect(monthInput).toHaveValue('02');
-      });
-    });
   });
 
   describe('mouse interaction', () => {
@@ -239,30 +205,6 @@ describe('packages/date-picker/shared/date-input-box', () => {
   });
 
   describe('Keyboard interaction', () => {
-    // Skipping, since {arrowup}/{arrowdown} do not trigger
-    // a change event in userEvent
-    // https://github.com/testing-library/user-event/issues/1066
-    // eslint-disable-next-line jest/no-disabled-tests
-    describe.skip('Up arrow', () => {
-      describe('increments the input value', () => {
-        test('year input', async () => {
-          const { yearInput } = renderDateInputBox({});
-          userEvent.type(yearInput, '2023{arrowup}');
-          expect(yearInput.value).toBe('2024');
-        });
-        test('month input', async () => {
-          const { monthInput } = renderDateInputBox();
-          userEvent.type(monthInput, '9{arrowup}');
-          expect(monthInput.value).toBe('10');
-        });
-        test('day input', async () => {
-          const { dayInput } = renderDateInputBox();
-          userEvent.type(dayInput, '26{arrowup}');
-          expect(dayInput.value).toBe('27');
-        });
-      });
-    });
-
     test('Tab moves focus to next segment', () => {
       const { dayInput, monthInput, yearInput } = renderDateInputBox(
         undefined,
@@ -274,5 +216,8 @@ describe('packages/date-picker/shared/date-input-box', () => {
       userEvent.tab();
       expect(dayInput).toHaveFocus();
     });
+
+    // Arrow key interaction tested in DateInputSegment
+    // & in relevant DatePicker/RangePicker input component
   });
 });

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
@@ -64,7 +64,7 @@ describe('packages/date-picker/shared/date-input-box', () => {
     onChange.mockClear();
   });
 
-  describe('rendering', () => {
+  describe('Rendering', () => {
     describe.each(['day', 'month', 'year'])('%p', segment => {
       test('renders the correct aria attributes', () => {
         const result = renderDateInputBox();
@@ -123,7 +123,7 @@ describe('packages/date-picker/shared/date-input-box', () => {
     });
   });
 
-  describe('typing', () => {
+  describe('Typing', () => {
     test('typing into a segment updates the segment value', () => {
       const { dayInput } = renderDateInputBox(undefined, testContext);
       userEvent.type(dayInput, '26');
@@ -201,7 +201,7 @@ describe('packages/date-picker/shared/date-input-box', () => {
     });
   });
 
-  describe('mouse interaction', () => {
+  describe('Mouse interaction', () => {
     test('click on segment focuses it', () => {
       const { dayInput } = renderDateInputBox(undefined, {
         dateFormat: 'iso8601',

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -68,19 +68,6 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
       prevSegments?: DateSegmentsState,
     ) => {
       const hasAnySegmentChanged = !isEqual(newSegments, prevSegments);
-      // const haveAllSegmentsChanged = Object.entries(newSegments).every(
-      //   ([segment, value]) => prevSegments?.[segment as DateSegment] !== value,
-      // );
-
-      // Trigger segment change events if all segments are updated at once
-      // if (haveAllSegmentsChanged) {
-      //   Object.entries(newSegments).forEach(([segment, value]) => {
-      //     onSegmentChangeProp?.({
-      //       segment: segment as DateSegment,
-      //       value: value as DateSegmentValue,
-      //     });
-      //   });
-      // }
 
       if (hasAnySegmentChanged) {
         const utcDate = newDateFromSegments(newSegments);

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -63,6 +63,11 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
 
     const containerRef = useForwardedRef(fwdRef, null);
 
+    // Store the value of which key is pressed when handleSegmentChange is fired.
+    // This key value will then be passed inside `triggerChangeEventForSegment`
+    // using ref and state will have stale values and we don't need the component to rerender when this value changes
+    let key = '';
+
     /**
      * Fires a synthetic change event
      * and calls the provided `onChange` handler
@@ -71,10 +76,13 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
       const changeEvent = new Event('change');
       const eventTarget = segmentRefs[segment].current;
 
+      console.log('triggerChangeEventForSegment', key);
+
       if (eventTarget) {
         const reactEvent = createSyntheticEvent(
           changeEvent,
           eventTarget,
+          key,
         ) as ChangeEvent<HTMLInputElement>;
         onSegmentChange?.(reactEvent);
       }
@@ -127,6 +135,10 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
     const handleSegmentChange: ChangeEventHandler<HTMLInputElement> = e => {
       const segmentName = e.target.getAttribute('id');
       const newValue = e.target.value;
+
+      // set the value of the key which will then be used
+      // @ts-ignore FIXME:
+      key = e.key;
 
       if (isDateSegment(segmentName)) {
         setSegment(segmentName, newValue);

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.types.ts
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.types.ts
@@ -1,9 +1,8 @@
-import { ChangeEventHandler } from 'react';
-
 import { HTMLElementProps } from '@leafygreen-ui/lib';
 
 import { SegmentRefs } from '../../../hooks';
 import { DateType } from '../../../types';
+import { DateInputSegmentChangeEventHandler } from '../DateInputSegment/DateInputSegment.types';
 
 export interface DateInputBoxProps
   extends Omit<HTMLElementProps<'div'>, 'onChange'> {
@@ -21,7 +20,7 @@ export interface DateInputBoxProps
   /**
    * Callback fired when any segment changes, but not necessarily a full value
    */
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: DateInputSegmentChangeEventHandler;
 
   /**
    * id of the labelling element

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.spec.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
+import { jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mean } from 'lodash';
+import { mean, round } from 'lodash';
 
 import { defaultMax, defaultMin } from '../../../constants';
 import { DateSegment } from '../../../hooks';
-import { eventContainingTargetValue } from '../../../utils/testutils';
+import { getValueFormatter } from '../../../utils';
 
+import { DateInputSegmentChangeEventHandler } from './DateInputSegment.types';
 import { DateInputSegment, type DateInputSegmentProps } from '.';
 
-const onChangeHandler = jest.fn();
+const onChangeHandler = jest.fn<DateInputSegmentChangeEventHandler>();
 
 const renderSegment = (props: DateInputSegmentProps) => {
   const result = render(<DateInputSegment {...props} />);
@@ -97,7 +99,18 @@ describe('packages/date-picker/shared/date-input-segment', () => {
       const input = result.getByTestId('lg-date_picker_input-segment');
       userEvent.type(input, '8');
       expect(onChangeHandler).toHaveBeenCalledWith(
-        eventContainingTargetValue('8'),
+        expect.objectContaining({ value: '8' }),
+      );
+    });
+
+    test('allows leading zeroes', () => {
+      const result = render(
+        <DateInputSegment segment="day" onChange={onChangeHandler} />,
+      );
+      const input = result.getByTestId('lg-date_picker_input-segment');
+      userEvent.type(input, '0');
+      expect(onChangeHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ value: '0' }),
       );
     });
 
@@ -111,101 +124,137 @@ describe('packages/date-picker/shared/date-input-segment', () => {
     });
   });
 
-  describe('Arrow Keys', () => {
-    const testCases: Array<DateSegment> = ['day', 'month', 'year'];
-
-    describe.each(testCases)('in %p input', segment => {
-      const minValue = defaultMin[segment];
-      const maxValue = defaultMax[segment];
-      const defaultValue = mean([minValue, maxValue]);
-
-      describe('Up arrow', () => {
-        test('calls handler with value + 1', () => {
-          const result = render(
-            <DateInputSegment
-              segment={segment}
-              onChange={onChangeHandler}
-              value={`${defaultValue}`}
-            />,
-          );
-          const input = result.getByTestId('lg-date_picker_input-segment');
-          userEvent.type(input, '{arrowup}');
-          expect(onChangeHandler).toHaveBeenCalledWith(
-            eventContainingTargetValue(`${defaultValue + 1}`),
-          );
-        });
-
-        test('calls handler with `min` if initially undefined', () => {
-          const result = render(
-            <DateInputSegment onChange={onChangeHandler} segment={segment} />,
-          );
-          const input = result.getByTestId('lg-date_picker_input-segment');
-
-          userEvent.type(input, '{arrowup}');
-          expect(onChangeHandler).toHaveBeenCalledWith(
-            eventContainingTargetValue(`${minValue}`),
-          );
-        });
-
-        test('calls handler with `min` when the new value is greater than the `max` value', () => {
-          const result = render(
-            <DateInputSegment
-              onChange={onChangeHandler}
-              segment={segment}
-              value={`${maxValue}`}
-            />,
-          );
-          const input = result.getByTestId('lg-date_picker_input-segment');
-
-          userEvent.type(input, '{arrowup}');
-          expect(onChangeHandler).toHaveBeenCalledWith(
-            eventContainingTargetValue(`${minValue}`),
-          );
-        });
+  describe('Keyboard', () => {
+    describe('Backspace', () => {
+      test('deletes value in the input', () => {
+        const result = render(
+          <DateInputSegment
+            segment="day"
+            onChange={onChangeHandler}
+            value="26"
+          />,
+        );
+        const input = result.getByTestId('lg-date_picker_input-segment');
+        userEvent.type(input, '{backspace}');
+        expect(onChangeHandler).toHaveBeenCalledWith(
+          expect.objectContaining({ value: '2' }),
+        );
       });
 
-      describe('Down arrow', () => {
-        test('calls handler with value - 1', () => {
-          const result = render(
-            <DateInputSegment
-              segment={segment}
-              onChange={onChangeHandler}
-              value={`${defaultValue}`}
-            />,
-          );
-          const input = result.getByTestId('lg-date_picker_input-segment');
-          userEvent.type(input, '{arrowdown}');
-          expect(onChangeHandler).toHaveBeenCalledWith(
-            eventContainingTargetValue(`${defaultValue - 1}`),
-          );
+      test('fully clears the input', () => {
+        const result = render(
+          <DateInputSegment
+            segment="day"
+            onChange={onChangeHandler}
+            value="2"
+          />,
+        );
+        const input = result.getByTestId('lg-date_picker_input-segment');
+        userEvent.type(input, '{backspace}');
+        expect(onChangeHandler).toHaveBeenCalledWith(
+          expect.objectContaining({ value: '' }),
+        );
+      });
+    });
+
+    describe('Arrow Keys', () => {
+      const testCases: Array<DateSegment> = ['day', 'month', 'year'];
+
+      describe.each(testCases)('in %p input', segment => {
+        const formatter = getValueFormatter(segment);
+
+        const minValue = defaultMin[segment];
+        const maxValue = defaultMax[segment];
+        const defaultValue = round(mean([minValue, maxValue]));
+
+        describe('Up arrow', () => {
+          test('calls handler with value +1', () => {
+            const result = render(
+              <DateInputSegment
+                segment={segment}
+                onChange={onChangeHandler}
+                value={`${defaultValue}`}
+              />,
+            );
+            const input = result.getByTestId('lg-date_picker_input-segment');
+            userEvent.type(input, '{arrowup}');
+            expect(onChangeHandler).toHaveBeenCalledWith(
+              expect.objectContaining({ value: formatter(defaultValue + 1) }),
+            );
+          });
+
+          test('calls handler with `min` if initially undefined', () => {
+            const result = render(
+              <DateInputSegment onChange={onChangeHandler} segment={segment} />,
+            );
+            const input = result.getByTestId('lg-date_picker_input-segment');
+
+            userEvent.type(input, '{arrowup}');
+            expect(onChangeHandler).toHaveBeenCalledWith(
+              expect.objectContaining({ value: formatter(minValue) }),
+            );
+          });
+
+          test('calls handler with `min` when the new value is greater than the `max` value', () => {
+            const result = render(
+              <DateInputSegment
+                onChange={onChangeHandler}
+                segment={segment}
+                value={`${maxValue}`}
+              />,
+            );
+            const input = result.getByTestId('lg-date_picker_input-segment');
+
+            userEvent.type(input, '{arrowup}');
+            expect(onChangeHandler).toHaveBeenCalledWith(
+              expect.objectContaining({ value: formatter(minValue) }),
+            );
+          });
         });
 
-        test('calls handler with `max` if initially undefined', () => {
-          const result = render(
-            <DateInputSegment onChange={onChangeHandler} segment={segment} />,
-          );
-          const input = result.getByTestId('lg-date_picker_input-segment');
+        describe('Down arrow', () => {
+          test('calls handler with value -1', () => {
+            const result = render(
+              <DateInputSegment
+                segment={segment}
+                onChange={onChangeHandler}
+                value={`${defaultValue}`}
+              />,
+            );
+            const input = result.getByTestId('lg-date_picker_input-segment');
+            userEvent.type(input, '{arrowdown}');
+            expect(onChangeHandler).toHaveBeenCalledWith(
+              expect.objectContaining({ value: formatter(defaultValue - 1) }),
+            );
+          });
 
-          userEvent.type(input, '{arrowdown}');
-          expect(onChangeHandler).toHaveBeenCalledWith(
-            eventContainingTargetValue(`${maxValue}`),
-          );
-        });
+          test('calls handler with `max` if initially undefined', () => {
+            const result = render(
+              <DateInputSegment onChange={onChangeHandler} segment={segment} />,
+            );
+            const input = result.getByTestId('lg-date_picker_input-segment');
 
-        test('calls handler with `max` value when the new value is less than the `min` value', () => {
-          const result = render(
-            <DateInputSegment
-              onChange={onChangeHandler}
-              segment={segment}
-              value={`${minValue}`}
-            />,
-          );
-          const input = result.getByTestId('lg-date_picker_input-segment');
+            userEvent.type(input, '{arrowdown}');
+            expect(onChangeHandler).toHaveBeenCalledWith(
+              expect.objectContaining({ value: formatter(maxValue) }),
+            );
+          });
 
-          userEvent.type(input, '{arrowdown}');
-          expect(onChangeHandler).toHaveBeenCalledWith(
-            eventContainingTargetValue(`${maxValue}`),
-          );
+          test('calls handler with `max` value when the new value is less than the `min` value', () => {
+            const result = render(
+              <DateInputSegment
+                onChange={onChangeHandler}
+                segment={segment}
+                value={`${minValue}`}
+              />,
+            );
+            const input = result.getByTestId('lg-date_picker_input-segment');
+
+            userEvent.type(input, '{arrowdown}');
+            expect(onChangeHandler).toHaveBeenCalledWith(
+              expect.objectContaining({ value: formatter(maxValue) }),
+            );
+          });
         });
       });
     });

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.spec.tsx
@@ -6,7 +6,7 @@ import { eventContainingTargetValue } from '../../../utils/testutils';
 
 import { DateInputSegment, type DateInputSegmentProps } from '.';
 
-const handler = jest.fn();
+const onChangeHandler = jest.fn();
 
 const renderSegment = (props: DateInputSegmentProps) => {
   const result = render(<DateInputSegment {...props} />);
@@ -18,8 +18,8 @@ const renderSegment = (props: DateInputSegmentProps) => {
 };
 
 describe('packages/date-picker/shared/date-input-segment', () => {
-  beforeEach(() => {
-    handler.mockClear();
+  afterEach(() => {
+    onChangeHandler.mockClear();
   });
 
   describe('rendering', () => {
@@ -89,44 +89,54 @@ describe('packages/date-picker/shared/date-input-segment', () => {
   describe('Typing', () => {
     test('calls the change handler', () => {
       const result = render(
-        <DateInputSegment segment="day" onChange={handler} />,
+        <DateInputSegment segment="day" onChange={onChangeHandler} />,
       );
       const input = result.getByTestId('lg-date_picker_input-segment');
-      userEvent.type(input, '12');
-      expect(handler).toHaveBeenCalledWith(eventContainingTargetValue('12'));
+      userEvent.type(input, '8');
+      expect(onChangeHandler).toHaveBeenCalledWith(
+        eventContainingTargetValue('8'),
+      );
     });
 
     test('does not allow non-number characters', () => {
       const result = render(
-        <DateInputSegment segment="day" onChange={handler} />,
+        <DateInputSegment segment="day" onChange={onChangeHandler} />,
       );
       const input = result.getByTestId('lg-date_picker_input-segment');
       userEvent.type(input, 'aB$/');
-      expect(handler).not.toHaveBeenCalled();
+      expect(onChangeHandler).not.toHaveBeenCalled();
     });
   });
 
-  // Skipping, since {arrowup}/{arrowdown} do not trigger
-  // a change event in userEvent
-  // https://github.com/testing-library/user-event/issues/1066
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('Arrow Keys', () => {
+  describe('Arrow Keys', () => {
     test('ArrowUp calls handler with +1', () => {
       const result = render(
-        <DateInputSegment segment="day" onChange={handler} value={'08'} />,
+        <DateInputSegment
+          segment="day"
+          onChange={onChangeHandler}
+          value={'08'}
+        />,
       );
       const input = result.getByTestId('lg-date_picker_input-segment');
       userEvent.type(input, '{arrowup}');
-      expect(handler).toHaveBeenCalledWith('09');
+      expect(onChangeHandler).toHaveBeenCalledWith(
+        eventContainingTargetValue('9'),
+      );
     });
 
     test('ArrowDown calls handler with -1', () => {
       const result = render(
-        <DateInputSegment segment="day" onChange={handler} value={'08'} />,
+        <DateInputSegment
+          segment="day"
+          onChange={onChangeHandler}
+          value={'08'}
+        />,
       );
       const input = result.getByTestId('lg-date_picker_input-segment');
       userEvent.type(input, '{arrowdown}');
-      expect(handler).toHaveBeenCalledWith('07');
+      expect(onChangeHandler).toHaveBeenCalledWith(
+        eventContainingTargetValue('7'),
+      );
     });
   });
 });

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.spec.tsx
@@ -95,6 +95,15 @@ describe('packages/date-picker/shared/date-input-segment', () => {
       userEvent.type(input, '12');
       expect(handler).toHaveBeenCalledWith(eventContainingTargetValue('12'));
     });
+
+    test('does not allow non-number characters', () => {
+      const result = render(
+        <DateInputSegment segment="day" onChange={handler} />,
+      );
+      const input = result.getByTestId('lg-date_picker_input-segment');
+      userEvent.type(input, 'aB$/');
+      expect(handler).not.toHaveBeenCalled();
+    });
   });
 
   // Skipping, since {arrowup}/{arrowdown} do not trigger

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.tsx
@@ -7,7 +7,7 @@ import React, {
 import { cx } from '@leafygreen-ui/emotion';
 import { useForwardedRef } from '@leafygreen-ui/hooks';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
-import { createSyntheticEvent, keyMap } from '@leafygreen-ui/lib';
+import { createSyntheticEvent, keyMap, rollover } from '@leafygreen-ui/lib';
 import { Size } from '@leafygreen-ui/tokens';
 import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 
@@ -73,34 +73,31 @@ export const DateInputSegment = React.forwardRef<
 
     /** Synthetically fire ChangeEvents when the up/down arrow keys are pressed */
     const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = e => {
-      const { key, target } = e;
+      const { key, target, ...rest } =
+        e as React.KeyboardEvent<HTMLInputElement> & {
+          target: HTMLInputElement;
+        };
 
-      switch (key) {
-        case keyMap.ArrowUp: {
-          e.preventDefault();
-          const incrementedValue = (Number(value) + 1).toString();
-          (target as HTMLInputElement).value = incrementedValue;
-          const changeEvent = createSyntheticEvent<
-            ChangeEvent<HTMLInputElement>
-          >(new Event('change'), target as HTMLInputElement);
-          onChange?.(changeEvent);
-          break;
-        }
+      if (key === keyMap.ArrowUp || key === keyMap.ArrowDown) {
+        e.preventDefault();
+        const valueDiff = key === keyMap.ArrowUp ? 1 : -1;
 
-        case keyMap.ArrowDown: {
-          e.preventDefault();
-          const decrementedValue = (Number(value) - 1).toString();
-          (target as HTMLInputElement).value = decrementedValue;
-          const changeEvent = createSyntheticEvent<
-            ChangeEvent<HTMLInputElement>
-          >(new Event('change'), target as HTMLInputElement);
-          onChange?.(changeEvent);
+        const initialValue = value
+          ? Number(value)
+          : key === keyMap.ArrowUp
+          ? max
+          : min;
 
-          break;
-        }
+        const newValue = rollover(initialValue + valueDiff, min, max);
+        const valueString = newValue.toString();
 
-        default:
-          break;
+        target.value = valueString;
+        const nativeEvent = new Event('change', { ...rest });
+        const changeEvent = createSyntheticEvent<ChangeEvent<HTMLInputElement>>(
+          nativeEvent,
+          target,
+        );
+        onChange?.(changeEvent);
       }
 
       onKeyDown?.(e);

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.tsx
@@ -1,12 +1,22 @@
-import React from 'react';
+import React, {
+  ChangeEvent,
+  ChangeEventHandler,
+  KeyboardEventHandler,
+} from 'react';
 
 import { cx } from '@leafygreen-ui/emotion';
 import { useForwardedRef } from '@leafygreen-ui/hooks';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import { createSyntheticEvent, keyMap } from '@leafygreen-ui/lib';
 import { Size } from '@leafygreen-ui/tokens';
 import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 
-import { defaultMax, defaultMin, defaultPlaceholder } from '../../../constants';
+import {
+  charsPerSegment,
+  defaultMax,
+  defaultMin,
+  defaultPlaceholder,
+} from '../../../constants';
 import { useDatePickerContext } from '../../DatePickerContext';
 
 import {
@@ -36,6 +46,7 @@ export const DateInputSegment = React.forwardRef<
       max: maxProp,
       onChange,
       onBlur,
+      onKeyDown,
       darkMode,
       ...rest
     }: DateInputSegmentProps,
@@ -49,21 +60,71 @@ export const DateInputSegment = React.forwardRef<
     const { theme } = useDarkMode(darkMode);
     const baseFontSize = useUpdatedBaseFontSize();
     const { size, disabled } = useDatePickerContext();
+    const pattern = `[0-9]{${charsPerSegment.year}}`;
 
+    const handleChange: ChangeEventHandler<HTMLInputElement> = e => {
+      const { target } = e;
+      const numericValue = Number(target.value);
+
+      if (!isNaN(numericValue)) {
+        onChange?.(e);
+      }
+    };
+
+    /** Synthetically fire ChangeEvents when the up/down arrow keys are pressed */
+    const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = e => {
+      const { key, target } = e;
+
+      switch (key) {
+        case keyMap.ArrowUp: {
+          e.preventDefault();
+          const incrementedValue = (Number(value) + 1).toString();
+          (target as HTMLInputElement).value = incrementedValue;
+          const changeEvent = createSyntheticEvent<
+            ChangeEvent<HTMLInputElement>
+          >(new Event('change'), target as HTMLInputElement);
+          onChange?.(changeEvent);
+          break;
+        }
+
+        case keyMap.ArrowDown: {
+          e.preventDefault();
+          const decrementedValue = (Number(value) - 1).toString();
+          (target as HTMLInputElement).value = decrementedValue;
+          const changeEvent = createSyntheticEvent<
+            ChangeEvent<HTMLInputElement>
+          >(new Event('change'), target as HTMLInputElement);
+          onChange?.(changeEvent);
+
+          break;
+        }
+
+        default:
+          break;
+      }
+
+      onKeyDown?.(e);
+    };
+
+    // Note: Using a text input with pattern attribute due to Firefox
+    // stripping leading zeros on number inputs - Thanks @matt-d-rat
+    // Number inputs also don't support the `selectionStart`/`End` API
     return (
       <input
         {...rest}
         aria-label={segment}
         id={segment}
         ref={inputRef}
-        type="number"
+        type="text"
+        pattern={pattern}
         role="spinbutton"
         value={value}
         min={min}
         max={max}
         placeholder={defaultPlaceholder[segment]}
-        onChange={onChange}
+        onChange={handleChange}
         onBlur={onBlur}
+        onKeyDown={handleKeyDown}
         disabled={disabled}
         data-testid="lg-date_picker_input-segment"
         data-segment={segment}

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.types.ts
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.types.ts
@@ -1,10 +1,23 @@
-import { DarkModeProps, HTMLElementProps } from '@leafygreen-ui/lib';
+import { DarkModeProps, HTMLElementProps, keyMap } from '@leafygreen-ui/lib';
 
 import { DateSegment, DateSegmentValue } from '../../../hooks';
 
+export interface DateInputSegmentChangeEvent {
+  segment: DateSegment;
+  value: DateSegmentValue;
+  meta?: {
+    key?: (typeof keyMap)[keyof typeof keyMap];
+    [key: string]: any;
+  };
+}
+
+export type DateInputSegmentChangeEventHandler = (
+  dateSegmentChangeEvent: DateInputSegmentChangeEvent,
+) => void;
+
 export interface DateInputSegmentProps
   extends DarkModeProps,
-    HTMLElementProps<'input'> {
+    Omit<HTMLElementProps<'input'>, 'onChange'> {
   /** Which date segment this input represents. Determines the aria-label, and min/max values where relevant */
   segment: DateSegment;
 
@@ -16,4 +29,6 @@ export interface DateInputSegmentProps
 
   /** Optional maximum value. Defaults to 31 for day, 12 for month, 2038 for year */
   max?: number;
+
+  onChange?: DateInputSegmentChangeEventHandler;
 }

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/index.ts
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/index.ts
@@ -1,2 +1,5 @@
 export { DateInputSegment } from './DateInputSegment';
-export { type DateInputSegmentProps } from './DateInputSegment.types';
+export {
+  type DateInputSegmentChangeEventHandler,
+  type DateInputSegmentProps,
+} from './DateInputSegment.types';

--- a/packages/date-picker/src/shared/hooks/useDateSegments/DateSegments.types.ts
+++ b/packages/date-picker/src/shared/hooks/useDateSegments/DateSegments.types.ts
@@ -29,7 +29,11 @@ export interface UseDateSegmentsOptions {
   onUpdate?: OnUpdateCallback;
 }
 
+export type SetSegmentCallback = (
+  segment: DateSegment,
+  value: DateSegmentValue,
+) => void;
 export interface UseDateSegmentsReturnValue {
   segments: DateSegmentsState;
-  setSegment: (segment: DateSegment, value: DateSegmentValue) => void;
+  setSegment: SetSegmentCallback;
 }

--- a/packages/date-picker/src/shared/utils/index.ts
+++ b/packages/date-picker/src/shared/utils/index.ts
@@ -4,7 +4,7 @@ export { doesSomeSegmentExist } from './doesSomeSegmentExist';
 export { getDaysInUTCMonth } from './getDaysInUTCMonth';
 export { getFirstEmptySegment } from './getFirstEmptySegment';
 export { getFirstOfMonth } from './getFirstOfMonth';
-export { getFormatParts } from './getFormatParts';
+export { getFormatParts, getFormatter } from './getFormatParts';
 export { getFullMonthLabel } from './getFullMonthLabel';
 export { getISODate } from './getISODate';
 export { getLastOfMonth } from './getLastOfMonth';

--- a/packages/date-picker/src/shared/utils/isSameUTCDay/isSameUTCDay.spec.ts
+++ b/packages/date-picker/src/shared/utils/isSameUTCDay/isSameUTCDay.spec.ts
@@ -1,57 +1,55 @@
 import tzMock from 'timezone-mock';
 
-import { Month } from '../../constants';
-
 import { isSameUTCDay } from '.';
 
 describe('packages/date-picker/utils/isSameUTCDay', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     tzMock.register('US/Eastern');
   });
 
-  beforeEach(() => {
-    jest
-      .useFakeTimers()
-      .setSystemTime(new Date(Date.UTC(2023, Month.September, 1, 0, 0, 0)));
+  describe(' when both dates are defined in UTC', () => {
+    test('returns true', () => {
+      const utc1 = new Date(Date.UTC(2023, 8, 1, 0, 0, 0));
+      const utc2 = new Date(Date.UTC(2023, 8, 1, 21, 0, 0));
+      expect(isSameUTCDay(utc1, utc2)).toBe(true);
+    });
+
+    test('returns false', () => {
+      const utc1 = new Date(Date.UTC(2023, 8, 1, 0, 0, 0));
+      const utc2 = new Date(Date.UTC(2023, 8, 2, 0, 0, 0));
+      expect(isSameUTCDay(utc1, utc2)).toBe(false);
+    });
   });
 
-  test('true: when both dates are defined in UTC', () => {
-    const utc1 = new Date(Date.UTC(2023, 8, 1, 0, 0, 0));
-    const utc2 = new Date(Date.UTC(2023, 8, 1, 21, 0, 0));
-    expect(isSameUTCDay(utc1, utc2)).toBe(true);
+  describe('when one date is defined locally', () => {
+    test('returns true ', () => {
+      const utc = new Date(Date.UTC(2023, 8, 10, 0, 0, 0));
+      const local = new Date('2023-09-09T21:00:00'); //2023-09-10T01:00:00Z
+      expect(isSameUTCDay(utc, local)).toBe(true);
+    });
+
+    test('returns false', () => {
+      const utc = new Date(Date.UTC(2023, 8, 10));
+      const local = new Date('2023-09-09T12:00'); //2023-09-09T16:00:00Z
+      expect(isSameUTCDay(utc, local)).toBe(false);
+    });
   });
 
-  test('false: when both dates are defined in UTC', () => {
-    const utc1 = new Date(Date.UTC(2023, 8, 1, 0, 0, 0));
-    const utc2 = new Date(Date.UTC(2023, 8, 2, 0, 0, 0));
-    expect(isSameUTCDay(utc1, utc2)).toBe(false);
+  describe('when both dates are defined locally', () => {
+    test('returns true', () => {
+      const local1 = new Date('2023-09-09T00:00');
+      const local2 = new Date('2023-09-09T19:00');
+      expect(isSameUTCDay(local1, local2)).toBe(true);
+    });
+
+    test('returns false', () => {
+      const local1 = new Date('2023-09-09T00:00');
+      const local2 = new Date('2023-09-09T20:00');
+      expect(isSameUTCDay(local1, local2)).toBe(false);
+    });
   });
 
-  test('true: when one date is defined locally', () => {
-    const utc = new Date(Date.UTC(2023, 8, 10, 0, 0, 0));
-    const local = new Date('2023-09-09T21:00:00'); //2023-09-10T01:00:00Z
-    expect(isSameUTCDay(utc, local)).toBe(true);
-  });
-
-  test('false: when one date is defined locally', () => {
-    const utc = new Date(Date.UTC(2023, 8, 10));
-    const local = new Date('2023-09-09T12:00'); //2023-09-09T16:00:00Z
-    expect(isSameUTCDay(utc, local)).toBe(false);
-  });
-
-  test('true: when both dates are defined locally', () => {
-    const local1 = new Date('2023-09-09T00:00');
-    const local2 = new Date('2023-09-09T19:00');
-    expect(isSameUTCDay(local1, local2)).toBe(true);
-  });
-
-  test('false: when both dates are defined locally', () => {
-    const local1 = new Date('2023-09-09T00:00');
-    const local2 = new Date('2023-09-09T20:00');
-    expect(isSameUTCDay(local1, local2)).toBe(false);
-  });
-
-  test('false: when one or both dates is null', () => {
+  test('returns false when one or both dates is null', () => {
     expect(isSameUTCDay(new Date(), null)).toBe(false);
     expect(isSameUTCDay(null, new Date())).toBe(false);
     expect(isSameUTCDay(null, null)).toBe(false);

--- a/packages/date-picker/src/shared/utils/isSameUTCMonth/isSameUTCMonth.spec.ts
+++ b/packages/date-picker/src/shared/utils/isSameUTCMonth/isSameUTCMonth.spec.ts
@@ -5,50 +5,50 @@ import { Month } from '../../constants';
 import { isSameUTCMonth } from '.';
 
 describe('packages/date-picker/utils/isSameUTCMonth', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     tzMock.register('US/Eastern');
   });
 
-  beforeEach(() => {
-    jest
-      .useFakeTimers()
-      .setSystemTime(new Date(Date.UTC(2023, Month.September, 1, 0, 0, 0)));
+  describe('when both dates are defined in UTC', () => {
+    test('true', () => {
+      const utc1 = new Date(Date.UTC(2023, Month.September, 1));
+      const utc2 = new Date(Date.UTC(2023, Month.September, 10));
+      expect(isSameUTCMonth(utc1, utc2)).toBe(true);
+    });
+
+    test('false', () => {
+      const utc1 = new Date(Date.UTC(2023, Month.September, 1));
+      const utc2 = new Date(Date.UTC(2023, Month.August, 31));
+      expect(isSameUTCMonth(utc1, utc2)).toBe(false);
+    });
   });
 
-  test('true, when both defined in UTC', () => {
-    const utc1 = new Date(Date.UTC(2023, Month.September, 1));
-    const utc2 = new Date(Date.UTC(2023, Month.September, 10));
-    expect(isSameUTCMonth(utc1, utc2)).toBe(true);
+  describe('when one date is defined locally', () => {
+    test('true', () => {
+      const utc = new Date(Date.UTC(2023, Month.September, 10));
+      const local = new Date('2023-08-31T21:00:00');
+      expect(isSameUTCMonth(utc, local)).toBe(true);
+    });
+
+    test('false', () => {
+      const utc = new Date(Date.UTC(2023, Month.September, 10));
+      const local = new Date('2023-08-31T12:00');
+      expect(isSameUTCMonth(utc, local)).toBe(false);
+    });
   });
 
-  test('false: when both dates are defined in UTC', () => {
-    const utc1 = new Date(Date.UTC(2023, Month.September, 1));
-    const utc2 = new Date(Date.UTC(2023, Month.August, 31));
-    expect(isSameUTCMonth(utc1, utc2)).toBe(false);
-  });
+  describe(' when both dates are defined locally', () => {
+    test('true', () => {
+      const local1 = new Date('2023-09-01T00:00');
+      const local2 = new Date('2023-09-30T19:00');
+      expect(isSameUTCMonth(local1, local2)).toBe(true);
+    });
 
-  test('true: when one date is defined locally', () => {
-    const utc = new Date(Date.UTC(2023, Month.September, 10));
-    const local = new Date('2023-08-31T21:00:00');
-    expect(isSameUTCMonth(utc, local)).toBe(true);
-  });
-
-  test('false: when one date is defined locally', () => {
-    const utc = new Date(Date.UTC(2023, Month.September, 10));
-    const local = new Date('2023-08-31T12:00');
-    expect(isSameUTCMonth(utc, local)).toBe(false);
-  });
-
-  test('true: when both dates are defined locally', () => {
-    const local1 = new Date('2023-09-01T00:00');
-    const local2 = new Date('2023-09-30T19:00');
-    expect(isSameUTCMonth(local1, local2)).toBe(true);
-  });
-
-  test('false: when both dates are defined locally', () => {
-    const local1 = new Date('2023-09-01T00:00');
-    const local2 = new Date('2023-09-30T20:00');
-    expect(isSameUTCMonth(local1, local2)).toBe(false);
+    test('false', () => {
+      const local1 = new Date('2023-09-01T00:00');
+      const local2 = new Date('2023-09-30T20:00');
+      expect(isSameUTCMonth(local1, local2)).toBe(false);
+    });
   });
 
   test('false: when one or both dates is null', () => {

--- a/packages/date-picker/src/shared/utils/setUTCMonth/setUTCMonth.spec.ts
+++ b/packages/date-picker/src/shared/utils/setUTCMonth/setUTCMonth.spec.ts
@@ -1,4 +1,3 @@
-import { setMonth } from 'date-fns';
 import tzMock from 'timezone-mock';
 
 import { Month } from '../../constants';
@@ -33,15 +32,9 @@ describe('packages/date-picker/utils/setUTCMonth', () => {
 
   test('does not care about time-zone', () => {
     tzMock.register('US/Pacific');
-    jest
-      .useFakeTimers()
-      .setSystemTime(new Date(Date.UTC(2023, Month.September, 1, 0, 0, 0)));
+
     const d = new Date(Date.UTC(2023, Month.September, 1, 0, 0, 0));
     const d_utc = setUTCMonth(d, Month.August);
     expect(d_utc.getUTCMonth()).toEqual(Month.August);
-
-    // For comparison:
-    const d_tz = setMonth(d, Month.August);
-    expect(d_tz.getUTCMonth()).toEqual(Month.September);
   });
 });

--- a/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
+++ b/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
@@ -29,7 +29,7 @@ export const createSyntheticEvent = <
     event.stopPropagation();
   };
 
-  return {
+  const syntheticEvent = {
     nativeEvent: event,
     currentTarget: event.currentTarget as EventTarget & TargetType,
     target: event.target as EventTarget & TargetType,
@@ -38,12 +38,14 @@ export const createSyntheticEvent = <
     defaultPrevented: event.defaultPrevented,
     eventPhase: event.eventPhase,
     isTrusted: event.isTrusted,
+    timeStamp: event.timeStamp,
+    type: event.type,
     preventDefault,
     isDefaultPrevented: () => isDefaultPrevented,
     stopPropagation,
     isPropagationStopped: () => isPropagationStopped,
     persist: () => {},
-    timeStamp: event.timeStamp,
-    type: event.type,
-  } as unknown as ReactEventType;
+  };
+
+  return syntheticEvent as unknown as ReactEventType;
 };

--- a/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
+++ b/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
@@ -1,12 +1,18 @@
+import React from 'react';
+
 /**
  * Creates a React SyntheticEvent based on the provided native event and target.
  *
  * Based on https://stackoverflow.com/a/68979462/2200383
  */
-export const createSyntheticEvent = <T extends Element, E extends Event>(
-  event: E,
-  target: T,
-): React.SyntheticEvent<T, E> => {
+export const createSyntheticEvent = <
+  ReactEventType extends React.SyntheticEvent<TargetType, NativeEventType>,
+  TargetType extends Element | EventTarget = Element,
+  NativeEventType extends Event = Event,
+>(
+  event: NativeEventType,
+  target: TargetType,
+): ReactEventType => {
   // Assign the target property to the event
   Object.defineProperty(event, 'target', { writable: false, value: target });
 
@@ -25,8 +31,8 @@ export const createSyntheticEvent = <T extends Element, E extends Event>(
 
   return {
     nativeEvent: event,
-    currentTarget: event.currentTarget as EventTarget & T,
-    target: event.target as EventTarget & T,
+    currentTarget: event.currentTarget as EventTarget & TargetType,
+    target: event.target as EventTarget & TargetType,
     bubbles: event.bubbles,
     cancelable: event.cancelable,
     defaultPrevented: event.defaultPrevented,
@@ -39,5 +45,5 @@ export const createSyntheticEvent = <T extends Element, E extends Event>(
     persist: () => {},
     timeStamp: event.timeStamp,
     type: event.type,
-  };
+  } as unknown as ReactEventType;
 };

--- a/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
+++ b/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
@@ -31,6 +31,7 @@ export const createSyntheticEvent = <
 
   const syntheticEvent = {
     nativeEvent: event,
+    ...event,
     currentTarget: event.currentTarget as EventTarget & TargetType,
     target: event.target as EventTarget & TargetType,
     bubbles: event.bubbles,

--- a/packages/lib/src/helpers/index.ts
+++ b/packages/lib/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export { pickAndOmit } from './pickAndOmit';
 export { consoleOnce } from './consoleOnce';
 export { allEqual } from './allEqual';
+export { rollover } from './rollover';

--- a/packages/lib/src/helpers/rollover/index.ts
+++ b/packages/lib/src/helpers/rollover/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns value if it is between lower & upper bounds (inclusive).
+ * Returns the difference between value & relevant bound if outside the bounds
+ *
+ * e.g.:
+ * `rollover(6, 1, 5) // 1`
+ * `rollover(0, 1, 5) // 5`
+ */
+export const rollover = (
+  value: number,
+  lowerBound: number,
+  upperBound: number,
+): number => {
+  const range = upperBound - lowerBound;
+
+  if (value > upperBound) {
+    const diff = value - upperBound - 1;
+    return lowerBound + (diff % range);
+  } else if (value < lowerBound) {
+    const diff = lowerBound - value - 1;
+    return upperBound - (diff % range);
+  }
+
+  return value;
+};

--- a/packages/lib/src/helpers/rollover/rollover.spec.ts
+++ b/packages/lib/src/helpers/rollover/rollover.spec.ts
@@ -1,0 +1,23 @@
+import { rollover } from '.';
+
+describe('packages/lib/helpers/rollover', () => {
+  test('returns value when within bounds', () => {
+    expect(rollover(5, 1, 12)).toEqual(5);
+  });
+
+  test('returns a rolled over value', () => {
+    expect(rollover(13, 1, 12)).toEqual(1);
+  });
+
+  test('returns a rolled under value', () => {
+    expect(rollover(0, 1, 12)).toEqual(12);
+  });
+
+  test('returns a rolled over value when value is > 2x the range', () => {
+    expect(rollover(25, 1, 12)).toEqual(2);
+  });
+
+  test('returns a rolled under value when value is > 2x the range', () => {
+    expect(rollover(-12, 1, 12)).toEqual(11);
+  });
+});


### PR DESCRIPTION
Ensures arrow keys move the cursor, or update focused segment

[LG-3756](https://jira.mongodb.org/browse/LG-3756) - L/R arrow keys should move focused segment
[LG-3771](https://jira.mongodb.org/browse/LG-3771) - When incrementing/decrementing a segment with up/down arrows, the focus should stay on the segment you're incrementing/decrementing.
[LG-3774](https://jira.mongodb.org/browse/LG-3774) - Tabbing into the datepicker and pressing the up arrow should set the value to the min value
[LG-3768](https://jira.mongodb.org/browse/LG-3768) - keyboard input should not open the menu