### PR TITLE
Updates default MarketingModal `closeIconColor` prop

### DIFF
--- a/.changeset/strange-pumpkins-invent.md
+++ b/.changeset/strange-pumpkins-invent.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/marketing-modal': patch
+---
+
+Fixes a bug and sets the default `closeIconColor` to 'default'

--- a/.changeset/strange-pumpkins-invent.md
+++ b/.changeset/strange-pumpkins-invent.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/marketing-modal': patch
 ---
 
-Fixes a bug and sets the default `closeIconColor` to 'default'
+Sets the default `closeIconColor` to correctly be 'default' (`CloseIconColor.Default`)

--- a/.changeset/tricky-games-worry.md
+++ b/.changeset/tricky-games-worry.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/modal': patch
 ---
 
-Fixes a bug, and sets the `CloseIconColor` enum to be readonly (`as const`)
+Sets the `CloseIconColor` enum to be readonly (`as const`). Improves TypeScript Intellisense/autocomplete

--- a/.changeset/tricky-games-worry.md
+++ b/.changeset/tricky-games-worry.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/modal': patch
+---
+
+Fixes a bug, and sets the `CloseIconColor` enum to be readonly (`as const`)

--- a/packages/marketing-modal/src/MarketingModal/MarketingModal.tsx
+++ b/packages/marketing-modal/src/MarketingModal/MarketingModal.tsx
@@ -38,7 +38,7 @@ const MarketingModal = ({
   linkText,
   darkMode: darkModeProp,
   graphicStyle = GraphicStyle.Center,
-  closeIconColor = CloseIconColor.Dark,
+  closeIconColor = CloseIconColor.Default,
   blobPosition = BlobPosition.TopLeft,
   showBlob = false,
   disclaimer,

--- a/packages/modal/src/Modal/Modal.types.ts
+++ b/packages/modal/src/Modal/Modal.types.ts
@@ -6,7 +6,7 @@ export const CloseIconColor = {
   Default: 'default',
   Dark: 'dark',
   Light: 'light',
-};
+} as const;
 
 export type CloseIconColor =
   (typeof CloseIconColor)[keyof typeof CloseIconColor];


### PR DESCRIPTION
## ✍️ Proposed changes


Fixes a bug and sets the default `closeIconColor` to 'default'


🎟 _Jira ticket:_ https://jira.mongodb.org/browse/LG-3957

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes
