### PR TITLE
React 17 `renderHook`

### DIFF
--- a/.changeset/bright-walls-glow.md
+++ b/.changeset/bright-walls-glow.md
@@ -1,0 +1,6 @@
+---
+'@lg-tools/validate': patch
+---
+
+- Adds `'@leafygreen-ui/testing-lib'` to list of external dependencies.
+- Updates handling of external dependencies with glob patterns

--- a/.changeset/fast-bananas-watch.md
+++ b/.changeset/fast-bananas-watch.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/toast': patch
+---
+
+Updates `updateToast` function to consistently return the new toast object

--- a/.changeset/healthy-needles-learn.md
+++ b/.changeset/healthy-needles-learn.md
@@ -1,0 +1,8 @@
+---
+'@leafygreen-ui/leafygreen-provider': patch
+'@leafygreen-ui/hooks': patch
+'@leafygreen-ui/toast': patch
+'@leafygreen-ui/a11y': patch
+---
+
+Updates test to import `renderHook` from `@leafygreen-ui/testing-lib`

--- a/.changeset/khaki-lies-carry.md
+++ b/.changeset/khaki-lies-carry.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/testing-lib': minor
+---
+
+Exports `waitForState`, a wrapper around `act` that returns the result of the state update callback

--- a/.changeset/strange-scissors-prove.md
+++ b/.changeset/strange-scissors-prove.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/testing-lib': minor
+---
+
+Exports overrides for `renderHook` and `act` that will work in both a React 17 and React 18 test environment

--- a/packages/a11y/src/A11y.spec.tsx
+++ b/packages/a11y/src/A11y.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
 import { axe } from 'jest-axe';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { AriaLabelProps, AriaLabelPropsWithLabel } from './AriaLabelProps';
 import {

--- a/packages/hooks/src/hooks.spec.tsx
+++ b/packages/hooks/src/hooks.spec.tsx
@@ -252,10 +252,10 @@ describe('packages/hooks', () => {
       expect(pollHandler).toHaveBeenCalledTimes(0);
     });
 
-    test('when document is not visible', () => {
+    test('when document is not visible', async () => {
       const pollHandler = jest.fn();
 
-      renderHook(() => usePoller(pollHandler));
+      const { rerender } = renderHook(() => usePoller(pollHandler));
 
       expect(pollHandler).toHaveBeenCalledTimes(1);
 
@@ -263,7 +263,6 @@ describe('packages/hooks', () => {
       act(() => {
         document.dispatchEvent(new Event('visibilitychange'));
       });
-
       jest.advanceTimersByTime(30e3);
 
       expect(pollHandler).toHaveBeenCalledTimes(1);
@@ -272,6 +271,7 @@ describe('packages/hooks', () => {
       act(() => {
         document.dispatchEvent(new Event('visibilitychange'));
       });
+      jest.advanceTimersByTime(30e3);
 
       // immediate triggers the pollHandler
       expect(pollHandler).toHaveBeenCalledTimes(2);
@@ -316,9 +316,6 @@ describe('packages/hooks', () => {
 
       rerender();
       expect(result.current).toEqual(123);
-
-      rerender(999);
-      expect(result.current).toEqual(undefined);
     });
   });
 

--- a/packages/hooks/src/hooks.spec.tsx
+++ b/packages/hooks/src/hooks.spec.tsx
@@ -268,12 +268,13 @@ describe('packages/hooks', () => {
       expect(pollHandler).toHaveBeenCalledTimes(1);
 
       mutableDocument.visibilityState = 'visible';
-      rerender(pollHandler);
 
       act(() => {
         document.dispatchEvent(new Event('visibilitychange'));
       });
       jest.advanceTimersByTime(30e3);
+
+      rerender(pollHandler);
 
       // immediate triggers the pollHandler
       expect(pollHandler).toHaveBeenCalledTimes(2);

--- a/packages/hooks/src/hooks.spec.tsx
+++ b/packages/hooks/src/hooks.spec.tsx
@@ -268,6 +268,8 @@ describe('packages/hooks', () => {
       expect(pollHandler).toHaveBeenCalledTimes(1);
 
       mutableDocument.visibilityState = 'visible';
+      rerender(pollHandler);
+
       act(() => {
         document.dispatchEvent(new Event('visibilitychange'));
       });

--- a/packages/hooks/src/hooks.spec.tsx
+++ b/packages/hooks/src/hooks.spec.tsx
@@ -1,4 +1,6 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+
+import { act, renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   useEventListener,
@@ -94,7 +96,7 @@ describe('packages/hooks', () => {
   describe.skip('useMutationObserver', () => {}); //eslint-disable-line jest/no-disabled-tests
 
   test('useViewportSize responds to updates in window size', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useViewportSize());
+    const { result, rerender } = renderHook(() => useViewportSize());
 
     const mutableWindow: { -readonly [K in keyof Window]: Window[K] } = window;
     const initialHeight = 360;
@@ -104,10 +106,11 @@ describe('packages/hooks', () => {
     mutableWindow.innerWidth = initialWidth;
 
     window.dispatchEvent(new Event('resize'));
-    await act(waitForNextUpdate);
-
-    expect(result?.current?.height).toBe(initialHeight);
-    expect(result?.current?.width).toBe(initialWidth);
+    rerender();
+    await waitFor(() => {
+      expect(result?.current?.height).toBe(initialHeight);
+      expect(result?.current?.width).toBe(initialWidth);
+    });
 
     const updateHeight = 768;
     const updateWidth = 1024;
@@ -116,10 +119,10 @@ describe('packages/hooks', () => {
     mutableWindow.innerWidth = updateWidth;
 
     window.dispatchEvent(new Event('resize'));
-    await act(waitForNextUpdate);
-
-    expect(result?.current?.height).toBe(updateHeight);
-    expect(result?.current?.width).toBe(updateWidth);
+    await waitFor(() => {
+      expect(result?.current?.height).toBe(updateHeight);
+      expect(result?.current?.width).toBe(updateWidth);
+    });
   });
 
   describe('usePoller', () => {
@@ -308,11 +311,14 @@ describe('packages/hooks', () => {
       rerender(2020);
       expect(result.current).toEqual(42);
 
-      rerender();
+      rerender(123);
       expect(result.current).toEqual(2020);
 
       rerender();
-      expect(result.current).toEqual(2020);
+      expect(result.current).toEqual(123);
+
+      rerender(999);
+      expect(result.current).toEqual(undefined);
     });
   });
 

--- a/packages/hooks/src/useControlledValue/useControlledValue.spec.ts
+++ b/packages/hooks/src/useControlledValue/useControlledValue.spec.ts
@@ -1,6 +1,7 @@
 import { ChangeEvent } from 'react';
 import { act } from 'react-test-renderer';
-import { renderHook } from '@testing-library/react-hooks';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { useControlledValue } from './useControlledValue';
 

--- a/packages/hooks/src/useDynamicRefs/useDynamicRefs.spec.tsx
+++ b/packages/hooks/src/useDynamicRefs/useDynamicRefs.spec.tsx
@@ -1,6 +1,6 @@
-import { renderHook } from '@testing-library/react-hooks';
-
+// import { renderHook } from '@testing-library/react-hooks';
 import { consoleOnce } from '@leafygreen-ui/lib';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { DynamicRefGetter, useDynamicRefs } from '.';
 
@@ -11,11 +11,13 @@ describe('packages/hooks/useDynamicRefs', () => {
   });
 
   test('returns identical getter when rerendered ', () => {
+    const props = { prefix: 'A' };
     const { result, rerender } = renderHook(v => useDynamicRefs(v), {
-      initialProps: { prefix: 'A' },
+      initialProps: props,
     });
-    rerender();
-    expect(result.all[0]).toBe(result.all[1]);
+    const initialValue = result.current;
+    rerender(props);
+    expect(result.current).toStrictEqual(initialValue);
   });
 
   test('returns unique getters when called with the same prefix', () => {
@@ -33,11 +35,14 @@ describe('packages/hooks/useDynamicRefs', () => {
 
   test('returns unique getters when re-rendered with a different prefix', () => {
     // This is an edge-case, but this is the behavior we want if it happens
+    const props = { prefix: 'A' };
     const { result, rerender } = renderHook(v => useDynamicRefs(v), {
-      initialProps: { prefix: 'A' },
+      initialProps: props,
     });
-    rerender({ prefix: 'B' });
-    expect(result.all[0]).not.toBe(result.all[1]);
+    const initialValue = result.current;
+    const newProps = { prefix: 'B' };
+    rerender(newProps);
+    expect(result.current).not.toBe(initialValue);
   });
 
   describe('ref getter function', () => {
@@ -66,18 +71,20 @@ describe('packages/hooks/useDynamicRefs', () => {
     });
 
     test('returns identical refs when called with the same key', () => {
-      const { result } = renderHook(() => useDynamicRefs({ prefix: 'A' }));
+      const props = { prefix: 'A' };
+      const { result } = renderHook(() => useDynamicRefs(props));
       const ref1 = result.current('key');
       const ref2 = result.current('key');
       expect(ref1).toBe(ref2);
     });
 
     test('returns identical refs when rerendered', () => {
+      const props = { prefix: 'A' };
       const { result, rerender } = renderHook(v => useDynamicRefs(v), {
-        initialProps: { prefix: 'A' },
+        initialProps: props,
       });
       const ref1 = result.current('key');
-      rerender();
+      rerender(props);
       const ref2 = result.current('key');
       expect(ref1).toBe(ref2);
     });

--- a/packages/leafygreen-provider/src/PopoverContext/PopoverContext.spec.tsx
+++ b/packages/leafygreen-provider/src/PopoverContext/PopoverContext.spec.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { PopoverProvider, type PopoverState, usePopoverContext } from '.';
 

--- a/packages/testing-lib/package.json
+++ b/packages/testing-lib/package.json
@@ -12,7 +12,9 @@
       ]
     }
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@lg-tools/build": "0.3.1"
+  },
   "peerDependencies": {
     "@testing-library/react": "^12.0.0 || ^13.1.0 || ^14.0.0"
   },
@@ -20,9 +22,8 @@
     "@testing-library/react-hooks": ">=3.7.0"
   },
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-internal-build-package",
+    "tsc": "tsc --build tsconfig.json"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/testing-lib/package.json
+++ b/packages/testing-lib/package.json
@@ -12,9 +12,6 @@
       ]
     }
   },
-  "dependencies": {
-    "@leafygreen-ui/lib": "^13.1.0"
-  },
   "devDependencies": {},
   "peerDependencies": {
     "@testing-library/react": "^12.0.0 || ^13.1.0 || ^14.0.0"

--- a/packages/testing-lib/package.json
+++ b/packages/testing-lib/package.json
@@ -12,6 +12,16 @@
       ]
     }
   },
+  "dependencies": {
+    "@leafygreen-ui/lib": "^13.1.0"
+  },
+  "devDependencies": {},
+  "peerDependencies": {
+    "@testing-library/react": "^12.0.0 || ^13.1.0 || ^14.0.0"
+  },
+  "optionalDependencies": {
+    "@testing-library/react-hooks": ">=3.7.0"
+  },
   "scripts": {
     "build": "lg build-package",
     "tsc": "lg build-ts",
@@ -28,6 +38,5 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/testing-lib/src/RTLOverrides.ts
+++ b/packages/testing-lib/src/RTLOverrides.ts
@@ -1,16 +1,31 @@
-import { act as ReactDOMAct } from 'react-dom/test-utils';
 import * as RTL from '@testing-library/react';
 
-export const renderHook =
-  RTL.renderHook ??
+type Exists<X, Y extends keyof X | string, Fallback = any> = Y extends keyof X
+  ? X[Y]
+  : Fallback;
+
+/**
+ * Re-exports `renderHook` from `"@testing-library/react"` if it exists,
+ * or from `"@testing-library/react-hooks"`
+ *
+ * (used when running in a React 17 test environment)
+ */
+export const renderHook: Exists<typeof RTL, 'renderHook'> =
+  (RTL as any).renderHook ??
   (() => {
-    const RTLH = require('@testing-library/react-hooks');
-    return RTLH.renderHook;
+    const RHTL = require('@testing-library/react-hooks');
+    return RHTL.renderHook;
   })();
 
-export const act: typeof ReactDOMAct =
+/**
+ * Re-exports `act` from `"@testing-library/react"` if it exists,
+ * or from `"@testing-library/react-hooks"`
+ *
+ * (used when running in a React 17 test environment)
+ */
+export const act: Exists<typeof RTL, 'act'> =
   RTL.act ??
   (() => {
-    const RTLH = require('@testing-library/react-hooks');
-    return RTLH.act;
+    const RHTL = require('@testing-library/react-hooks');
+    return RHTL.act;
   })();

--- a/packages/testing-lib/src/RTLOverrides.ts
+++ b/packages/testing-lib/src/RTLOverrides.ts
@@ -1,8 +1,13 @@
 import * as RTL from '@testing-library/react';
 
-type Exists<X, Y extends keyof X | string, Fallback = any> = Y extends keyof X
-  ? X[Y]
-  : Fallback;
+/**
+ * Utility type that returns `X.Y` if it exists, otherwise defaults to fallback type `Z`, or `any`
+ */
+export type Exists<
+  X,
+  Y extends keyof X | string,
+  Z = unknown,
+> = Y extends keyof X ? X[Y] : Z;
 
 /**
  * Re-exports `renderHook` from `"@testing-library/react"` if it exists,

--- a/packages/testing-lib/src/RTLOverrides.ts
+++ b/packages/testing-lib/src/RTLOverrides.ts
@@ -1,0 +1,16 @@
+import { act as ReactDOMAct } from 'react-dom/test-utils';
+import * as RTL from '@testing-library/react';
+
+export const renderHook =
+  RTL.renderHook ??
+  (() => {
+    const RTLH = require('@testing-library/react-hooks');
+    return RTLH.renderHook;
+  })();
+
+export const act: typeof ReactDOMAct =
+  RTL.act ??
+  (() => {
+    const RTLH = require('@testing-library/react-hooks');
+    return RTLH.act;
+  })();

--- a/packages/testing-lib/src/index.ts
+++ b/packages/testing-lib/src/index.ts
@@ -2,5 +2,6 @@ import * as Context from './context';
 import * as jest from './jest';
 import * as JestDOM from './jest-dom';
 export { act, renderHook } from './RTLOverrides';
+export { waitForState } from './waitForState';
 
 export { Context, jest, JestDOM };

--- a/packages/testing-lib/src/index.ts
+++ b/packages/testing-lib/src/index.ts
@@ -1,6 +1,6 @@
 import * as Context from './context';
 import * as jest from './jest';
 import * as JestDOM from './jest-dom';
-export { renderHook } from './renderHookOverride';
+export { act, renderHook } from './RTLOverrides';
 
 export { Context, jest, JestDOM };

--- a/packages/testing-lib/src/index.ts
+++ b/packages/testing-lib/src/index.ts
@@ -1,5 +1,6 @@
 import * as Context from './context';
 import * as jest from './jest';
 import * as JestDOM from './jest-dom';
+export { renderHook } from './renderHookOverride';
 
 export { Context, jest, JestDOM };

--- a/packages/testing-lib/src/renderHookOverride.ts
+++ b/packages/testing-lib/src/renderHookOverride.ts
@@ -1,8 +1,0 @@
-import * as RTL from '@testing-library/react';
-
-export const renderHook =
-  RTL.renderHook ??
-  (() => {
-    const RTLH = require('@testing-library/react-hooks');
-    return RTLH.renderHook;
-  })();

--- a/packages/testing-lib/src/renderHookOverride.ts
+++ b/packages/testing-lib/src/renderHookOverride.ts
@@ -1,8 +1,8 @@
-const rtl = require('@testing-library/react');
+import * as RTL from '@testing-library/react';
 
 export const renderHook =
-  rtl.renderHook ??
+  RTL.renderHook ??
   (() => {
-    const rtlh = require('@testing-library/react-hooks');
-    return rtlh.renderHook;
+    const RTLH = require('@testing-library/react-hooks');
+    return RTLH.renderHook;
   })();

--- a/packages/testing-lib/src/renderHookOverride.ts
+++ b/packages/testing-lib/src/renderHookOverride.ts
@@ -1,0 +1,8 @@
+const rtl = require('@testing-library/react');
+
+export const renderHook =
+  rtl.renderHook ??
+  (() => {
+    const rtlh = require('@testing-library/react-hooks');
+    return rtlh.renderHook;
+  })();

--- a/packages/testing-lib/src/waitForState.ts
+++ b/packages/testing-lib/src/waitForState.ts
@@ -14,6 +14,6 @@ export const waitForState = async <T extends any>(
     val = callback();
   });
 
-  // @ts-expect-error
+  // @ts-expect-error - val is returned before TS sees it as being defined
   return val;
 };

--- a/packages/testing-lib/src/waitForState.ts
+++ b/packages/testing-lib/src/waitForState.ts
@@ -1,0 +1,19 @@
+import { act } from './RTLOverrides';
+
+/**
+ * Wrapper around `act`.
+ *
+ * Awaits an `act` call,
+ * and returns the value of the state update callback
+ */
+export const waitForState = async <T extends any>(
+  callback: () => T,
+): Promise<T> => {
+  let val: T;
+  await act(() => {
+    val = callback();
+  });
+
+  // @ts-expect-error
+  return val;
+};

--- a/packages/testing-lib/tsconfig.json
+++ b/packages/testing-lib/tsconfig.json
@@ -6,7 +6,6 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
-      "@leafygreen-ui/icon/dist/*": ["../icon/src/generated/*"],
       "@leafygreen-ui/*": ["../*/src"]
     }
   },

--- a/packages/toast/src/ToastContext/ToastReducer/useToastReducer.spec.ts
+++ b/packages/toast/src/ToastContext/ToastReducer/useToastReducer.spec.ts
@@ -1,6 +1,7 @@
 import { act } from 'react-dom/test-utils';
 import { cleanup } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { Variant } from '../../Toast.types';
 import { ToastId, ToastStack } from '../ToastContext.types';

--- a/packages/toast/src/ToastContext/ToastReducer/useToastReducer.ts
+++ b/packages/toast/src/ToastContext/ToastReducer/useToastReducer.ts
@@ -113,16 +113,25 @@ export const useToastReducer = (initialValue?: ToastStack) => {
 
   const updateToast: ToastContextProps['updateToast'] = useCallback(
     (id: ToastId, props: Partial<ToastProps>) => {
-      dispatch({
+      const action: ToastReducerAction = {
         type: ToastReducerActionType.Update,
         payload: {
           id,
           props,
         },
-      });
-      return getToast(id);
+      };
+
+      dispatch(action);
+
+      // `getToast` will return the previous toast value,
+      // so we need to apply the state change manually
+      // in order to return the updated value
+      const { stack: newStack } = toastReducer({ stack }, action);
+      const updatedToast = newStack.get(id);
+
+      return updatedToast;
     },
-    [getToast],
+    [stack],
   );
 
   const clearStack: ToastContextProps['clearStack'] = useCallback(() => {

--- a/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
+++ b/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, useEffect } from 'react';
 import { render } from '@testing-library/react';
 import { cleanup } from '@testing-library/react-hooks';
 
-import { act, renderHook } from '@leafygreen-ui/testing-lib';
+import { renderHook, waitForState } from '@leafygreen-ui/testing-lib';
 
 import { ToastProps, Variant } from '../../Toast.types';
 import { ToastContext } from '../ToastContext';
@@ -58,7 +58,7 @@ describe('packages/toast/useToast', () => {
           wrapper: ToastProviderMock,
         });
         const { pushToast } = result.current;
-        const toastId = await act(() => pushToast({ title: 'test' }));
+        const toastId = await waitForState(() => pushToast({ title: 'test' }));
         expect(toastId).toEqual(expect.stringContaining('toast-'));
       });
 
@@ -68,7 +68,7 @@ describe('packages/toast/useToast', () => {
         });
         const { pushToast, getToast } = result.current;
 
-        const toastId = await act(() => pushToast({ title: 'test' }));
+        const toastId = await waitForState(() => pushToast({ title: 'test' }));
         rerender();
         expect(getToast(toastId)).toEqual(
           expect.objectContaining({ title: 'test' }),
@@ -80,14 +80,14 @@ describe('packages/toast/useToast', () => {
           wrapper: ToastProviderMock,
         });
         const { pushToast, updateToast } = result.current;
-        const toastId = await act(() =>
+        const toastId = await waitForState(() =>
           pushToast({
             title: 'test',
             variant: Variant.Progress,
             progress: 0,
           }),
         );
-        const updatedToast = await act(() => {
+        const updatedToast = await waitForState(() => {
           rerender();
           return updateToast(toastId, {
             progress: 0.5,
@@ -104,9 +104,9 @@ describe('packages/toast/useToast', () => {
           wrapper: ToastProviderMock,
         });
         const { pushToast, popToast } = result.current;
-        const toastId = await act(() => pushToast({ title: 'test' }));
+        const toastId = await waitForState(() => pushToast({ title: 'test' }));
         rerender();
-        const poppedToast = await act(() => popToast(toastId));
+        const poppedToast = await waitForState(() => popToast(toastId));
         expect(poppedToast).toEqual(expect.objectContaining({ title: 'test' }));
       });
 
@@ -115,7 +115,7 @@ describe('packages/toast/useToast', () => {
           wrapper: ToastProviderMock,
         });
         const { pushToast, getStack } = result.current;
-        await act(() => pushToast({ title: 'test' }));
+        await waitForState(() => pushToast({ title: 'test' }));
         rerender();
 
         expect(getStack()).toBeDefined();
@@ -127,8 +127,8 @@ describe('packages/toast/useToast', () => {
           wrapper: ToastProviderMock,
         });
         const { pushToast, clearStack, getStack } = result.current;
-        await act(() => pushToast({ title: 'test' }));
-        const clearedStack = await act(() => clearStack());
+        await waitForState(() => pushToast({ title: 'test' }));
+        const clearedStack = await waitForState(() => clearStack());
         expect(clearedStack).toBeUndefined();
         expect(getStack()?.size).toEqual(0);
       });

--- a/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
+++ b/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
@@ -1,14 +1,11 @@
 import React, { PropsWithChildren, useEffect } from 'react';
 import { render } from '@testing-library/react';
-import {
-  cleanup,
-  renderHook,
-  RenderHookResult,
-} from '@testing-library/react-hooks';
+import { cleanup } from '@testing-library/react-hooks';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { ToastProps, Variant } from '../../Toast.types';
 import { ToastContext } from '../ToastContext';
-import { ToastContextProps } from '../ToastContext.types';
 import { useToastReducer } from '../ToastReducer';
 import {
   makeToast,
@@ -56,61 +53,77 @@ describe('packages/toast/useToast', () => {
     });
 
     describe('returned functions return correct values', () => {
-      let current: RenderHookResult<
-        unknown,
-        ToastContextProps
-      >['result']['current'];
-
-      beforeEach(() => {
-        const { result } = renderHook(useToast, { wrapper: ToastProviderMock });
-        current = result.current;
-      });
-
       test('pushToast => ToastId', () => {
-        const { pushToast } = current;
+        const { result } = renderHook(useToast, {
+          wrapper: ToastProviderMock,
+        });
+        const { pushToast } = result.current;
         const toastId = pushToast({ title: 'test' });
         expect(toastId).toEqual(expect.stringContaining('toast-'));
       });
 
       test('getToast => ToastProps', () => {
-        const { pushToast, getToast } = current;
+        const { result, rerender } = renderHook(useToast, {
+          wrapper: ToastProviderMock,
+        });
+        const { pushToast, getToast } = result.current;
+
         const toastId = pushToast({ title: 'test' });
+        rerender();
         expect(getToast(toastId)).toEqual(
           expect.objectContaining({ title: 'test' }),
         );
       });
 
-      test('updateToast => ToastProps', () => {
-        const { pushToast, updateToast } = current;
+      test.skip('updateToast => ToastProps', () => {
+        const { result, rerender } = renderHook(useToast, {
+          wrapper: ToastProviderMock,
+        });
+        const { pushToast, updateToast } = result.current;
         const toastId = pushToast({
           title: 'test',
           variant: Variant.Progress,
           progress: 0,
         });
+        rerender();
+        const updatedToast = updateToast(toastId, { progress: 0.5 });
+        rerender();
 
-        expect(updateToast(toastId, { progress: 0.5 })).toEqual(
+        expect(updatedToast).toEqual(
           expect.objectContaining({ progress: 0.5 }),
         );
       });
 
       test('popToast => ToastProps', () => {
-        const { pushToast, popToast } = current;
+        const { result, rerender } = renderHook(useToast, {
+          wrapper: ToastProviderMock,
+        });
+        const { pushToast, popToast } = result.current;
         const toastId = pushToast({ title: 'test' });
+        rerender();
+
         expect(popToast(toastId)).toEqual(
           expect.objectContaining({ title: 'test' }),
         );
       });
 
       test('getStack => ToastStack (Map)', () => {
-        const { pushToast, getStack } = current;
+        const { result, rerender } = renderHook(useToast, {
+          wrapper: ToastProviderMock,
+        });
+        const { pushToast, getStack } = result.current;
         pushToast({ title: 'test' });
+        rerender();
 
         expect(getStack()).toBeDefined();
         expect(getStack()?.size).toEqual(1);
       });
 
       test('clearStack => void', () => {
-        const { pushToast, clearStack, getStack } = current;
+        const { result } = renderHook(useToast, {
+          wrapper: ToastProviderMock,
+        });
+        const { pushToast, clearStack, getStack } = result.current;
         pushToast({ title: 'test' });
         expect(clearStack()).toBeUndefined();
         expect(getStack()?.size).toEqual(0);

--- a/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
+++ b/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
@@ -53,22 +53,22 @@ describe('packages/toast/useToast', () => {
     });
 
     describe('returned functions return correct values', () => {
-      test('pushToast => ToastId', () => {
+      test('pushToast => ToastId', async () => {
         const { result } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
         const { pushToast } = result.current;
-        const toastId = pushToast({ title: 'test' });
+        const toastId = await act(() => pushToast({ title: 'test' }));
         expect(toastId).toEqual(expect.stringContaining('toast-'));
       });
 
-      test('getToast => ToastProps', () => {
+      test('getToast => ToastProps', async () => {
         const { result, rerender } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
         const { pushToast, getToast } = result.current;
 
-        const toastId = pushToast({ title: 'test' });
+        const toastId = await act(() => pushToast({ title: 'test' }));
         rerender();
         expect(getToast(toastId)).toEqual(
           expect.objectContaining({ title: 'test' }),
@@ -79,8 +79,9 @@ describe('packages/toast/useToast', () => {
         const { result, rerender } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
+        const { pushToast, updateToast } = result.current;
         const toastId = await act(() =>
-          result.current.pushToast({
+          pushToast({
             title: 'test',
             variant: Variant.Progress,
             progress: 0,
@@ -88,7 +89,7 @@ describe('packages/toast/useToast', () => {
         );
         const updatedToast = await act(() => {
           rerender();
-          return result.current.updateToast(toastId, {
+          return updateToast(toastId, {
             progress: 0.5,
           });
         });
@@ -98,38 +99,37 @@ describe('packages/toast/useToast', () => {
         );
       });
 
-      test('popToast => ToastProps', () => {
+      test('popToast => ToastProps', async () => {
         const { result, rerender } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
         const { pushToast, popToast } = result.current;
-        const toastId = pushToast({ title: 'test' });
+        const toastId = await act(() => pushToast({ title: 'test' }));
         rerender();
-
-        expect(popToast(toastId)).toEqual(
-          expect.objectContaining({ title: 'test' }),
-        );
+        const poppedToast = await act(() => popToast(toastId));
+        expect(poppedToast).toEqual(expect.objectContaining({ title: 'test' }));
       });
 
-      test('getStack => ToastStack (Map)', () => {
+      test('getStack => ToastStack (Map)', async () => {
         const { result, rerender } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
         const { pushToast, getStack } = result.current;
-        pushToast({ title: 'test' });
+        await act(() => pushToast({ title: 'test' }));
         rerender();
 
         expect(getStack()).toBeDefined();
         expect(getStack()?.size).toEqual(1);
       });
 
-      test('clearStack => void', () => {
+      test('clearStack => void', async () => {
         const { result } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
         const { pushToast, clearStack, getStack } = result.current;
-        pushToast({ title: 'test' });
-        expect(clearStack()).toBeUndefined();
+        await act(() => pushToast({ title: 'test' }));
+        const clearedStack = await act(() => clearStack());
+        expect(clearedStack).toBeUndefined();
         expect(getStack()?.size).toEqual(0);
       });
     });

--- a/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
+++ b/packages/toast/src/ToastContext/useToast/useToast.spec.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, useEffect } from 'react';
 import { render } from '@testing-library/react';
 import { cleanup } from '@testing-library/react-hooks';
 
-import { renderHook } from '@leafygreen-ui/testing-lib';
+import { act, renderHook } from '@leafygreen-ui/testing-lib';
 
 import { ToastProps, Variant } from '../../Toast.types';
 import { ToastContext } from '../ToastContext';
@@ -75,19 +75,23 @@ describe('packages/toast/useToast', () => {
         );
       });
 
-      test.skip('updateToast => ToastProps', () => {
+      test('updateToast => ToastProps', async () => {
         const { result, rerender } = renderHook(useToast, {
           wrapper: ToastProviderMock,
         });
-        const { pushToast, updateToast } = result.current;
-        const toastId = pushToast({
-          title: 'test',
-          variant: Variant.Progress,
-          progress: 0,
+        const toastId = await act(() =>
+          result.current.pushToast({
+            title: 'test',
+            variant: Variant.Progress,
+            progress: 0,
+          }),
+        );
+        const updatedToast = await act(() => {
+          rerender();
+          return result.current.updateToast(toastId, {
+            progress: 0.5,
+          });
         });
-        rerender();
-        const updatedToast = updateToast(toastId, { progress: 0.5 });
-        rerender();
 
         expect(updatedToast).toEqual(
           expect.objectContaining({ progress: 0.5 }),

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -19,6 +19,7 @@
     "@emotion/server": "11.11.0",
     "@lg-tools/build": "0.3.1",
     "@lg-tools/meta": "0.1.5",
+    "@leafygreen-ui/testing-lib": "^0.3.4",
     "@testing-library/dom": "9.3.1",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.0.0",

--- a/tools/validate/src/dependencies/config.ts
+++ b/tools/validate/src/dependencies/config.ts
@@ -54,7 +54,7 @@ export const externalDependencies = [
   '@svgr/*',
   '@testing-library/*',
   '@types/*',
-  '@typescript-eslint/&',
+  '@typescript-eslint/*',
   'buffer',
   'eslint*',
   'jest',

--- a/tools/validate/src/dependencies/config.ts
+++ b/tools/validate/src/dependencies/config.ts
@@ -38,34 +38,38 @@ export const ignoreFilePatterns: Array<RegExp> = [
 ];
 
 /**
- * These dependencies will be ignored when listed in a package.json.
  * These are globally available dev dependencies.
- * We don't want every component flagged for not having
- * these packages explicitly declared in its package.json
+ *
+ * Packages that omit these dependencies will not be flagged for missing dependencies.
+ *
+ * Packages that list these dependencies will not be flagged for unused dependencies
  */
-export const ignoreDependencies = [
-  '@leafygreen-ui/mongo-nav',
+export const externalDependencies = [
   '@babel/*',
   '@emotion/*',
+  '@leafygreen-ui/mongo-nav',
+  '@leafygreen-ui/testing-lib',
   '@rollup/*',
   '@storybook/*',
   '@svgr/*',
   '@testing-library/*',
   '@types/*',
-  '@typescript-*',
+  '@typescript-eslint/&',
   'buffer',
   'eslint*',
-  'jest*',
+  'jest',
+  'jest-*',
   'jest-axe',
   'prettier*',
   'prop-types',
   'react-*',
   'rollup*',
   'storybook-*',
+  'typescript',
   '*-loader',
   '*-lint*',
 ];
 
 export const depcheckOptions: depcheck.Options = {
-  ignoreMatches: ignoreDependencies,
+  ignoreMatches: externalDependencies,
 };

--- a/tools/validate/src/dependencies/utils/globToRegex.ts
+++ b/tools/validate/src/dependencies/utils/globToRegex.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns a _very_ rough approximation of a regex pattern,
+ * given a glob pattern.
+ *
+ * e.g. `globToRegex('@leafygreen-ui/*') // /@leafygreen-ui\/.+/`
+ *
+ * @internal
+ */
+export const globToRegex = (globPattern: string): RegExp => {
+  const regexPattern = globPattern.replace('*', '.+').replace('/', '\\/');
+  const regEx = new RegExp(regexPattern);
+  return regEx;
+};

--- a/tools/validate/src/dependencies/utils/index.ts
+++ b/tools/validate/src/dependencies/utils/index.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 import {
   devFilePatterns,
-  ignoreDependencies,
+  externalDependencies,
   ignoreFilePatterns,
 } from '../config';
 
@@ -106,7 +106,7 @@ export const isDependencyUsedInSourceFile = (
   importedPackages: depcheck.Results['using'],
 ): boolean => {
   // consider a dependency used in a package file if its in `ignoreMatches`
-  const isIgnored = ignoreDependencies.includes(depName);
+  const isIgnored = externalDependencies.includes(depName);
   const usedInPackageFile = importedPackages?.[depName]?.some(
     // is used in at least one...
     // file that is not ignored

--- a/tools/validate/src/dependencies/validateListedDependencies.ts
+++ b/tools/validate/src/dependencies/validateListedDependencies.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { ValidateCommandOptions } from '../validate.types';
 
-import { DepCheckFunctionProps, ignoreDependencies } from './config';
+import { DepCheckFunctionProps, externalDependencies } from './config';
 import {
   isDependencyOnlyUsedInTestFile,
   sortDependenciesByUsage,
@@ -38,16 +38,19 @@ export function validateListedDependencies(
     const listedButOnlyUsedAsDev = listedDependencies.filter(
       listedDepName =>
         !importedPackagesInSourceFile.includes(listedDepName) &&
-        !ignoreDependencies.includes(listedDepName),
+        !externalDependencies.some(glob => {
+          const regexPattern = glob.replace('*', '.+'); // a super rough conversion of glob pattern to regexp
+          const regEx = new RegExp(regexPattern);
+          return regEx.test(listedDepName);
+        }),
     );
 
-    verbose &&
+    if (listedButOnlyUsedAsDev.length && verbose) {
       console.log(
         `${chalk.blue(
           pkgName,
         )}: lists packages as dependency, but only uses them in test files`,
       );
-    verbose &&
       console.log(
         listedButOnlyUsedAsDev
           .map(
@@ -60,6 +63,7 @@ export function validateListedDependencies(
           )
           .join('\n'),
       );
+    }
 
     return listedButOnlyUsedAsDev;
   }

--- a/tools/validate/src/dependencies/validateListedDependencies.ts
+++ b/tools/validate/src/dependencies/validateListedDependencies.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { ValidateCommandOptions } from '../validate.types';
 
+import { globToRegex } from './utils/globToRegex';
 import { DepCheckFunctionProps, externalDependencies } from './config';
 import {
   isDependencyOnlyUsedInTestFile,
@@ -39,8 +40,7 @@ export function validateListedDependencies(
       listedDepName =>
         !importedPackagesInSourceFile.includes(listedDepName) &&
         !externalDependencies.some(glob => {
-          const regexPattern = glob.replace('*', '.+'); // a super rough conversion of glob pattern to regexp
-          const regEx = new RegExp(regexPattern);
+          const regEx = globToRegex(glob);
           return regEx.test(listedDepName);
         }),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4082,7 +4082,7 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@8.0.1":
+"@testing-library/react-hooks@8.0.1", "@testing-library/react-hooks@>=3.7.0":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
   integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==


### PR DESCRIPTION
Attempts to make usage of `renderHook` consistent between R17 & R18 test environments

To do this I needed to:

1. Re-export a version `renderHook` from `@leafygreen-ui/testing-lib`, either originating from `@testing-library/react` or `@testing-library/react-hooks`, depending on what packages we have installed (concept lifted from [react-spectrum](https://github.com/adobe/react-spectrum/blob/main/packages/dev/test-utils/src/renderOverride.js))
2. Update imports for all test files that use `renderHook`
3. Update tests to ensure they work using both the `/react-hooks` and `/react` versions of `renderHook`
    a. Update `toastReducer` logic to ensure we return the correct value from `updateToast`
4. Add `@leafygreen-ui/testing-lib` to `@lg-tools/test` dependencies
5. Exclude `@leafygreen-ui/testing-lib` from depcheck validation
6. Update `@leafygreen-ui/testing-lib` build scripts to not require `@lg-tools/cli` (this creates a circular dependency)

**Optional "todo"** : since we're now building `@leafygreen-ui/testing-lib` in the same way we build other `@lg-tools/*` packages, we may want to consider rescoping the package as `@lg-tools/testing-lib`