### PR TITLE
Table cell overflow [LG-3952]

### DIFF
--- a/.changeset/old-singers-kneel.md
+++ b/.changeset/old-singers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/table': minor
+---
+
+Adds `contentClassName` prop, applied to the inner `div` of the Cell

--- a/.changeset/wicked-impalas-battle.md
+++ b/.changeset/wicked-impalas-battle.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/table': minor
+---
+
+Adds `overflow` prop to `Cell` component. By default there is no change. When `overflow === 'truncate'`, the styling of the cell is updated (if necessary) to be aligned to the top, with an ellipsis after 2 lines of text.

--- a/packages/table/src/Cell/Cell.styles.ts
+++ b/packages/table/src/Cell/Cell.styles.ts
@@ -1,7 +1,7 @@
 import { TransitionStatus } from 'react-transition-group';
 
 import { css } from '@leafygreen-ui/emotion';
-import { spacing, transitionDuration } from '@leafygreen-ui/tokens';
+import { spacing, transitionDuration, typeScales } from '@leafygreen-ui/tokens';
 
 import { Align } from './Cell.types';
 
@@ -17,7 +17,6 @@ export const standardCellHeight = spacing[5] + spacing[2];
 export const baseCellStyles = css`
   padding: 0 8px;
   overflow: hidden;
-  text-overflow: ellipsis;
 
   &:focus-visible {
     box-shadow: inset;
@@ -75,35 +74,43 @@ export const basicCellStyles = css`
   }
 `;
 
-export const cellContentContainerStyles = css`
+export const cellTransitionContainerStyles = css`
   display: flex;
   align-items: center;
-  text-overflow: ellipsis;
   min-height: ${standardCellHeight}px;
-  transition-property: min-height, max-height, opacity, transform, padding;
+  transition-property: min-height, max-height, opacity, padding, transform;
   transition-duration: ${transitionDuration.default}ms;
   transition-timing-function: ease;
 `;
 
+export const truncatedContentStyles = css`
+  /* See https://css-tricks.com/line-clampin/#aa-the-standardized-way */
+  display: -webkit-box;
+  -webkit-line-clamp: ${standardCellHeight / typeScales.body1.lineHeight};
+  -webkit-box-orient: vertical;
+  -webkit-box-align: start;
+`;
+
 export const disableAnimationStyles = css`
+  transition-duration: 0;
   transition: none;
 `;
 
-const _hiddenStyles = css`
-  opacity: 0;
-  min-height: 0;
-  max-height: 0;
-  overflow: hidden;
-`;
-
-export const cellContentTransitionStyles = (
-  height: number,
+export const cellContentTransitionStateStyles = (
+  height?: number,
 ): Record<TransitionStatus, string> => {
+  const _hiddenStyles = css`
+    opacity: 0;
+    min-height: 0;
+    max-height: 0;
+    overflow: hidden;
+  `;
+
   return {
     entered: css`
       opacity: 1;
       min-height: ${standardCellHeight}px;
-      max-height: ${height}px;
+      max-height: ${height + 'px' ?? 'unset'};
     `,
     entering: _hiddenStyles,
     exiting: _hiddenStyles,

--- a/packages/table/src/Cell/Cell.styles.ts
+++ b/packages/table/src/Cell/Cell.styles.ts
@@ -110,7 +110,7 @@ export const cellContentTransitionStateStyles = (
     entered: css`
       opacity: 1;
       min-height: ${standardCellHeight}px;
-      max-height: ${height + 'px' ?? 'unset'};
+      max-height: ${height ? height + 'px' : 'unset'};
     `,
     entering: _hiddenStyles,
     exiting: _hiddenStyles,

--- a/packages/table/src/Cell/Cell.tsx
+++ b/packages/table/src/Cell/Cell.tsx
@@ -8,7 +8,7 @@ import {
   alignmentStyles,
   baseCellStyles,
   basicCellStyles,
-  cellContentContainerStyles,
+  cellTransitionContainerStyles,
   disableAnimationStyles,
 } from './Cell.styles';
 import { CellProps } from '.';
@@ -19,7 +19,7 @@ const Cell = ({ className, align, children, ...rest }: CellProps) => {
     <td className={cx(baseCellStyles, basicCellStyles, className)} {...rest}>
       <div
         className={cx(
-          cellContentContainerStyles,
+          cellTransitionContainerStyles,
           { [disableAnimationStyles]: disableAnimations },
           alignmentStyles(align),
         )}

--- a/packages/table/src/Cell/Cell.tsx
+++ b/packages/table/src/Cell/Cell.tsx
@@ -13,15 +13,22 @@ import {
 } from './Cell.styles';
 import { CellProps } from '.';
 
-const Cell = ({ className, align, children, ...rest }: CellProps) => {
+const Cell = ({
+  className,
+  contentClassName,
+  align,
+  children,
+  ...rest
+}: CellProps) => {
   const { disableAnimations } = useTableContext();
   return (
     <td className={cx(baseCellStyles, basicCellStyles, className)} {...rest}>
       <div
         className={cx(
           cellTransitionContainerStyles,
-          { [disableAnimationStyles]: disableAnimations },
           alignmentStyles(align),
+          { [disableAnimationStyles]: disableAnimations },
+          contentClassName,
         )}
       >
         {children}

--- a/packages/table/src/Cell/Cell.types.ts
+++ b/packages/table/src/Cell/Cell.types.ts
@@ -22,6 +22,9 @@ interface BaseCellProps extends HTMLElementProps<'td'> {
    */
   align?: Align;
 
+  /** A `className` applied to the inner `div` of the Cell  */
+  contentClassName?: string;
+
   /**
    * Defines how a cell should behave when its content is larger than the standard cell height.
    *

--- a/packages/table/src/Cell/Cell.types.ts
+++ b/packages/table/src/Cell/Cell.types.ts
@@ -5,40 +5,63 @@ export type Align = Extract<
   'left' | 'right' | 'center'
 >;
 
-interface AlignProp {
+export const CellOverflowBehavior = {
+  Default: 'default',
+  Truncate: 'truncate',
+  // TODO: `Expand`: The cell will expand to the height of its content
+  // Expand: 'expand',
+} as const;
+export type CellOverflowBehavior =
+  (typeof CellOverflowBehavior)[keyof typeof CellOverflowBehavior];
+
+interface BaseCellProps extends HTMLElementProps<'td'> {
   /**
    * Alignment of the cell's contents
    *
    * Overrides `<td>`'s deprecated `align` prop
    */
   align?: Align;
+
+  /**
+   * Defines how a cell should behave when its content is larger than the standard cell height.
+   *
+   * `Default`: The cell height will be fixed to the standard cell height (40px by default).
+   * Any overflowing content will be clipped.
+   *
+   * `Truncate`: The cell height will be fixed to the standard cell height (40px by default),
+   * and include an ellipsis before the content is clipped.
+   *
+   * Note: It's recommended to provide the same value for all cells in a given row.
+   *
+   * @default CellOverflowBehavior.Default
+   */
+  overflow?: CellOverflowBehavior;
 }
 
-export type CellProps = HTMLElementProps<'td'> & AlignProp;
+export type CellProps = BaseCellProps;
 
-export type InternalCellProps = CellProps &
-  AlignProp & {
-    /**
-     * Index of the cell in its parent row.
-     */
-    cellIndex: number;
+export interface InternalCellProps extends BaseCellProps {
+  /**
+   * Index of the cell in its parent row.
+   */
+  cellIndex: number;
 
-    /**
-     * Depth of nesting its parent row has.
-     */
-    depth: number;
+  /**
+   * Depth of nesting its parent row has.
+   */
+  depth: number;
 
-    /**
-     * Defines whether the cell's row is visible (i.e. expanded)
-     *
-     * @default true
-     */
-    isVisible?: boolean;
+  /**
+   * Defines whether the cell's row is visible (i.e. expanded)
+   *
+   * @default true
+   */
+  isVisible?: boolean;
 
-    /**
-     * Defines whether the cell's row is expandable
-     *
-     * @default false
-     */
-    isExpandable?: boolean;
-  };
+  /**
+   * Defines whether the cell's row is expandable
+   *
+   * @default false
+   */
+  isExpandable?: boolean;
+}

--- a/packages/table/src/Cell/HeaderCell/HeaderCell.tsx
+++ b/packages/table/src/Cell/HeaderCell/HeaderCell.tsx
@@ -7,7 +7,7 @@ import { LGRowData } from '../../useLeafyGreenTable';
 import {
   alignmentStyles,
   baseCellStyles,
-  cellContentContainerStyles,
+  cellContentStyles,
   getCellPadding,
 } from '../Cell.styles';
 
@@ -65,7 +65,7 @@ const HeaderCell = <T extends LGRowData>({
     >
       <div
         className={cx(
-          cellContentContainerStyles,
+          cellContentStyles,
           headerCellContentStyles,
           // TS error is ignored (and not expected) as it doesn't show up locally but interrupts build
           // @ts-ignore Header types need to be extended or declared in the react-table namespace

--- a/packages/table/src/Cell/HeaderCell/HeaderCell.tsx
+++ b/packages/table/src/Cell/HeaderCell/HeaderCell.tsx
@@ -7,7 +7,7 @@ import { LGRowData } from '../../useLeafyGreenTable';
 import {
   alignmentStyles,
   baseCellStyles,
-  cellContentStyles,
+  cellTransitionContainerStyles,
   getCellPadding,
 } from '../Cell.styles';
 
@@ -65,7 +65,7 @@ const HeaderCell = <T extends LGRowData>({
     >
       <div
         className={cx(
-          cellContentStyles,
+          cellTransitionContainerStyles,
           headerCellContentStyles,
           // TS error is ignored (and not expected) as it doesn't show up locally but interrupts build
           // @ts-ignore Header types need to be extended or declared in the react-table namespace

--- a/packages/table/src/Cell/InternalCell.tsx
+++ b/packages/table/src/Cell/InternalCell.tsx
@@ -18,9 +18,6 @@ import {
 } from './Cell.styles';
 import { CellOverflowBehavior, InternalCellProps } from './Cell.types';
 
-// const heightProperty = 'clientHeight';
-// const calcHeight = (el: HTMLElement | null) => el?.[heightProperty];
-
 const InternalCell = ({
   children,
   className,

--- a/packages/table/src/Cell/InternalCell.tsx
+++ b/packages/table/src/Cell/InternalCell.tsx
@@ -21,6 +21,7 @@ import { CellOverflowBehavior, InternalCellProps } from './Cell.types';
 const InternalCell = ({
   children,
   className,
+  contentClassName,
   cellIndex,
   depth,
   isVisible = true,
@@ -68,6 +69,7 @@ const InternalCell = ({
                 [disableAnimationStyles]: disableAnimations,
                 [truncatedContentStyles]: shouldTruncate,
               },
+              contentClassName,
             )}
           >
             {children}

--- a/packages/table/src/ExpandedContent/ExpandedContent.tsx
+++ b/packages/table/src/ExpandedContent/ExpandedContent.tsx
@@ -6,8 +6,8 @@ import { cx } from '@leafygreen-ui/emotion';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 
 import {
-  cellContentContainerStyles,
-  cellContentTransitionStyles,
+  cellContentStyles,
+  cellContentTransitionStateStyles,
   disableAnimationStyles,
 } from '../Cell/Cell.styles';
 import InternalRowBase from '../Row/InternalRowBase';
@@ -49,10 +49,10 @@ const ExpandedContent = <T extends RowData>({
             <div
               data-state={state}
               className={cx(
-                cellContentContainerStyles,
+                cellContentStyles,
                 { [disableAnimationStyles]: disableAnimations },
                 expandedContentStyles[theme],
-                cellContentTransitionStyles(contentHeight)[state],
+                cellContentTransitionStateStyles(contentHeight)[state],
               )}
             >
               <div ref={contentRef}>{content}</div>

--- a/packages/table/src/ExpandedContent/ExpandedContent.tsx
+++ b/packages/table/src/ExpandedContent/ExpandedContent.tsx
@@ -6,8 +6,8 @@ import { cx } from '@leafygreen-ui/emotion';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 
 import {
-  cellContentStyles,
   cellContentTransitionStateStyles,
+  cellTransitionContainerStyles,
   disableAnimationStyles,
 } from '../Cell/Cell.styles';
 import InternalRowBase from '../Row/InternalRowBase';
@@ -49,7 +49,7 @@ const ExpandedContent = <T extends RowData>({
             <div
               data-state={state}
               className={cx(
-                cellContentStyles,
+                cellTransitionContainerStyles,
                 { [disableAnimationStyles]: disableAnimations },
                 expandedContentStyles[theme],
                 cellContentTransitionStateStyles(contentHeight)[state],

--- a/packages/table/src/Table.story.tsx
+++ b/packages/table/src/Table.story.tsx
@@ -43,6 +43,7 @@ const meta: StoryMetaType<typeof Table> = {
   component: Table,
   argTypes: {
     shouldAlternateRowColor: { control: 'boolean' },
+    disableAnimations: { control: 'boolean' },
   },
   parameters: {
     default: 'LiveExample',
@@ -198,7 +199,7 @@ export const LiveExample: StoryFn<StoryTableProps> = args => {
             <Row key={row.id} row={row}>
               {row.getVisibleCells().map(cell => {
                 return (
-                  <Cell key={cell.id}>
+                  <Cell key={cell.id} id={cell.id} overflow="truncate">
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </Cell>
                 );
@@ -208,7 +209,7 @@ export const LiveExample: StoryFn<StoryTableProps> = args => {
                   <Row key={subRow.id} row={subRow}>
                     {subRow.getVisibleCells().map(cell => {
                       return (
-                        <Cell key={cell.id}>
+                        <Cell key={cell.id} id={cell.id}>
                           {flexRender(
                             cell.column.columnDef.cell,
                             cell.getContext(),
@@ -275,6 +276,7 @@ export const OverflowingCell: StoryFn<StoryTableProps> = args => {
                       width: '80px',
                       textOverflow: 'ellipsis',
                       overflow: 'hidden',
+                      whiteSpace: 'nowrap',
                     }}
                   >
                     {row[cellKey]}

--- a/packages/table/src/utils/makeData.testutils.tsx
+++ b/packages/table/src/utils/makeData.testutils.tsx
@@ -99,7 +99,11 @@ const createKitchenSinkData: (depth?: number) => object = (depth = 0) => {
   return {
     dateCreated: faker.date.past({ refDate: new Date('2023-12-26') }),
     frequency: faker.helpers.arrayElement(['Daily', 'Weekly', 'Monthly']),
-    clusterType: faker.helpers.arrayElement(['Replica set', 'Sharded cluster']),
+    clusterType: faker.helpers.weightedArrayElement([
+      { value: 'Replica set', weight: 0.45 },
+      { value: 'Sharded cluster', weight: 0.45 },
+      { value: faker.lorem.lines(2), weight: 0.1 },
+    ]),
     encryptorEnabled: faker.datatype.boolean(0.75),
     mdbVersion: faker.system.semver(),
     subRows:


### PR DESCRIPTION
## ✍️ Proposed changes

Adds `overflow` prop to `Cell` component. By default there is no change. When `overflow === 'truncate'`, the styling of the cell is updated (if necessary) to be aligned to the top, with an ellipsis after 2 lines of text.

🎟 _Jira ticket:_ 
[LG-3952](https://jira.mongodb.org/browse/LG-3952)

![Screenshot 2024-01-18 at 4 24 16 PM](https://github.com/mongodb/leafygreen-ui/assets/2414030/e1b1b567-0360-4e11-8fa5-f5af7f07bc37)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

