### PR TITLE
LG-3878: Date Picker add current year/month selection to aria-label

### DIFF
--- a/.changeset/tough-goats-jam.md
+++ b/.changeset/tough-goats-jam.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/date-picker': patch
+---
+
+Dynamically update the `aria-label` for the year/month select to include the current selection, enabling screen readers to announce the current selection.

--- a/packages/date-picker/src/DatePicker/DatePicker.testutils.tsx
+++ b/packages/date-picker/src/DatePicker/DatePicker.testutils.tsx
@@ -120,10 +120,18 @@ export const renderDatePicker = (
     const rightChevron =
       withinElement(menuContainerEl)?.queryByLabelText('Next month') ||
       withinElement(menuContainerEl)?.queryByLabelText('Next valid month');
-    const monthSelect =
-      withinElement(menuContainerEl)?.queryByLabelText('Select month');
-    const yearSelect =
-      withinElement(menuContainerEl)?.queryByLabelText('Select year');
+    const monthSelect = withinElement(menuContainerEl)?.queryByLabelText(
+      'Select month',
+      {
+        exact: false,
+      },
+    );
+    const yearSelect = withinElement(menuContainerEl)?.queryByLabelText(
+      'Select year',
+      {
+        exact: false,
+      },
+    );
 
     const queryCellByDate = (date: Date): HTMLTableCellElement | null => {
       const cell = calendarGrid?.querySelector(

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.spec.tsx
@@ -91,8 +91,8 @@ const renderDatePickerMenu = (
   const rightChevron =
     result.queryByLabelText('Next month') ||
     result.queryByLabelText('Next valid month');
-  const monthSelect = result.queryByLabelText('Select month');
-  const yearSelect = result.queryByLabelText('Select year');
+  const monthSelect = result.queryByLabelText('Select month', { exact: false });
+  const yearSelect = result.queryByLabelText('Select year', { exact: false });
 
   return {
     ...result,
@@ -127,31 +127,19 @@ describe('packages/date-picker/date-picker-menu', () => {
       expect(grid).toHaveAttribute('aria-label', 'September 2023');
     });
     test('chevrons have aria labels', () => {
-      const result = renderDatePickerMenu();
-      const leftChevron = result.getByLabelText('Previous month');
-      const rightChevron = result.getByLabelText('Next month');
+      const { getByLabelText } = renderDatePickerMenu();
+      const leftChevron = getByLabelText('Previous month');
+      const rightChevron = getByLabelText('Next month');
       expect(leftChevron).toBeInTheDocument();
       expect(rightChevron).toBeInTheDocument();
     });
     test('select menu triggers have aria labels', () => {
-      const result = renderDatePickerMenu();
-      const monthSelect = result.getByLabelText('Select month', {
-        exact: false,
-      });
-      const yearSelect = result.getByLabelText('Select year', {
-        exact: false,
-      });
+      const { monthSelect, yearSelect } = renderDatePickerMenu();
       expect(monthSelect).toBeInTheDocument();
       expect(yearSelect).toBeInTheDocument();
     });
     test('select menus have correct values', () => {
-      const result = renderDatePickerMenu();
-      const monthSelect = result.getByLabelText('Select month', {
-        exact: false,
-      });
-      const yearSelect = result.getByLabelText('Select year', {
-        exact: false,
-      });
+      const { monthSelect, yearSelect } = renderDatePickerMenu();
       expect(monthSelect).toHaveValue(Month.September.toString());
       expect(yearSelect).toHaveValue('2023');
     });
@@ -177,14 +165,11 @@ describe('packages/date-picker/date-picker-menu', () => {
         expect(grid).toHaveAttribute('aria-label', 'March 2024');
       });
       test('select menus have correct values', () => {
-        const { getByLabelText, rerenderDatePickerMenu } =
+        const { rerenderDatePickerMenu, monthSelect, yearSelect } =
           renderDatePickerMenu();
         rerenderDatePickerMenu(null, {
           value: newUTC(2024, Month.March, 10),
         });
-
-        const monthSelect = getByLabelText('Select month', { exact: false });
-        const yearSelect = getByLabelText('Select year', { exact: false });
         expect(monthSelect).toHaveValue(Month.March.toString());
         expect(yearSelect).toHaveValue('2024');
       });

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.spec.tsx
@@ -135,15 +135,23 @@ describe('packages/date-picker/date-picker-menu', () => {
     });
     test('select menu triggers have aria labels', () => {
       const result = renderDatePickerMenu();
-      const monthSelect = result.getByLabelText('Select month');
-      const yearSelect = result.getByLabelText('Select year');
+      const monthSelect = result.getByLabelText('Select month', {
+        exact: false,
+      });
+      const yearSelect = result.getByLabelText('Select year', {
+        exact: false,
+      });
       expect(monthSelect).toBeInTheDocument();
       expect(yearSelect).toBeInTheDocument();
     });
     test('select menus have correct values', () => {
       const result = renderDatePickerMenu();
-      const monthSelect = result.getByLabelText('Select month');
-      const yearSelect = result.getByLabelText('Select year');
+      const monthSelect = result.getByLabelText('Select month', {
+        exact: false,
+      });
+      const yearSelect = result.getByLabelText('Select year', {
+        exact: false,
+      });
       expect(monthSelect).toHaveValue(Month.September.toString());
       expect(yearSelect).toHaveValue('2023');
     });
@@ -175,8 +183,8 @@ describe('packages/date-picker/date-picker-menu', () => {
           value: newUTC(2024, Month.March, 10),
         });
 
-        const monthSelect = getByLabelText('Select month');
-        const yearSelect = getByLabelText('Select year');
+        const monthSelect = getByLabelText('Select month', { exact: false });
+        const yearSelect = getByLabelText('Select year', { exact: false });
         expect(monthSelect).toHaveValue(Month.March.toString());
         expect(yearSelect).toHaveValue('2024');
       });

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.stories.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.stories.tsx
@@ -221,7 +221,9 @@ export const OpenMonthMenu: DatePickerMenuInteractionTestType = {
   play: async ctx => {
     const canvas = within(ctx.canvasElement.parentElement!);
     await canvas.findByRole('listbox');
-    const monthMenu = await canvas.findByLabelText('Select month');
+    const monthMenu = await canvas.findByLabelText('Select month', {
+      exact: false,
+    });
     userEvent.click(monthMenu);
   },
 };
@@ -242,7 +244,9 @@ export const OpenYearMenu: DatePickerMenuInteractionTestType = {
   play: async ctx => {
     const canvas = within(ctx.canvasElement.parentElement!);
     await canvas.findByRole('listbox');
-    const monthMenu = await canvas.findByLabelText('Select year');
+    const monthMenu = await canvas.findByLabelText('Select year', {
+      exact: false,
+    });
     userEvent.click(monthMenu);
   },
 };

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.spec.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.spec.tsx
@@ -50,7 +50,9 @@ describe('packages/date-picker/menu/header', () => {
           </MockSharedDatePickerProvider>,
         );
 
-        const monthSelect = getByLabelText('Select month');
+        const monthSelect = getByLabelText('Select month', {
+          exact: false,
+        });
 
         userEvent.click(monthSelect);
 
@@ -87,7 +89,9 @@ describe('packages/date-picker/menu/header', () => {
           </MockSharedDatePickerProvider>,
         );
 
-        const monthSelect = getByLabelText('Select month');
+        const monthSelect = getByLabelText('Select month', {
+          exact: false,
+        });
 
         userEvent.click(monthSelect);
 
@@ -125,7 +129,9 @@ describe('packages/date-picker/menu/header', () => {
           </MockSharedDatePickerProvider>,
         );
 
-        const monthSelect = getByLabelText('Select month');
+        const monthSelect = getByLabelText('Select month', {
+          exact: false,
+        });
 
         userEvent.click(monthSelect);
 
@@ -161,7 +167,9 @@ describe('packages/date-picker/menu/header', () => {
             </MockSharedDatePickerProvider>,
           );
 
-          const monthSelect = getByLabelText('Select month');
+          const monthSelect = getByLabelText('Select month', {
+            exact: false,
+          });
 
           userEvent.click(monthSelect);
 
@@ -196,8 +204,12 @@ describe('packages/date-picker/menu/header', () => {
             </MockSharedDatePickerProvider>,
           );
 
-          const monthSelect = getByLabelText('Select month');
-          const yearSelect = getByLabelText('Select year');
+          const monthSelect = getByLabelText('Select month', {
+            exact: false,
+          });
+          const yearSelect = getByLabelText('Select year', {
+            exact: false,
+          });
 
           expect(monthSelect).toHaveTextContent('Jul');
           expect(yearSelect).toHaveTextContent('2025');
@@ -227,7 +239,9 @@ describe('packages/date-picker/menu/header', () => {
             </MockSharedDatePickerProvider>,
           );
 
-          const monthSelect = getByLabelText('Select month');
+          const monthSelect = getByLabelText('Select month', {
+            exact: false,
+          });
 
           userEvent.click(monthSelect);
 
@@ -262,8 +276,12 @@ describe('packages/date-picker/menu/header', () => {
             </MockSharedDatePickerProvider>,
           );
 
-          const monthSelect = getByLabelText('Select month');
-          const yearSelect = getByLabelText('Select year');
+          const monthSelect = getByLabelText('Select month', {
+            exact: false,
+          });
+          const yearSelect = getByLabelText('Select year', {
+            exact: false,
+          });
 
           expect(monthSelect).toHaveTextContent('Jul');
           expect(yearSelect).toHaveTextContent('2021');
@@ -317,7 +335,9 @@ describe('packages/date-picker/menu/header', () => {
         </AllMockProviders>,
       );
 
-      const monthSelect = getByLabelText('Select month');
+      const monthSelect = getByLabelText('Select month', {
+        exact: false,
+      });
       userEvent.click(monthSelect);
       await waitFor(() => {
         jest.advanceTimersByTime(transitionDuration.default);

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.tsx
@@ -123,7 +123,9 @@ export const DatePickerMenuHeader = forwardRef<
       <div className={menuHeaderSelectContainerStyles}>
         <Select
           {...selectElementProps}
-          aria-label="Select month"
+          aria-label={`Select month - ${
+            monthOptions[month.getUTCMonth()].short
+          } selected`}
           value={month.getUTCMonth().toString()}
           onChange={m => {
             const newMonth = setUTCMonth(month, Number(m));
@@ -147,7 +149,9 @@ export const DatePickerMenuHeader = forwardRef<
         </Select>
         <Select
           {...selectElementProps}
-          aria-label="Select year"
+          aria-label={`Select year - ${month
+            .getUTCFullYear()
+            .toString()} selected`}
           value={month.getUTCFullYear().toString()}
           onChange={y => {
             const newMonth = setUTCYear(month, Number(y));

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.tsx
@@ -124,7 +124,7 @@ export const DatePickerMenuHeader = forwardRef<
         <Select
           {...selectElementProps}
           aria-label={`Select month - ${
-            monthOptions[month.getUTCMonth()].short
+            monthOptions[month.getUTCMonth()].long
           } selected`}
           value={month.getUTCMonth().toString()}
           onChange={m => {

--- a/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
+++ b/packages/date-picker/src/shared/components/DateInput/DateInputBox/DateInputBox.spec.tsx
@@ -66,8 +66,8 @@ describe('packages/date-picker/shared/date-input-box', () => {
   describe('Rendering', () => {
     describe.each(['day', 'month', 'year'])('%p', segment => {
       test('renders the correct aria attributes', () => {
-        const result = renderDateInputBox();
-        const input = result.getByLabelText(segment);
+        const { getByLabelText } = renderDateInputBox();
+        const input = getByLabelText(segment);
 
         // each segment has appropriate aria label
         expect(input).toHaveAttribute('aria-label', segment);
@@ -76,24 +76,30 @@ describe('packages/date-picker/shared/date-input-box', () => {
 
     describe('renders segments in the correct order', () => {
       test('iso8601', () => {
-        const result = renderDateInputBox(undefined, { locale: 'iso8601' });
-        const segments = result.getAllByRole('spinbutton');
+        const { getAllByRole } = renderDateInputBox(undefined, {
+          locale: 'iso8601',
+        });
+        const segments = getAllByRole('spinbutton');
         expect(segments[0]).toHaveAttribute('aria-label', 'year');
         expect(segments[1]).toHaveAttribute('aria-label', 'month');
         expect(segments[2]).toHaveAttribute('aria-label', 'day');
       });
 
       test('en-US', () => {
-        const result = renderDateInputBox(undefined, { locale: 'en-US' });
-        const segments = result.getAllByRole('spinbutton');
+        const { getAllByRole } = renderDateInputBox(undefined, {
+          locale: 'en-US',
+        });
+        const segments = getAllByRole('spinbutton');
         expect(segments[0]).toHaveAttribute('aria-label', 'month');
         expect(segments[1]).toHaveAttribute('aria-label', 'day');
         expect(segments[2]).toHaveAttribute('aria-label', 'year');
       });
 
       test('en-UK', () => {
-        const result = renderDateInputBox(undefined, { locale: 'en-UK' });
-        const segments = result.getAllByRole('spinbutton');
+        const { getAllByRole } = renderDateInputBox(undefined, {
+          locale: 'en-UK',
+        });
+        const segments = getAllByRole('spinbutton');
         expect(segments[0]).toHaveAttribute('aria-label', 'day');
         expect(segments[1]).toHaveAttribute('aria-label', 'month');
         expect(segments[2]).toHaveAttribute('aria-label', 'year');


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [LG-3878](https://jira.mongodb.org/browse/LG-3878)

Currently, when navigating with VoiceOver, VoiceOver does not announce the current selection for the year and month selects. This happens because we pass a static `aria-label` to the `Select` component. My solution is to make the `aria-label` dynamic by appending the current selection to the `aria-label` string.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
