### PR TITLE
DatePicker [LG-3899] arrow key errors

### DIFF
--- a/packages/date-picker/src/DatePicker.stories.tsx
+++ b/packages/date-picker/src/DatePicker.stories.tsx
@@ -4,6 +4,8 @@ import { StoryFn } from '@storybook/react';
 
 import Button from '@leafygreen-ui/button';
 import {
+  DateType,
+  isValidDate,
   Month,
   newUTC,
   testLocales,
@@ -92,7 +94,7 @@ const meta: StoryMetaType<typeof DatePicker, SharedDatePickerContextProps> = {
 export default meta;
 
 export const LiveExample: StoryFn<typeof DatePicker> = props => {
-  const [value, setValue] = useState<Date | null | undefined>();
+  const [value, setValue] = useState<DateType>();
 
   return (
     <DatePicker
@@ -101,7 +103,9 @@ export const LiveExample: StoryFn<typeof DatePicker> = props => {
       onDateChange={v => {
         // eslint-disable-next-line no-console
         console.log('Storybook: onDateChange', { v });
-        setValue(v);
+        if (isValidDate(v)) {
+          setValue(v);
+        }
       }}
       handleValidation={date =>
         // eslint-disable-next-line no-console

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   fireEvent,
-  prettyDOM,
+  // prettyDOM,
   render,
   waitFor,
   waitForElementToBeRemoved,

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   fireEvent,
+  prettyDOM,
   render,
   waitFor,
   waitForElementToBeRemoved,
@@ -1052,6 +1053,13 @@ describe('packages/date-picker', () => {
                   ).toBeFalsy();
                 }
 
+                const errorElement = renderResult.queryByTestId(
+                  'lg-form_field-error_message',
+                );
+
+                await waitFor(() =>
+                  expect(errorElement).not.toBeInTheDocument(),
+                );
                 userEvent.tab();
               }
             });
@@ -1078,6 +1086,14 @@ describe('packages/date-picker', () => {
                     ),
                   ).toBeFalsy();
                 }
+
+                const errorElement = renderResult.queryByTestId(
+                  'lg-form_field-error_message',
+                );
+
+                await waitFor(() =>
+                  expect(errorElement).not.toBeInTheDocument(),
+                );
 
                 userEvent.tab();
                 // There are side-effects triggered on CSS transition-end events.

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1880,7 +1880,7 @@ describe('packages/date-picker', () => {
                     }
 
                     case 'day': {
-                      test('changing date rolls down to days-in-month', async () => {
+                      test('changing date rolls over to number of days-in-month', async () => {
                         const result = renderDatePicker({
                           value: newUTC(2020, Month.February, 1),
                         });

--- a/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.spec.tsx
@@ -1544,18 +1544,20 @@ describe('packages/date-picker', () => {
 
                       test('error state stays after menu is closed', async () => {
                         const result = renderDatePicker({
-                          value: newUTC(2020, Month.February, 29),
+                          value: newUTC(2020, Month.January, 31),
                         });
                         const input = getRelevantInput(result);
                         userEvent.click(input);
                         userEvent.keyboard('{arrowup}');
+                        const { menuContainerEl } =
+                          await result.findMenuElements();
                         userEvent.click(result.container.parentElement!);
-                        await waitFor(() => {
-                          const errorElement = result.queryByTestId(
-                            'lg-form_field-error_message',
-                          );
-                          expect(errorElement).toBeInTheDocument();
-                        });
+
+                        await waitForElementToBeRemoved(menuContainerEl);
+                        const errorElement = result.queryByTestId(
+                          'lg-form_field-error_message',
+                        );
+                        expect(errorElement).toBeInTheDocument();
                       });
 
                       break;
@@ -1802,7 +1804,6 @@ describe('packages/date-picker', () => {
                   });
                 });
 
-                // TODO:
                 describe('if the new value would be invalid', () => {
                   // E.g. Feb 30 2020 or Feb 29 2021
                   switch (segment) {
@@ -1859,25 +1860,48 @@ describe('packages/date-picker', () => {
 
                       test('error state stays after menu is closed', async () => {
                         const result = renderDatePicker({
-                          value: newUTC(2020, Month.February, 29),
+                          value: newUTC(2020, Month.March, 31),
                         });
                         const input = getRelevantInput(result);
                         userEvent.click(input);
                         userEvent.keyboard('{arrowdown}');
+                        const { menuContainerEl } =
+                          await result.findMenuElements();
                         userEvent.click(result.container.parentElement!);
-                        await waitFor(() => {
-                          const errorElement = result.queryByTestId(
-                            'lg-form_field-error_message',
-                          );
-                          expect(errorElement).toBeInTheDocument();
-                        });
+
+                        await waitForElementToBeRemoved(menuContainerEl);
+                        const errorElement = result.queryByTestId(
+                          'lg-form_field-error_message',
+                        );
+                        expect(errorElement).toBeInTheDocument();
                       });
 
                       break;
                     }
 
                     case 'day': {
-                      // There is no case where decrementing a day results in an invalid date value
+                      test('changing date rolls down to days-in-month', async () => {
+                        const result = renderDatePicker({
+                          value: newUTC(2020, Month.February, 1),
+                        });
+                        const input = getRelevantInput(result);
+                        userEvent.click(input);
+                        userEvent.keyboard('{arrowdown}');
+
+                        await waitFor(() => {
+                          expect(result.yearInput).toHaveValue('2020');
+                          expect(result.monthInput).toHaveValue('02');
+                          expect(result.dayInput).toHaveValue('29');
+                          expect(result.inputContainer).toHaveAttribute(
+                            'aria-invalid',
+                            'false',
+                          );
+                          const errorElement = result.queryByTestId(
+                            'lg-form_field-error_message',
+                          );
+                          expect(errorElement).not.toBeInTheDocument();
+                        });
+                      });
                       break;
                     }
 

--- a/packages/date-picker/src/DatePicker/DatePickerContext/DatePickerContext.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerContext/DatePickerContext.tsx
@@ -24,6 +24,7 @@ import {
   getFormattedDateString,
   getFormattedDateStringFromSegments,
   getSegmentStateFromRefs,
+  isEverySegmentFilled,
 } from '../../shared/utils';
 import { getInitialHighlight } from '../utils/getInitialHighlight';
 
@@ -112,7 +113,7 @@ export const DatePickerProvider = ({
    * Handles internal validation,
    * and calls the provided `handleValidation` callback
    */
-  const handleValidation = (val?: DateType) => {
+  const handleValidation = (val?: DateType): void => {
     // Set an internal error state if necessary
     if (val && !isInRange(val)) {
       if (isOnOrBefore(val, min)) {
@@ -128,12 +129,14 @@ export const DatePickerProvider = ({
       // Wait for the inputs to update, then check they're valid
       setTimeout(() => {
         const segments = getSegmentStateFromRefs(refs.segmentRefs);
+        const areAllFilled = isEverySegmentFilled(segments);
         const areSegmentsValidDate = doSegmentsFormValidDate(segments);
 
         // If the segments are valid, clear any error messages
         if (areSegmentsValidDate) {
           clearInternalErrorMessage();
-        } else {
+        } else if (areAllFilled) {
+          // Show an error iff areAllFilled
           const dateString = getFormattedDateStringFromSegments(
             segments,
             locale,

--- a/packages/date-picker/src/DatePicker/DatePickerContext/DatePickerContext.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerContext/DatePickerContext.tsx
@@ -19,7 +19,12 @@ import {
 import { usePrevious } from '@leafygreen-ui/hooks';
 
 import { useSharedDatePickerContext } from '../../shared/context';
-import { getFormattedDateString } from '../../shared/utils';
+import {
+  doSegmentsFormValidDate,
+  getFormattedDateString,
+  getFormattedDateStringFromSegments,
+  getSegmentStateFromRefs,
+} from '../../shared/utils';
 import { getInitialHighlight } from '../utils/getInitialHighlight';
 
 import {
@@ -120,7 +125,23 @@ export const DatePickerProvider = ({
         );
       }
     } else {
-      clearInternalErrorMessage();
+      // Wait for the inputs to update, then check they're valid
+      setTimeout(() => {
+        const segments = getSegmentStateFromRefs(refs.segmentRefs);
+        const areSegmentsValidDate = doSegmentsFormValidDate(segments);
+
+        // If the segments are valid, clear any error messages
+        if (areSegmentsValidDate) {
+          clearInternalErrorMessage();
+        } else {
+          const dateString = getFormattedDateStringFromSegments(
+            segments,
+            locale,
+          );
+          // Setting the error message here is likely redundant (handled by DateInputBox)
+          setInternalErrorMessage(`${dateString} is not a valid date`);
+        }
+      });
     }
 
     _handleValidation?.(val);

--- a/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/DatePickerInput.tsx
@@ -197,10 +197,10 @@ export const DatePickerInput = forwardRef<HTMLDivElement, DatePickerInputProps>(
         /**
          * Fire a simulated `change` event
          */
-        const changeEvent = new Event('change');
         const target = segmentRefs[segment].current;
 
         if (target) {
+          const changeEvent = new Event('change');
           const reactEvent = createSyntheticEvent<
             ChangeEvent<HTMLInputElement>
           >(changeEvent, target);

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -73,7 +73,6 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
       locale,
       setIsDirty,
       setInternalErrorMessage,
-      clearInternalErrorMessage,
     } = useSharedDatePickerContext();
     const { theme } = useDarkMode();
 

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.tsx
@@ -65,8 +65,16 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
     }: DateInputBoxProps,
     fwdRef,
   ) => {
-    const { formatParts, disabled, min, max, locale, setInternalErrorMessage } =
-      useSharedDatePickerContext();
+    const {
+      formatParts,
+      disabled,
+      min,
+      max,
+      locale,
+      setIsDirty,
+      setInternalErrorMessage,
+      clearInternalErrorMessage,
+    } = useSharedDatePickerContext();
     const { theme } = useDarkMode();
 
     const containerRef = useForwardedRef(fwdRef, null);
@@ -115,6 +123,8 @@ export const DateInputBox = React.forwardRef<HTMLDivElement, DateInputBoxProps>(
             // This error state will be removed by `handleValidation` once a value is set
             setInternalErrorMessage(`${dateString} is not a valid date`);
           }
+          // If all values are filled, set the input as dirty
+          setIsDirty(true);
         }
       }
     };

--- a/packages/date-picker/src/shared/context/SharedDatePickerContext.tsx
+++ b/packages/date-picker/src/shared/context/SharedDatePickerContext.tsx
@@ -19,9 +19,6 @@ import { useDatePickerErrorNotifications } from './useDatePickerErrorNotificatio
 export const SharedDatePickerContext =
   createContext<SharedDatePickerContextProps>(defaultSharedDatePickerContext);
 
-// TODO: Consider renaming this to `SharedDatePickerContext`,
-// and use `SharedDatePickerContext` for what's currently `DatePickerContext`
-
 /** The Provider component for SharedDatePickerContext */
 export const SharedDatePickerProvider = ({
   children,

--- a/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/getSegmentStateFromRefs.spec.ts
+++ b/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/getSegmentStateFromRefs.spec.ts
@@ -1,0 +1,34 @@
+import { SegmentRefs } from '../../hooks';
+import { segmentRefsMock } from '../../testutils';
+
+import { getSegmentStateFromRefs } from '.';
+
+describe('packages/date-picker/utils/getSegmentStateFromRefs', () => {
+  test('empty refs', () => {
+    expect(getSegmentStateFromRefs(segmentRefsMock)).toEqual({
+      day: '',
+      month: '',
+      year: '',
+    });
+  });
+
+  test('Refs with values', () => {
+    const refs: SegmentRefs = { ...segmentRefsMock };
+    // @ts-expect-error - current is read-only
+    refs.day.current = document.createElement('input');
+    // @ts-expect-error - current is read-only
+    refs.month.current = document.createElement('input');
+    // @ts-expect-error - current is read-only
+    refs.year.current = document.createElement('input');
+
+    refs.day.current.value = '02';
+    refs.month.current.value = '02';
+    refs.year.current.value = '2020';
+
+    expect(getSegmentStateFromRefs(refs)).toEqual({
+      day: '02',
+      month: '02',
+      year: '2020',
+    });
+  });
+});

--- a/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/getSegmentStateFromRefs.ts
+++ b/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/getSegmentStateFromRefs.ts
@@ -1,6 +1,9 @@
 import { SegmentRefs } from '../../hooks';
 import { DateSegmentsState } from '../../types';
 
+/**
+ * Returns a {@link DateSegmentsState} object given a {@link SegmentRefs} Ref object
+ */
 export const getSegmentStateFromRefs = (
   refs: SegmentRefs,
 ): DateSegmentsState => {

--- a/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/getSegmentStateFromRefs.ts
+++ b/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/getSegmentStateFromRefs.ts
@@ -1,0 +1,12 @@
+import { SegmentRefs } from '../../hooks';
+import { DateSegmentsState } from '../../types';
+
+export const getSegmentStateFromRefs = (
+  refs: SegmentRefs,
+): DateSegmentsState => {
+  return {
+    day: refs.day.current?.value ?? '',
+    month: refs.month.current?.value ?? '',
+    year: refs.year.current?.value ?? '',
+  };
+};

--- a/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/index.ts
+++ b/packages/date-picker/src/shared/utils/getSegmentStateFromRefs/index.ts
@@ -1,0 +1,1 @@
+export { getSegmentStateFromRefs } from './getSegmentStateFromRefs';

--- a/packages/date-picker/src/shared/utils/index.ts
+++ b/packages/date-picker/src/shared/utils/index.ts
@@ -19,6 +19,7 @@ export {
   getFormattedSegmentsFromDate,
   getSegmentsFromDate,
 } from './getSegmentsFromDate';
+export { getSegmentStateFromRefs } from './getSegmentStateFromRefs';
 export { getValueFormatter } from './getValueFormatter';
 export { isElementInputSegment } from './isElementInputSegment';
 export { isEverySegmentFilled } from './isEverySegmentFilled';


### PR DESCRIPTION
### Bug:
- Enter '1996-02-29' > press up/down on year. Results in an invalid date ('1995-02-29' not a leap year)
- Enter '2021-03-31' > down on month > Results in "2021-02-31" (not valid)
- Enter '2020-02-29' > up on day > Results in "2020-02-30" (not valid)


### New behavior:
- Pressing up/down on a month or year input that results in an invalid date will show an error message
- Pressing up/down on a date input will roll-over the date value (e.g. Sep 30 -> up -> Sep 1)