### PR TITLE
Popover Props [LG-3797]

### DIFF
--- a/.changeset/popular-hats-travel.md
+++ b/.changeset/popular-hats-travel.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/popover': patch
+---
+
+Adds @types/react-transition-group as a dependency of Popover

--- a/.changeset/popular-hats-travel.md
+++ b/.changeset/popular-hats-travel.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/popover': patch
 ---
 
-Adds @types/react-transition-group as a dependency of Popover
+Adds `@types/react-transition-group` as a dependency of `Popover`. This ensures that any components extending `PopoverProps` are typed correctly.

--- a/.changeset/stale-bikes-smoke.md
+++ b/.changeset/stale-bikes-smoke.md
@@ -1,5 +1,0 @@
----
-'@leafygreen-ui/popover': minor
----
-
-All props in TransitionLifecycleCallbacks are now optional

--- a/.changeset/stale-bikes-smoke.md
+++ b/.changeset/stale-bikes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/popover': minor
+---
+
+All props in TransitionLifecycleCallbacks are now optional

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/lodash": "^4.14.170",
     "@types/react": "18.2.23",
     "@types/react-dom": "18.2.8",
-    "@types/react-transition-group": "4.4.8",
     "chromatic": "^6.17.2",
     "dotenv": "^10.0.0",
     "gh-pages": "^3.1.0",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -27,12 +27,12 @@
     "@leafygreen-ui/lib": "^13.2.0",
     "@leafygreen-ui/portal": "^5.0.3",
     "@leafygreen-ui/tokens": "^2.2.0",
-    "react-transition-group": "^4.4.5"
+    "react-transition-group": "^4.4.5",
+    "@types/react-transition-group": "^4.4.5"
   },
   "devDependencies": {
     "@leafygreen-ui/palette": "^4.0.7",
-    "@leafygreen-ui/button": "^21.0.11",
-    "@types/react-transition-group": "4.4.8"
+    "@leafygreen-ui/button": "^21.0.11"
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "^3.1.11"

--- a/packages/popover/src/Popover.types.ts
+++ b/packages/popover/src/Popover.types.ts
@@ -5,11 +5,9 @@ import { HTMLElementProps } from '@leafygreen-ui/lib';
 
 type TransitionProps = React.ComponentProps<typeof Transition<HTMLElement>>;
 
-type TransitionLifecycleCallbacks = Partial<
-  Pick<
-    TransitionProps,
-    'onEnter' | 'onEntering' | 'onEntered' | 'onExit' | 'onExiting' | 'onExited'
-  >
+type TransitionLifecycleCallbacks = Pick<
+  TransitionProps,
+  'onEnter' | 'onEntering' | 'onEntered' | 'onExit' | 'onExiting' | 'onExited'
 >;
 
 /**

--- a/packages/popover/src/Popover.types.ts
+++ b/packages/popover/src/Popover.types.ts
@@ -4,9 +4,12 @@ import { Transition } from 'react-transition-group';
 import { HTMLElementProps } from '@leafygreen-ui/lib';
 
 type TransitionProps = React.ComponentProps<typeof Transition<HTMLElement>>;
-type TransitionLifecycleCallbacks = Pick<
-  TransitionProps,
-  'onEnter' | 'onEntering' | 'onEntered' | 'onExit' | 'onExiting' | 'onExited'
+
+type TransitionLifecycleCallbacks = Partial<
+  Pick<
+    TransitionProps,
+    'onEnter' | 'onEntering' | 'onEntered' | 'onExit' | 'onExiting' | 'onExited'
+  >
 >;
 
 /**

--- a/packages/popover/src/Popover/Popover.spec.tsx
+++ b/packages/popover/src/Popover/Popover.spec.tsx
@@ -224,6 +224,15 @@ describe('packages/popover', () => {
         Popover Content
       </Popover>;
     });
+    
+    test('accepts transition lifecycle props', () => {
+      <Popover onEnter={() => {}}>test</Popover>;
+      <Popover onEntering={() => {}}>test</Popover>;
+      <Popover onEntered={() => {}}>test</Popover>;
+      <Popover onExit={() => {}}>test</Popover>;
+      <Popover onExiting={() => {}}>test</Popover>;
+      <Popover onExited={() => {}}>test</Popover>;
+    });    
 
     test('accepts `div` props', () => {
       <Popover

--- a/packages/popover/src/Popover/Popover.spec.tsx
+++ b/packages/popover/src/Popover/Popover.spec.tsx
@@ -224,7 +224,7 @@ describe('packages/popover', () => {
         Popover Content
       </Popover>;
     });
-    
+
     test('accepts transition lifecycle props', () => {
       <Popover onEnter={() => {}}>test</Popover>;
       <Popover onEntering={() => {}}>test</Popover>;
@@ -232,7 +232,7 @@ describe('packages/popover', () => {
       <Popover onExit={() => {}}>test</Popover>;
       <Popover onExiting={() => {}}>test</Popover>;
       <Popover onExited={() => {}}>test</Popover>;
-    });    
+    });
 
     test('accepts `div` props', () => {
       <Popover

--- a/packages/popover/src/Popover/Popover.spec.tsx
+++ b/packages/popover/src/Popover/Popover.spec.tsx
@@ -209,13 +209,13 @@ describe('packages/popover', () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   describe.skip('types', () => {
-    test('default', () => {
-      <Popover>Popover Content</Popover>;
-    });
-
     test('requires children', () => {
       // @ts-expect-error
       <Popover></Popover>;
+    });
+
+    test('Requires only children', () => {
+      <Popover>Popover Content</Popover>;
     });
 
     test('does not allow specifying "portalClassName", when "usePortal" is false', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4616,10 +4616,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@4.4.8":
-  version "4.4.8"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.8.tgz#46f87d80512959cac793ecc610a93d80ef241ccf"
-  integrity sha512-QmQ22q+Pb+HQSn04NL3HtrqHwYMf4h3QKArOy5F8U5nEVMaihBs3SR10WiOM1iwPz5jIo8x/u11al+iEGZZrvg==
+"@types/react-transition-group@^4.4.5":
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
+  integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Resolves: https://jira.mongodb.org/browse/LG-3797

Popover now require `@types/react-transition-group` so components extending `PopoverProps` use the correct types.

Duplicates https://github.com/mongodb/leafygreen-ui/pull/2159