### PR TITLE
LG-3954: Combobox incorrectly makes selection on "Enter" key press

### DIFF
--- a/.changeset/cuddly-wasps-float.md
+++ b/.changeset/cuddly-wasps-float.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/combobox': patch
+---
+
+Fixes bug where Combobox incorrectly makes selection on "Enter" key press.

--- a/packages/combobox/src/Combobox/Combobox.spec.tsx
+++ b/packages/combobox/src/Combobox/Combobox.spec.tsx
@@ -876,6 +876,17 @@ describe('packages/combobox', () => {
           expect(menuContainerEl).toBeInTheDocument();
         });
 
+        test('does not make a selection when clicking enter on a closed menu', () => {
+          const { getMenuElements, inputEl } = renderCombobox(select);
+          userEvent.tab();
+          userEvent.keyboard('{enter}');
+          expect(inputEl).toHaveValue('');
+          const { menuContainerEl } = getMenuElements();
+          expect(menuContainerEl).not.toBeNull();
+          expect(menuContainerEl).toBeInTheDocument();
+          expect(inputEl).toHaveValue('');
+        });
+
         test('selects highlighted option', () => {
           const { inputEl, openMenu, queryChipsByName } =
             renderCombobox(select);

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1005,11 +1005,14 @@ export function Combobox<M extends boolean>({
         }
 
         case keyMap.Enter: {
-          if (
-            // Select the highlighted option iff
+          if (!isOpen) {
+            openMenu();
+          } else if (
+            // Select the highlighted option if
             // the menu is open,
             // we're focused on input element,
             // and the highlighted option is not disabled
+            isOpen &&
             focusedElementName === ComboboxElement.Input &&
             !isNull(highlightedOption) &&
             !isOptionDisabled(highlightedOption)


### PR DESCRIPTION
## ✍️ Proposed changes

Combobox incorrectly makes selection on "Enter" key press

🎟 _Jira ticket:_ [LG-3954](https://jira.mongodb.org/browse/LG-3954)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
