### PR TITLE
DatePicker [LG-3771, LG-3774] up/down arrows

### DIFF
--- a/.changeset/proud-doors-smoke.md
+++ b/.changeset/proud-doors-smoke.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/lib': minor
+---
+
+Creates `rollover` utility function

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.spec.tsx
@@ -133,5 +133,57 @@ describe('packages/date-picker/date-picker-input', () => {
         expect(yearInput).toHaveFocus();
       });
     });
+
+    describe('Up Arrow', () => {
+      test('keeps the focus in the current segment', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowup}');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('keeps the focus in the current segment even if the value is valid', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowup}{arrowup}{arrowup}');
+        expect(monthInput).toHaveValue('03');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('Resets the value to the min value when the new value is greater than the max value', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowup}');
+        expect(monthInput).toHaveValue('01');
+        userEvent.keyboard(
+          '{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}{arrowup}',
+        );
+        expect(monthInput).toHaveValue('01');
+      });
+    });
+
+    describe('Down Arrow', () => {
+      test('keeps the focus in the current segment', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowdown}');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('keeps the focus in the current segment even if the value is valid', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowdown}{arrowdown}{arrowdown}');
+        expect(monthInput).toHaveValue('10');
+        expect(monthInput).toHaveFocus();
+      });
+
+      test('Resets the value to the max value when the new value is less than the min value', () => {
+        const { monthInput } = renderDatePickerInput();
+        userEvent.click(monthInput);
+        userEvent.keyboard('{arrowdown}');
+        expect(monthInput).toHaveValue('12');
+      });
+    });
   });
 });

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -59,7 +59,7 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
      */
     const handleInputClick: MouseEventHandler<HTMLElement> = ({ target }) => {
       if (!disabled) {
-        // openMenu();
+        openMenu();
 
         const segmentToFocus = getSegmentToFocus({
           target,
@@ -156,10 +156,6 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
         case keyMap.Tab:
           // Behavior handled by parent or menu
           break;
-
-        default:
-          // any other keydown should open the menu
-          openMenu();
       }
 
       // call any handler that was passed in
@@ -192,6 +188,7 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
       const segment = e.target.dataset['segment'];
       const segmentValue = e.target.value;
       const areUpDownKeys =
+        // @ts-ignore FIXME:
         e.key === keyMap.ArrowDown || e.key === keyMap.ArrowUp;
 
       if (isValidSegmentName(segment)) {

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -191,14 +191,14 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
     const handleSegmentChange: ChangeEventHandler<HTMLInputElement> = e => {
       const segment = e.target.dataset['segment'];
       const segmentValue = e.target.value;
-      const notUpDownKeys =
-        e.key !== keyMap.ArrowDown && e.key !== keyMap.ArrowUp;
+      const areUpDownKeys =
+        e.key === keyMap.ArrowDown || e.key === keyMap.ArrowUp;
 
       if (isValidSegmentName(segment)) {
         if (
           isValidValueForSegment(segment, segmentValue) &&
           isExplicitSegmentValue(segment, segmentValue) &&
-          notUpDownKeys
+          !areUpDownKeys
         ) {
           const nextSegment = getRelativeSegment('next', {
             segment: segmentRefs[segment],

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -59,7 +59,7 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
      */
     const handleInputClick: MouseEventHandler<HTMLElement> = ({ target }) => {
       if (!disabled) {
-        openMenu();
+        // openMenu();
 
         const segmentToFocus = getSegmentToFocus({
           target,
@@ -186,15 +186,19 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
 
     /**
      * Called when any segment changes
+     * If up/down arrows are pressed, don't move to the next segment
      */
     const handleSegmentChange: ChangeEventHandler<HTMLInputElement> = e => {
       const segment = e.target.dataset['segment'];
       const segmentValue = e.target.value;
+      const notUpDownKeys =
+        e.key !== keyMap.ArrowDown && e.key !== keyMap.ArrowUp;
 
       if (isValidSegmentName(segment)) {
         if (
           isValidValueForSegment(segment, segmentValue) &&
-          isExplicitSegmentValue(segment, segmentValue)
+          isExplicitSegmentValue(segment, segmentValue) &&
+          notUpDownKeys
         ) {
           const nextSegment = getRelativeSegment('next', {
             segment: segmentRefs[segment],

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -64,6 +64,9 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
 
     const containerRef = useForwardedRef(fwdRef, null);
 
+    // Store the value of which key is pressed when handleSegmentChange is fired.
+    // This key value will then be passed inside `triggerChangeEventForSegment`
+    // using ref and state will have stale values and we don't need the component to rerender when this value changes
     let key = '';
 
     /**
@@ -134,6 +137,7 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
       const segmentName = e.target.getAttribute('id');
       const newValue = e.target.value;
 
+      // set the value of the key which will then be used
       key = e.key;
 
       if (isDateSegment(segmentName)) {

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -2,7 +2,6 @@ import React, {
   ChangeEvent,
   ChangeEventHandler,
   FocusEventHandler,
-  useState,
 } from 'react';
 import { isSameDay } from 'date-fns';
 import isEqual from 'lodash/isEqual';
@@ -138,6 +137,7 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
       const newValue = e.target.value;
 
       // set the value of the key which will then be used
+      // @ts-ignore FIXME:
       key = e.key;
 
       if (isDateSegment(segmentName)) {

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEvent,
   ChangeEventHandler,
   FocusEventHandler,
+  useState,
 } from 'react';
 import { isSameDay } from 'date-fns';
 import isEqual from 'lodash/isEqual';
@@ -63,6 +64,8 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
 
     const containerRef = useForwardedRef(fwdRef, null);
 
+    let key = '';
+
     /**
      * Fires a synthetic change event
      * and calls the provided `onChange` handler
@@ -71,10 +74,13 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
       const changeEvent = new Event('change');
       const eventTarget = segmentRefs[segment].current;
 
+      console.log('triggerChangeEventForSegment', key);
+
       if (eventTarget) {
         const reactEvent = createSyntheticEvent(
           changeEvent,
           eventTarget,
+          key,
         ) as ChangeEvent<HTMLInputElement>;
         onSegmentChange?.(reactEvent);
       }
@@ -127,6 +133,8 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
     const handleSegmentChange: ChangeEventHandler<HTMLInputElement> = e => {
       const segmentName = e.target.getAttribute('id');
       const newValue = e.target.value;
+
+      key = e.key;
 
       if (isDateSegment(segmentName)) {
         setSegment(segmentName, newValue);

--- a/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputSegment/DateInputSegment.tsx
@@ -75,27 +75,39 @@ export const DateInputSegment = React.forwardRef<
     const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = e => {
       const { key, target } = e;
 
+      /** adds in leading zero */
+      const getPaddedValue = (num: number) => String(num).padStart(2, '0');
+
+      /** checks if the newValue is within the min and max limits of the segment */
+      const getNewValue = (newValue: number, direction: 'up' | 'down') =>
+        newValue >= min && newValue <= max
+          ? getPaddedValue(newValue)
+          : getPaddedValue(direction === 'up' ? min : max);
+
       switch (key) {
         case keyMap.ArrowUp: {
           e.preventDefault();
-          const incrementedValue = (Number(value) + 1).toString();
+          const newValue = Number(value) + 1;
+          const incrementedValue = getNewValue(newValue, 'up');
+
           (target as HTMLInputElement).value = incrementedValue;
           const changeEvent = createSyntheticEvent<
             ChangeEvent<HTMLInputElement>
-          >(new Event('change'), target as HTMLInputElement);
+          >(new Event('change'), target as HTMLInputElement, keyMap.ArrowUp);
           onChange?.(changeEvent);
           break;
         }
 
         case keyMap.ArrowDown: {
           e.preventDefault();
-          const decrementedValue = (Number(value) - 1).toString();
+          const newValue = Number(value) - 1;
+          const decrementedValue = getNewValue(newValue, 'down');
+
           (target as HTMLInputElement).value = decrementedValue;
           const changeEvent = createSyntheticEvent<
             ChangeEvent<HTMLInputElement>
-          >(new Event('change'), target as HTMLInputElement);
+          >(new Event('change'), target as HTMLInputElement, keyMap.ArrowDown);
           onChange?.(changeEvent);
-
           break;
         }
 

--- a/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
+++ b/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
@@ -12,9 +12,12 @@ export const createSyntheticEvent = <
 >(
   event: NativeEventType,
   target: TargetType,
+  key?: string,
 ): ReactEventType => {
   // Assign the target property to the event
   Object.defineProperty(event, 'target', { writable: false, value: target });
+
+  console.log({ key });
 
   let isDefaultPrevented = false;
   let isPropagationStopped = false;
@@ -45,5 +48,6 @@ export const createSyntheticEvent = <
     persist: () => {},
     timeStamp: event.timeStamp,
     type: event.type,
+    key,
   } as unknown as ReactEventType;
 };

--- a/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
+++ b/packages/lib/src/createSyntheticEvent/createSyntheticEvent.ts
@@ -12,12 +12,9 @@ export const createSyntheticEvent = <
 >(
   event: NativeEventType,
   target: TargetType,
-  key?: string,
 ): ReactEventType => {
   // Assign the target property to the event
   Object.defineProperty(event, 'target', { writable: false, value: target });
-
-  console.log({ key });
 
   let isDefaultPrevented = false;
   let isPropagationStopped = false;
@@ -32,7 +29,7 @@ export const createSyntheticEvent = <
     event.stopPropagation();
   };
 
-  return {
+  const syntheticEvent = {
     nativeEvent: event,
     currentTarget: event.currentTarget as EventTarget & TargetType,
     target: event.target as EventTarget & TargetType,
@@ -41,13 +38,14 @@ export const createSyntheticEvent = <
     defaultPrevented: event.defaultPrevented,
     eventPhase: event.eventPhase,
     isTrusted: event.isTrusted,
+    timeStamp: event.timeStamp,
+    type: event.type,
     preventDefault,
     isDefaultPrevented: () => isDefaultPrevented,
     stopPropagation,
     isPropagationStopped: () => isPropagationStopped,
     persist: () => {},
-    timeStamp: event.timeStamp,
-    type: event.type,
-    key,
-  } as unknown as ReactEventType;
+  };
+
+  return syntheticEvent as unknown as ReactEventType;
 };

--- a/packages/lib/src/helpers/index.ts
+++ b/packages/lib/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export { pickAndOmit } from './pickAndOmit';
 export { consoleOnce } from './consoleOnce';
 export { allEqual } from './allEqual';
+export { rollover } from './rollover';

--- a/packages/lib/src/helpers/rollover/index.ts
+++ b/packages/lib/src/helpers/rollover/index.ts
@@ -3,8 +3,8 @@
  * Returns the difference between value & relevant bound if outside the bounds
  *
  * e.g.:
- * `rollover(7, 0, 5) // 2`
- * `rollover(-1, 0, 5) // 4`
+ * `rollover(6, 1, 5) // 1`
+ * `rollover(0, 1, 5) // 5`
  */
 export const rollover = (
   value: number,
@@ -12,13 +12,14 @@ export const rollover = (
   upperBound: number,
 ): number => {
   const range = upperBound - lowerBound;
+
   if (value > upperBound) {
-    const diff = value - upperBound;
+    const diff = value - upperBound - 1;
     return lowerBound + (diff % range);
-  }
-  if (value < lowerBound) {
-    const diff = lowerBound - value;
+  } else if (value < lowerBound) {
+    const diff = lowerBound - value - 1;
     return upperBound - (diff % range);
   }
+
   return value;
 };

--- a/packages/lib/src/helpers/rollover/index.ts
+++ b/packages/lib/src/helpers/rollover/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns value if it is between lower & upper bounds (inclusive).
+ * Returns the difference between value & relevant bound if outside the bounds
+ *
+ * e.g.:
+ * `rollover(7, 0, 5) // 2`
+ * `rollover(-1, 0, 5) // 4`
+ */
+export const rollover = (
+  value: number,
+  lowerBound: number,
+  upperBound: number,
+): number => {
+  const range = upperBound - lowerBound;
+  if (value > upperBound) {
+    const diff = value - upperBound;
+    return lowerBound + (diff % range);
+  }
+  if (value < lowerBound) {
+    const diff = lowerBound - value;
+    return upperBound - (diff % range);
+  }
+  return value;
+};

--- a/packages/lib/src/helpers/rollover/rollover.spec.ts
+++ b/packages/lib/src/helpers/rollover/rollover.spec.ts
@@ -1,0 +1,23 @@
+import { rollover } from '.';
+
+describe('packages/lib/helpers/rollover', () => {
+  test('returns value when within bounds', () => {
+    expect(rollover(5, 0, 10)).toEqual(5);
+  });
+
+  test('returns a rolled over value', () => {
+    expect(rollover(11, 0, 10)).toEqual(1);
+  });
+
+  test('returns a rolled under value', () => {
+    expect(rollover(-1, 0, 10)).toEqual(9);
+  });
+
+  test('returns a rolled over value when value is > 2x the range', () => {
+    expect(rollover(21, 0, 10)).toEqual(1);
+  });
+
+  test('returns a rolled under value when value is > 2x the range', () => {
+    expect(rollover(-11, 0, 10)).toEqual(9);
+  });
+});

--- a/packages/lib/src/helpers/rollover/rollover.spec.ts
+++ b/packages/lib/src/helpers/rollover/rollover.spec.ts
@@ -2,22 +2,22 @@ import { rollover } from '.';
 
 describe('packages/lib/helpers/rollover', () => {
   test('returns value when within bounds', () => {
-    expect(rollover(5, 0, 10)).toEqual(5);
+    expect(rollover(5, 1, 12)).toEqual(5);
   });
 
   test('returns a rolled over value', () => {
-    expect(rollover(11, 0, 10)).toEqual(1);
+    expect(rollover(13, 1, 12)).toEqual(1);
   });
 
   test('returns a rolled under value', () => {
-    expect(rollover(-1, 0, 10)).toEqual(9);
+    expect(rollover(0, 1, 12)).toEqual(12);
   });
 
   test('returns a rolled over value when value is > 2x the range', () => {
-    expect(rollover(21, 0, 10)).toEqual(1);
+    expect(rollover(25, 1, 12)).toEqual(2);
   });
 
   test('returns a rolled under value when value is > 2x the range', () => {
-    expect(rollover(-11, 0, 10)).toEqual(9);
+    expect(rollover(-12, 1, 12)).toEqual(11);
   });
 });


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

[LG-3771](https://jira.mongodb.org/browse/LG-3771) - When incrementing/decrementing a segment with up/down arrows, the focus moves to the next segment instead of staying focused on the segment you're incrementing/decrementing.
[LG-3774](https://jira.mongodb.org/browse/LG-3774) - Tabbing into the datepicker and pressing the up arrow shows random number
[LG-3768](https://jira.mongodb.org/browse/LG-3768) - keypresses in the input opens the menu and the input focus is hijacked
## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
