### PR TITLE
[LG-3617] Menu backdrop click with popover as children

### DIFF
--- a/packages/hooks/src/useBackdropClick/index.ts
+++ b/packages/hooks/src/useBackdropClick/index.ts
@@ -1,0 +1,1 @@
+export { useBackdropClick } from './useBackdropClick';

--- a/packages/hooks/src/useBackdropClick/useBackdropClick.ts
+++ b/packages/hooks/src/useBackdropClick/useBackdropClick.ts
@@ -1,4 +1,4 @@
-import useEventListener from './useEventListener';
+import useEventListener from '../useEventListener';
 
 /**
  * Fires a callback when any element(s)

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -34,6 +34,10 @@
     "lodash": "^4.17.21",
     "react-transition-group": "^4.4.5"
   },
+  "devDependencies": {
+    "@leafygreen-ui/button": "^21.0.9",
+    "@leafygreen-ui/modal": "^16.0.3"
+  },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "^3.1.10"
   },
@@ -45,8 +49,5 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
-  },
-  "devDependencies": {
-    "@leafygreen-ui/button": "^21.0.9"
   }
 }

--- a/packages/menu/src/Menu.spec.tsx
+++ b/packages/menu/src/Menu.spec.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import {
   getAllByRole as globalGetAllByRole,
+  prettyDOM,
   render,
   waitFor,
   waitForElementToBeRemoved,
-  prettyDOM,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import Popover from '@leafygreen-ui/popover';
 import { expectElementToNotBeRemoved } from '@leafygreen-ui/testing-lib';
 
@@ -280,7 +281,7 @@ describe('packages/menu', () => {
     });
 
     test('clicking Popover rendered by `MenuItem` does not close the menu', async () => {
-      const SomeMenuItem = React.forwardRef(({ popoverRef }: any, fwdRef) => {
+      const SomeMenuItem = ({ popoverRef }: any) => {
         const [popoverOpen, setPopoverOpen] = useState(false);
 
         const handleClick = () => {
@@ -301,7 +302,7 @@ describe('packages/menu', () => {
             </Popover>
           </>
         );
-      });
+      };
 
       const popoverRef = React.createRef<HTMLElement>();
       const { getByTestId, findByTestId } = render(

--- a/packages/menu/src/Menu.spec.tsx
+++ b/packages/menu/src/Menu.spec.tsx
@@ -280,7 +280,7 @@ describe('packages/menu', () => {
     });
 
     test('clicking Popover rendered by `MenuItem` does not close the menu', async () => {
-      const SomeMenuItem = () => {
+      const SomeMenuItem = React.forwardRef(({ popoverRef }: any, fwdRef) => {
         const [popoverOpen, setPopoverOpen] = useState(false);
 
         const handleClick = () => {
@@ -292,16 +292,25 @@ describe('packages/menu', () => {
             <MenuItem data-testid="menu-item" onClick={handleClick}>
               Open modal
             </MenuItem>
-            <Popover data-testid={'popover'} active={popoverOpen}>
+            <Popover
+              ref={popoverRef}
+              data-testid="popover"
+              active={popoverOpen}
+            >
               Popover content
             </Popover>
           </>
         );
-      };
+      });
 
+      const popoverRef = React.createRef<HTMLElement>();
       const { getByTestId, findByTestId } = render(
-        <Menu trigger={trigger} data-testid={menuTestId}>
-          <SomeMenuItem />
+        <Menu
+          trigger={trigger}
+          data-testid={menuTestId}
+          foreground={popoverRef}
+        >
+          <SomeMenuItem popoverRef={popoverRef} />
         </Menu>,
       );
       const button = getByTestId('menu-trigger');

--- a/packages/menu/src/Menu.spec.tsx
+++ b/packages/menu/src/Menu.spec.tsx
@@ -88,84 +88,6 @@ describe('packages/menu', () => {
     });
   });
 
-  test('clicking a menuitem closes the menu', async () => {
-    const { getByTestId } = renderMenu({
-      trigger,
-    });
-
-    const button = getByTestId('menu-trigger');
-
-    userEvent.click(button);
-    const menu = getByTestId(menuTestId);
-
-    expect(menu).toBeInTheDocument();
-
-    const menuItem = getByTestId('menu-item-a');
-    userEvent.click(menuItem);
-
-    await waitForElementToBeRemoved(menu);
-    expect(menu).not.toBeInTheDocument();
-  });
-
-  test('pressing enter on a menuitem closes the menu', async () => {
-    const { getByTestId } = renderMenu({
-      trigger,
-    });
-
-    const button = getByTestId('menu-trigger');
-
-    userEvent.click(button);
-    const menu = getByTestId(menuTestId);
-
-    expect(menu).toBeInTheDocument();
-
-    const menuItem = getByTestId('menu-item-a');
-
-    menuItem.focus();
-    userEvent.keyboard('[Enter]');
-
-    await waitForElementToBeRemoved(menu);
-    expect(menu).not.toBeInTheDocument();
-  });
-
-  test('pressing space on a menuitem closes the menu', async () => {
-    const { getByTestId } = renderMenu({
-      trigger,
-    });
-
-    const button = getByTestId('menu-trigger');
-
-    userEvent.click(button);
-    const menu = getByTestId(menuTestId);
-
-    expect(menu).toBeInTheDocument();
-
-    const menuItem = getByTestId('menu-item-a');
-
-    menuItem.focus();
-    userEvent.keyboard('[Space]');
-
-    await waitForElementToBeRemoved(menu);
-    expect(menu).not.toBeInTheDocument();
-  });
-
-  test('clicking outside the menu closes the menu', async () => {
-    const { getByTestId, backdrop } = renderMenu({
-      trigger,
-    });
-
-    const button = getByTestId('menu-trigger');
-    userEvent.click(button);
-    const menu = getByTestId(menuTestId);
-
-    expect(menu).toBeInTheDocument();
-
-    userEvent.click(backdrop);
-
-    await waitForElementToBeRemoved(menu);
-    expect(menu).not.toBeInTheDocument();
-  });
-
   describe('when controlled', () => {
     const ControlledExample = () => {
       const [open, setOpen] = React.useState(true);
@@ -274,6 +196,84 @@ describe('packages/menu', () => {
         expect(menu).toBeInTheDocument();
         expect(parentHandler).toHaveBeenCalled();
       });
+    });
+
+    test('clicking a menuitem closes the menu', async () => {
+      const { getByTestId } = renderMenu({
+        trigger,
+      });
+
+      const button = getByTestId('menu-trigger');
+
+      userEvent.click(button);
+      const menu = getByTestId(menuTestId);
+
+      expect(menu).toBeInTheDocument();
+
+      const menuItem = getByTestId('menu-item-a');
+      userEvent.click(menuItem);
+
+      await waitForElementToBeRemoved(menu);
+      expect(menu).not.toBeInTheDocument();
+    });
+
+    test('pressing enter on a menuitem closes the menu', async () => {
+      const { getByTestId } = renderMenu({
+        trigger,
+      });
+
+      const button = getByTestId('menu-trigger');
+
+      userEvent.click(button);
+      const menu = getByTestId(menuTestId);
+
+      expect(menu).toBeInTheDocument();
+
+      const menuItem = getByTestId('menu-item-a');
+
+      menuItem.focus();
+      userEvent.keyboard('[Enter]');
+
+      await waitForElementToBeRemoved(menu);
+      expect(menu).not.toBeInTheDocument();
+    });
+
+    test('pressing space on a menuitem closes the menu', async () => {
+      const { getByTestId } = renderMenu({
+        trigger,
+      });
+
+      const button = getByTestId('menu-trigger');
+
+      userEvent.click(button);
+      const menu = getByTestId(menuTestId);
+
+      expect(menu).toBeInTheDocument();
+
+      const menuItem = getByTestId('menu-item-a');
+
+      menuItem.focus();
+      userEvent.keyboard('[Space]');
+
+      await waitForElementToBeRemoved(menu);
+      expect(menu).not.toBeInTheDocument();
+    });
+
+    test('clicking outside the menu closes the menu', async () => {
+      const { getByTestId, backdrop } = renderMenu({
+        trigger,
+      });
+
+      const button = getByTestId('menu-trigger');
+      userEvent.click(button);
+      const menu = getByTestId(menuTestId);
+
+      expect(menu).toBeInTheDocument();
+
+      userEvent.click(backdrop);
+
+      await waitForElementToBeRemoved(menu);
+      expect(menu).not.toBeInTheDocument();
     });
   });
 

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -92,6 +92,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
     portalContainer,
     scrollContainer,
     popoverZIndex,
+    foreground,
     ...rest
   }: MenuProps,
   forwardRef,
@@ -282,7 +283,19 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
     }
   }, [open]);
 
-  useBackdropClick(handleClose, [popoverRef, triggerRef], open);
+  useBackdropClick(
+    handleClose,
+    [
+      popoverRef,
+      triggerRef,
+      ...(foreground
+        ? Array.isArray(foreground)
+          ? foreground
+          : [foreground]
+        : []),
+    ],
+    open,
+  );
 
   function handleKeyDown(e: KeyboardEvent) {
     let refToFocus: HTMLElement;

--- a/packages/menu/src/Menu/Menu.types.ts
+++ b/packages/menu/src/Menu/Menu.types.ts
@@ -67,4 +67,13 @@ export interface MenuProps extends Omit<PopoverProps, 'active'> {
    * id passed to the menu dropdown.
    */
   id?: string;
+
+  /**
+   * Element(s) (in addition to the trigger & menu) that are excluded from backdrop click
+   *
+   * (i.e. when these elements are clicked, the menu will not close)
+   */
+  foreground?:
+    | React.RefObject<HTMLElement>
+    | Array<React.RefObject<HTMLElement>>;
 }

--- a/packages/testing-lib/src/expectElementToNotBeRemoved/index.ts
+++ b/packages/testing-lib/src/expectElementToNotBeRemoved/index.ts
@@ -1,0 +1,27 @@
+import {
+  prettyDOM,
+  waitForElementToBeRemoved,
+  waitForOptions,
+} from '@testing-library/react';
+
+/**
+ * Throws an error if the element is removed.
+ *
+ * Waits for the element to be removed, and throws an error if it is removed.
+ * Expects the `waitForElementToBeRemoved` call to throw a timeout error
+ */
+export async function expectElementToNotBeRemoved(
+  element: HTMLElement,
+  waitForOptions?: waitForOptions,
+) {
+  try {
+    await waitForElementToBeRemoved(element, waitForOptions);
+    throw new Error(`Element was removed: \n ${prettyDOM(element)}`);
+  } catch (error) {
+    if (error instanceof Error) {
+      expect(error.toString()).toMatch(
+        'Timed out in waitForElementToBeRemoved.',
+      );
+    }
+  }
+}

--- a/packages/testing-lib/src/index.ts
+++ b/packages/testing-lib/src/index.ts
@@ -1,10 +1,11 @@
 import * as Context from './context';
 import * as jest from './jest';
 import * as JestDOM from './jest-dom';
-export { act, renderHook } from './RTLOverrides';
-export { waitForState } from './waitForState';
 
 export { Context, jest, JestDOM };
 
 export { eventContainingTargetValue } from './eventContainingTargetValue';
+export { expectElementToNotBeRemoved } from './expectElementToNotBeRemoved';
+export { act, renderHook } from './RTLOverrides';
 export { tabNTimes } from './tabNTimes';
+export { waitForState } from './waitForState';


### PR DESCRIPTION
## ✍️ Proposed changes

🎟 _Jira ticket:_ https://jira.mongodb.org/browse/LG-3617

Proposes a `foreground` prop to `Menu`.

This enables developers to render Portal-ed content from within Menu and prevent clicks in the portal's content from triggering the `backdropClick` handler to close the menu. This also enables developers to identify any other external elements that should not cause the menu to close when clicked.

### Usage
```ts
const App = () => {
  const popoverRef = useRef(null);

  return (
    <Menu trigger={trigger} foreground={popoverRef}>
      <SomeMenuItem popoverRef={popoverRef} />
    </Menu>
  )
}

const SomeMenuItem = ({ popoverRef }) => {
  const [popoverOpen, setPopoverOpen] = useState(false);

  const handleClick = () => {
    setPopoverOpen(o => !o);
  };

  return (
    <>
      <MenuItem onClick={handleClick}>Open modal</MenuItem>
      <Popover ref={popoverRef} active={popoverOpen}>Popover content</Popover>
    </>
  );
};
```

### Background
Inside `Menu` we assign `refs` to the trigger element and menu element.
Then from `useBackdropClick` we create a global 'click' event handler. When this is fired, we check to see if the click originated from the trigger, menu, or any of their children. If it was not, then we consider this a "backdrop click" and close the menu.

However, if a `MenuItem` renders a Modal, clicks on the Modal will trigger the backdrop click.
This is because portal-ed content (e.g. Modal) is not a DOM descendant of either the trigger or menu.

### Attempted fixes
I was hoping to be able to solve this by checking the React tree instead of the DOM tree, however this is not always possible. Additionally, even if we _could_ access the full React tree, we would need a `ref` assigned to each descendant. Otherwise, if an element was clicked without a ref assigned, we would have no way of checking whether the event target is in the menu's sub-tree.

## Alternatives
It's not recommended to render Portal-ed content from within another portal. The alternative solution would be to require any Portals opened by MenuItems to be siblings of the Menu itself

i.e.
```ts
const App = () => {
  const [popoverOpen, setPopoverOpen] = useState(false);

  const handleClick = () => {
    setPopoverOpen(o => !o);
  };

  return (
    <>
      <Popover ref={fwdRef} active={popoverOpen}>Popover content</Popover>
      <Menu trigger={trigger}>
        <MenuItem onClick={handleClick}>Open modal</MenuItem>
      </Menu>
    </>
  )
}
```

