### PR TITLE
Adds multiple package managers to `link` script

### DIFF
--- a/.changeset/nice-crabs-sniff.md
+++ b/.changeset/nice-crabs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/meta': minor
+---
+
+Adds `pnpm` as a possible `getPackageManager` return value.

--- a/.changeset/wicked-donuts-search.md
+++ b/.changeset/wicked-donuts-search.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/link': minor
+---
+
+Previously, `lg link` would only install & link packages using `yarn`. Now it will check the destination app's package manager (via lock file) and link packages using the correct package manager.

--- a/tools/link/src/utils/createLinkFrom.spec.ts
+++ b/tools/link/src/utils/createLinkFrom.spec.ts
@@ -1,0 +1,48 @@
+import { ChildProcess } from 'child_process';
+import xSpawn from 'cross-spawn';
+import fsx from 'fs-extra';
+import { createLinkFrom } from './createLinkFrom';
+import { MockChildProcess } from './mocks.testutils';
+import path from 'path';
+
+describe('tools/link/createLinkFrom', () => {
+  let spawnSpy: jest.SpyInstance<ChildProcess>;
+
+  beforeAll(() => {
+    fsx.emptyDirSync('./tmp');
+    fsx.rmdirSync('./tmp/');
+    fsx.mkdirSync('./tmp/');
+    fsx.mkdirSync('./tmp/test');
+    fsx.mkdirSync('./tmp/test/test-package');
+  });
+
+  beforeEach(() => {
+    spawnSpy = jest.spyOn(xSpawn, 'spawn');
+    spawnSpy.mockImplementation((..._args) => new MockChildProcess());
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    fsx.emptyDirSync('./tmp');
+  });
+
+  afterAll(() => {
+    fsx.rmdirSync('./tmp/');
+  });
+
+  test('calls `npm link` command from package directory', () => {
+    createLinkFrom(path.resolve('./tmp/'), {
+      scopeName: '@example',
+      scopePath: 'test',
+      packageName: 'test-package',
+    });
+
+    expect(spawnSpy).toHaveBeenCalledWith(
+      'npm',
+      ['link'],
+      expect.objectContaining({
+        cwd: expect.stringContaining('tmp/test/test-package'),
+      }),
+    );
+  });
+});

--- a/tools/link/src/utils/createLinkFrom.spec.ts
+++ b/tools/link/src/utils/createLinkFrom.spec.ts
@@ -1,9 +1,10 @@
 import { ChildProcess } from 'child_process';
 import xSpawn from 'cross-spawn';
 import fsx from 'fs-extra';
+import path from 'path';
+
 import { createLinkFrom } from './createLinkFrom';
 import { MockChildProcess } from './mocks.testutils';
-import path from 'path';
 
 describe('tools/link/createLinkFrom', () => {
   let spawnSpy: jest.SpyInstance<ChildProcess>;

--- a/tools/link/src/utils/createLinkFrom.ts
+++ b/tools/link/src/utils/createLinkFrom.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { getPackageManager, SupportedPackageManager } from '@lg-tools/meta';
 import chalk from 'chalk';
 import { spawn } from 'cross-spawn';
 import path from 'path';
@@ -6,18 +7,29 @@ import path from 'path';
 import { findDirectory } from './findDirectory';
 import { PackageDetails } from './types';
 
+interface CreateLinkOptions extends PackageDetails {
+  verbose?: boolean;
+  packageManager?: SupportedPackageManager;
+}
+
 /**
  * Runs the yarn link command in a leafygreen-ui package directory
  * @returns Promise that resolves when the yarn link command has finished
  */
 export function createLinkFrom(
   source: string,
-  { scopeName, scopePath, packageName }: PackageDetails,
-  verbose?: boolean,
+  {
+    scopeName,
+    scopePath,
+    packageName,
+    packageManager,
+    verbose,
+  }: CreateLinkOptions,
 ): Promise<void> {
   const scopeSrc = scopePath;
   return new Promise<void>(resolve => {
     const packagesDirectory = findDirectory(process.cwd(), scopeSrc);
+    packageManager = packageManager ?? getPackageManager(process.cwd());
 
     if (packagesDirectory) {
       verbose &&
@@ -25,7 +37,8 @@ export function createLinkFrom(
           'Creating link for:',
           chalk.green(`${scopeName}/${packageName}`),
         );
-      spawn('yarn', ['link'], {
+
+      spawn(packageManager, ['link'], {
         cwd: path.join(packagesDirectory, packageName),
         stdio: verbose ? 'inherit' : 'ignore',
       })

--- a/tools/link/src/utils/createLinkFrom.ts
+++ b/tools/link/src/utils/createLinkFrom.ts
@@ -17,7 +17,7 @@ interface CreateLinkOptions extends PackageDetails {
  * @returns Promise that resolves when the yarn link command has finished
  */
 export function createLinkFrom(
-  source: string,
+  source: string = process.cwd(),
   {
     scopeName,
     scopePath,
@@ -28,8 +28,8 @@ export function createLinkFrom(
 ): Promise<void> {
   const scopeSrc = scopePath;
   return new Promise<void>(resolve => {
-    const packagesDirectory = findDirectory(process.cwd(), scopeSrc);
-    packageManager = packageManager ?? getPackageManager(process.cwd());
+    const packagesDirectory = findDirectory(source, scopeSrc);
+    packageManager = packageManager ?? getPackageManager(source);
 
     if (packagesDirectory) {
       verbose &&

--- a/tools/link/src/utils/install.spec.ts
+++ b/tools/link/src/utils/install.spec.ts
@@ -1,0 +1,48 @@
+import { ChildProcess } from 'child_process';
+import xSpawn from 'cross-spawn';
+import fsx from 'fs-extra';
+
+// const withLocalTmpDir = require('with-local-tmp-dir')
+import { installPackages } from './install';
+import { MockChildProcess } from './mocks.testutils';
+
+describe('tools/link/utils/install', () => {
+  let spawnSpy: jest.SpyInstance<ChildProcess>;
+
+  beforeAll(() => {
+    fsx.mkdirSync('./tmp/');
+  });
+
+  beforeEach(() => {
+    spawnSpy = jest.spyOn(xSpawn, 'spawn');
+    spawnSpy.mockImplementation((..._args) => new MockChildProcess());
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    fsx.emptyDirSync('./tmp');
+  });
+
+  afterAll(() => {
+    fsx.rmdirSync('./tmp/');
+  });
+
+  test('runs `npm install` command', async () => {
+    await installPackages('./tmp');
+    expect(spawnSpy).toHaveBeenCalledWith(
+      'npm',
+      ['install'],
+      expect.objectContaining({}),
+    );
+  });
+
+  test('runs install command using local package manager', async () => {
+    fsx.createFileSync('./tmp/yarn.lock');
+    await installPackages('./tmp');
+    expect(spawnSpy).toHaveBeenCalledWith(
+      'yarn',
+      ['install'],
+      expect.objectContaining({}),
+    );
+  });
+});

--- a/tools/link/src/utils/install.spec.ts
+++ b/tools/link/src/utils/install.spec.ts
@@ -2,7 +2,6 @@ import { ChildProcess } from 'child_process';
 import xSpawn from 'cross-spawn';
 import fsx from 'fs-extra';
 
-// const withLocalTmpDir = require('with-local-tmp-dir')
 import { installPackages } from './install';
 import { MockChildProcess } from './mocks.testutils';
 

--- a/tools/link/src/utils/install.ts
+++ b/tools/link/src/utils/install.ts
@@ -38,7 +38,9 @@ export async function installPackages(
         .on('error', err => {
           throw new Error(`Error installing packages\n` + err);
         });
+    } else {
+      console.error(`Path ${path} does not exist`);
+      reject();
     }
-    reject();
   });
 }

--- a/tools/link/src/utils/install.ts
+++ b/tools/link/src/utils/install.ts
@@ -1,7 +1,13 @@
+import { getPackageManager } from '@lg-tools/meta';
+import { SupportedPackageManager } from '@lg-tools/meta/src/getPackageManager';
 import { spawn } from 'cross-spawn';
+import fsx from 'fs-extra';
 
+/**
+ * @deprecated use `installPackages` instead
+ */
 export function yarnInstall(path: string) {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     spawn('yarn', ['install'], {
       cwd: path,
       stdio: 'ignore',
@@ -10,5 +16,29 @@ export function yarnInstall(path: string) {
       .on('error', () => {
         throw new Error(`Error installing packages`);
       });
+  });
+}
+
+export async function installPackages(
+  path: string,
+  options?: {
+    packageManager?: SupportedPackageManager;
+    verbose?: boolean;
+  },
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (fsx.existsSync(path)) {
+      const pkgMgr = options?.packageManager ?? getPackageManager(path);
+
+      spawn(pkgMgr, ['install'], {
+        cwd: path,
+        stdio: options?.verbose ? 'inherit' : 'ignore',
+      })
+        .on('close', resolve)
+        .on('error', err => {
+          throw new Error(`Error installing packages\n` + err);
+        });
+    }
+    reject();
   });
 }

--- a/tools/link/src/utils/install.ts
+++ b/tools/link/src/utils/install.ts
@@ -3,22 +3,6 @@ import { SupportedPackageManager } from '@lg-tools/meta/src/getPackageManager';
 import { spawn } from 'cross-spawn';
 import fsx from 'fs-extra';
 
-/**
- * @deprecated use `installPackages` instead
- */
-export function yarnInstall(path: string) {
-  return new Promise(resolve => {
-    spawn('yarn', ['install'], {
-      cwd: path,
-      stdio: 'ignore',
-    })
-      .on('close', resolve)
-      .on('error', () => {
-        throw new Error(`Error installing packages`);
-      });
-  });
-}
-
 export async function installPackages(
   path: string,
   options?: {

--- a/tools/link/src/utils/linkPackageTo.spec.ts
+++ b/tools/link/src/utils/linkPackageTo.spec.ts
@@ -1,10 +1,10 @@
 import { ChildProcess } from 'child_process';
 import xSpawn from 'cross-spawn';
 import fsx from 'fs-extra';
-import { MockChildProcess } from './mocks.testutils';
 import path from 'path';
 
 import { linkPackageTo } from './linkPackageTo';
+import { MockChildProcess } from './mocks.testutils';
 
 describe('tools/link/linkPackageTo', () => {
   let spawnSpy: jest.SpyInstance<ChildProcess>;

--- a/tools/link/src/utils/linkPackageTo.spec.ts
+++ b/tools/link/src/utils/linkPackageTo.spec.ts
@@ -1,19 +1,19 @@
 import { ChildProcess } from 'child_process';
 import xSpawn from 'cross-spawn';
 import fsx from 'fs-extra';
-import { createLinkFrom } from './createLinkFrom';
 import { MockChildProcess } from './mocks.testutils';
 import path from 'path';
 
-describe('tools/link/createLinkFrom', () => {
+import { linkPackageTo } from './linkPackageTo';
+
+describe('tools/link/linkPackageTo', () => {
   let spawnSpy: jest.SpyInstance<ChildProcess>;
 
   beforeAll(() => {
     fsx.emptyDirSync('./tmp');
     fsx.rmdirSync('./tmp/');
     fsx.mkdirSync('./tmp/');
-    fsx.mkdirSync('./tmp/scope');
-    fsx.mkdirSync('./tmp/scope/test-package');
+    fsx.mkdirSync('./tmp/app');
   });
 
   beforeEach(() => {
@@ -30,18 +30,17 @@ describe('tools/link/createLinkFrom', () => {
     fsx.rmdirSync('./tmp/');
   });
 
-  test('calls `npm link` command from package directory', () => {
-    createLinkFrom(path.resolve('./tmp/'), {
+  test('calls `npm link <package>` from the destination directory', () => {
+    linkPackageTo(path.resolve('./tmp/app'), {
       scopeName: '@example',
-      scopePath: 'scope',
       packageName: 'test-package',
     });
 
     expect(spawnSpy).toHaveBeenCalledWith(
       'npm',
-      ['link'],
+      ['link', '@example/test-package'],
       expect.objectContaining({
-        cwd: expect.stringContaining('tmp/scope/test-package'),
+        cwd: expect.stringContaining('tmp/app'),
       }),
     );
   });

--- a/tools/link/src/utils/linkPackageTo.ts
+++ b/tools/link/src/utils/linkPackageTo.ts
@@ -1,7 +1,14 @@
+import { getPackageManager, SupportedPackageManager } from '@lg-tools/meta';
 import chalk from 'chalk';
 import { spawn } from 'cross-spawn';
 
 import { PackageDetails } from './types';
+
+interface LinkPackagesToOptions
+  extends Pick<PackageDetails, 'scopeName' | 'packageName'> {
+  verbose?: boolean;
+  packageManager?: SupportedPackageManager;
+}
 
 /**
  * Runs the yarn link <packageName> command in the destination directory
@@ -9,14 +16,15 @@ import { PackageDetails } from './types';
  */
 export function linkPackageTo(
   destination: string,
-  { scopeName, packageName }: Pick<PackageDetails, 'scopeName' | 'packageName'>,
-  verbose?: boolean,
+  { scopeName, packageName, verbose, packageManager }: LinkPackagesToOptions,
 ): Promise<void> {
   const fullPackageName = `${scopeName}/${packageName}`;
   return new Promise<void>(resolve => {
     // eslint-disable-next-line no-console
     verbose && console.log('Linking package:', chalk.blue(fullPackageName));
-    spawn('yarn', ['link', fullPackageName], {
+    packageManager = packageManager ?? getPackageManager(destination);
+
+    spawn(packageManager, ['link', fullPackageName], {
       cwd: destination,
       stdio: verbose ? 'inherit' : 'ignore',
     })

--- a/tools/link/src/utils/linkPackagesForScope.spec.ts
+++ b/tools/link/src/utils/linkPackagesForScope.spec.ts
@@ -1,0 +1,67 @@
+import { ChildProcess } from 'child_process';
+import xSpawn from 'cross-spawn';
+import fsx from 'fs-extra';
+import { MockChildProcess } from './mocks.testutils';
+import path from 'path';
+import { linkPackagesForScope } from './linkPackagesForScope';
+
+describe('tools/link/linkPackagesForScope', () => {
+  let spawnSpy: jest.SpyInstance<ChildProcess>;
+
+  beforeAll(() => {
+    fsx.emptyDirSync('./tmp');
+    fsx.rmdirSync('./tmp/');
+    fsx.mkdirSync('./tmp/');
+  });
+
+  beforeEach(() => {
+    spawnSpy = jest.spyOn(xSpawn, 'spawn');
+    spawnSpy.mockImplementation((..._args) => new MockChildProcess());
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    fsx.emptyDirSync('./tmp');
+  });
+
+  afterAll(() => {
+    fsx.rmdirSync('./tmp/');
+  });
+
+  test('creates npm links, and consumes links for all packages', async () => {
+    fsx.mkdirSync('./tmp/packages');
+    fsx.mkdirSync('./tmp/packages/scope');
+    fsx.mkdirSync('./tmp/packages/scope/test-package');
+    fsx.mkdirSync('./tmp/app');
+    fsx.mkdirSync('./tmp/app/node_modules');
+    fsx.mkdirSync('./tmp/app/node_modules/@example');
+    fsx.mkdirSync('./tmp/app/node_modules/@example/test-package');
+
+    await linkPackagesForScope(
+      {
+        scopeName: '@example',
+        scopePath: 'scope',
+      },
+      path.resolve('./tmp/packages'),
+      path.resolve('./tmp/app'),
+    );
+
+    // Creates links
+    expect(spawnSpy).toHaveBeenCalledWith(
+      'npm',
+      ['link'],
+      expect.objectContaining({
+        cwd: expect.stringContaining('tmp/packages/scope/test-package'),
+      }),
+    );
+
+    // Consumes links
+    expect(spawnSpy).toHaveBeenCalledWith(
+      'npm',
+      ['link', '@example/test-package'],
+      expect.objectContaining({
+        cwd: expect.stringContaining('tmp/app'),
+      }),
+    );
+  });
+});

--- a/tools/link/src/utils/linkPackagesForScope.spec.ts
+++ b/tools/link/src/utils/linkPackagesForScope.spec.ts
@@ -1,9 +1,10 @@
 import { ChildProcess } from 'child_process';
 import xSpawn from 'cross-spawn';
 import fsx from 'fs-extra';
-import { MockChildProcess } from './mocks.testutils';
 import path from 'path';
+
 import { linkPackagesForScope } from './linkPackagesForScope';
+import { MockChildProcess } from './mocks.testutils';
 
 describe('tools/link/linkPackagesForScope', () => {
   let spawnSpy: jest.SpyInstance<ChildProcess>;

--- a/tools/link/src/utils/linkPackagesForScope.ts
+++ b/tools/link/src/utils/linkPackagesForScope.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-console */
+import { getPackageManager } from '@lg-tools/meta';
+import chalk from 'chalk';
+import fse from 'fs-extra';
+import path from 'path';
+
+import { createLinkFrom } from './createLinkFrom';
+import { formatLog } from './formatLog';
+import { installPackages } from './install';
+import { linkPackageTo } from './linkPackageTo';
+import { PackageDetails } from './types';
+
+/** Packages that we will not link */
+const ignorePackages = ['mongo-nav'];
+
+export async function linkPackagesForScope(
+  { scopeName, scopePath }: Pick<PackageDetails, 'scopeName' | 'scopePath'>,
+  source: string,
+  destination: string,
+  packages?: Array<string>,
+  verbose?: boolean,
+): Promise<void> {
+  const node_modulesDir = path.join(destination, 'node_modules');
+
+  // The directory where the scope's packages are installed
+  const installedModulesDir = path.join(destination, 'node_modules', scopeName);
+
+  if (fse.existsSync(node_modulesDir)) {
+    // Check that the destination has scope's packages installed
+    if (fse.existsSync(installedModulesDir)) {
+      // Get a list of all the packages in the destination
+      // Run npm link on each package
+      // Run npm link <packageName> on the destination
+      const installedLGPackages = fse.readdirSync(installedModulesDir);
+
+      const destinationPackageManager = getPackageManager(destination);
+
+      const packagesToLink = installedLGPackages.filter(
+        installedPkg =>
+          !ignorePackages.includes(installedPkg) &&
+          (!packages ||
+            packages.some(pkgFlag => pkgFlag.includes(installedPkg))),
+      );
+
+      /** Create links */
+      console.log(
+        chalk.gray(
+          ` Creating links to ${formatLog.scope(scopeName)} packages...`,
+        ),
+      );
+      await Promise.all(
+        packagesToLink.map(pkg => {
+          createLinkFrom(source, {
+            scopeName,
+            scopePath,
+            packageName: pkg,
+            verbose,
+            packageManager: destinationPackageManager,
+          });
+        }),
+      );
+
+      /** Connect link */
+      console.log(
+        chalk.gray(
+          ` Connecting links for ${formatLog.scope(
+            scopeName,
+          )} packages to ${chalk.blue(formatLog.path(destination))}...`,
+        ),
+      );
+      await Promise.all(
+        packagesToLink.map((pkg: string) =>
+          linkPackageTo(destination, {
+            scopeName,
+            packageName: pkg,
+            packageManager: destinationPackageManager,
+            verbose,
+          }),
+        ),
+      );
+    } else {
+      console.error(
+        chalk.gray(
+          ` Couldn't find ${formatLog.scope(
+            scopeName,
+          )} scoped packages installed at ${chalk.blue(
+            formatLog.path(destination),
+          )}. Skipping.`,
+        ),
+      );
+    }
+  } else {
+    console.error(chalk.yellow(`${formatLog.path('node_modules')} not found.`));
+    // TODO: Prompt user to install instead of just running it
+
+    await installPackages(destination);
+
+    await linkPackagesForScope(
+      { scopeName, scopePath },
+      destination,
+      source,
+      packages,
+      verbose,
+    );
+  }
+}

--- a/tools/link/src/utils/mocks.testutils.ts
+++ b/tools/link/src/utils/mocks.testutils.ts
@@ -1,0 +1,8 @@
+import { ChildProcess } from 'child_process';
+
+export class MockChildProcess extends ChildProcess {
+  on = jest.fn().mockImplementation((event: string, cb: Function) => {
+    cb();
+    return new MockChildProcess();
+  });
+}

--- a/tools/meta/src/getPackageManager.spec.ts
+++ b/tools/meta/src/getPackageManager.spec.ts
@@ -1,0 +1,45 @@
+import fsx from 'fs-extra';
+
+import { getPackageManager } from './getPackageManager';
+
+describe('tools/meta/getPackageManager', () => {
+  beforeAll(() => {
+    fsx.mkdirSync('./tmp/');
+  });
+
+  afterEach(() => {
+    fsx.emptyDirSync('./tmp');
+  });
+
+  afterAll(() => {
+    fsx.rmdirSync('./tmp/');
+  });
+
+  test('returns `npm` by default', () => {
+    const pkgMgr = getPackageManager('./tmp');
+    expect(pkgMgr).toBe('npm');
+  });
+
+  test('returns provided default package manager', () => {
+    const pkgMgr = getPackageManager('./tmp', 'yarn');
+    expect(pkgMgr).toBe('yarn');
+  });
+
+  test('returns `npm` when package-lock exists', () => {
+    fsx.createFileSync('./tmp/package-lock.json');
+    const pkgMgr = getPackageManager('./tmp');
+    expect(pkgMgr).toBe('npm');
+  });
+
+  test('returns `yarn` when yarn.lock exists', () => {
+    fsx.createFileSync('./tmp/yarn.lock');
+    const pkgMgr = getPackageManager('./tmp');
+    expect(pkgMgr).toBe('yarn');
+  });
+
+  test('returns `pnpm` when pnpm-lock exists', () => {
+    fsx.createFileSync('./tmp/pnpm-lock.yaml');
+    const pkgMgr = getPackageManager('./tmp');
+    expect(pkgMgr).toBe('pnpm');
+  });
+});

--- a/tools/meta/src/getPackageManager.ts
+++ b/tools/meta/src/getPackageManager.ts
@@ -1,11 +1,19 @@
 import fse from 'fs-extra';
+
+export type SupportedPackageManager = `npm` | `yarn` | `pnpm`;
+
 /** Reads the lock file to determine which package manager to use */
-export function getPackageManager(appPath: string): `npm` | `yarn` {
+export function getPackageManager(
+  appPath: string,
+  defaultPackageManager: SupportedPackageManager = 'npm',
+): SupportedPackageManager {
   if (fse.existsSync(`${appPath}/yarn.lock`)) {
     return 'yarn';
+  } else if (fse.existsSync(`${appPath}/pnpm-lock.yaml`)) {
+    return 'pnpm';
   } else if (fse.existsSync(`${appPath}/package-lock.json`)) {
     return 'npm';
   }
 
-  return 'npm';
+  return defaultPackageManager;
 }

--- a/tools/meta/src/index.ts
+++ b/tools/meta/src/index.ts
@@ -2,6 +2,9 @@ export { exitWithErrorMessage } from './exitWithErrorMessage';
 export { getAllPackageNames, getAllPackages } from './getAllPackages';
 export { getLGConfig, type LGConfig } from './getLGConfig';
 export { getPackageJson } from './getPackageJson';
-export { getPackageManager } from './getPackageManager';
+export {
+  getPackageManager,
+  type SupportedPackageManager,
+} from './getPackageManager';
 export { getPackageName } from './getPackageName';
 export { getRootPackageJson, isValidJSON } from './getRootPackageJson';


### PR DESCRIPTION
Previously the `lg link` script would only install & link packages using yarn. Now it will check the destination app's package manager (via lock file) and link packages using the correct package manager.

Additionally, this PR tests for many `link` utils

