### PR TITLE
Expose scroll to index functionality in table

### DIFF
--- a/.changeset/four-vans-tickle.md
+++ b/.changeset/four-vans-tickle.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/table': minor
+---
+
+useLeafygreenTable now exposes an `scrollToIndex` method for virtualized tables.

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -188,7 +188,7 @@ Setting this prop will indicate that the Table component is being used with the 
 
 #### `useVirtualScrolling`
 
-`react-virtual`'s `useVirtual` hook will be called if this option is set. When this option is set, the object returned by `useLeafygreenTable` will include `virtualRows` and `totalSize`. Refer to our [Storybook deployment](https://mongodb.github.io/leafygreen-ui) to find examples.
+`react-virtual`'s `useVirtual` hook will be called if this option is set. When this option is set, the object returned by `useLeafygreenTable` will include `virtualRows`, `totalSize` and `scrollToIndex`. Refer to our [Storybook deployment](https://mongodb.github.io/leafygreen-ui) to find examples.
 
 > Note that the number of virtual rows rendered depends on the height passed to the `Table` component. For a reasonably performant use of virtual scrolling, ensure that there is a height set on the component to reduce the number of virtual rows rendered.
 

--- a/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.tsx
+++ b/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.tsx
@@ -83,6 +83,7 @@ function useLeafyGreenTable<T extends LGRowData, V extends unknown = unknown>({
     ...(useVirtualScrolling && {
       virtualRows: _rowVirtualizer.virtualItems,
       totalSize: _rowVirtualizer.totalSize,
+      scrollToIndex: _rowVirtualizer.scrollToIndex,
     }),
     hasSelectableRows,
   } as LeafyGreenTable<T>;

--- a/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.types.ts
+++ b/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.types.ts
@@ -54,7 +54,7 @@ export interface LeafyGreenTableOptions<
 /** LeafyGreen extension of `useReactTable` {@link Table}*/
 export interface LeafyGreenTable<T extends LGRowData>
   extends Table<LGTableDataType<T>>,
-    Pick<VirtualizerValues, 'totalSize'> {
+    Pick<VirtualizerValues, 'totalSize' | 'scrollToIndex'> {
   virtualRows?: Array<VirtualItem>;
   hasSelectableRows: boolean;
 }


### PR DESCRIPTION
## ✍️ Proposed changes

We would like to expose the `scrollToIndex` method in the @leafygreen-ui/table virtualization library to allow the table to programmatically scroll to a certain row. 

🎟 _Jira ticket:_ [Name of ticket](https://jira.mongodb.org/browse/[name-of-ticket])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
