### PR TITLE
LG-3355: Updates ExpandableCard Live Example

### DIFF
--- a/.changeset/early-coins-fry.md
+++ b/.changeset/early-coins-fry.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/expandable-card': patch
+---
+
+Updates live example so that `title` does not look like an optional prop

--- a/packages/expandable-card/src/ExpandableCard.story.tsx
+++ b/packages/expandable-card/src/ExpandableCard.story.tsx
@@ -23,7 +23,7 @@ const meta: StoryMetaType<typeof ExpandableCard> = {
       combineArgs: {
         darkMode: [false, true],
         description: [undefined, loremIpsum],
-        flagText: [undefined, 'optional'],
+        flagText: [undefined, 'title'],
         isOpen: [false, true],
       },
     },
@@ -31,7 +31,7 @@ const meta: StoryMetaType<typeof ExpandableCard> = {
   args: {
     title: 'Title',
     description: loremIpsum,
-    flagText: 'optional',
+    flagText: 'title',
     children:
       'Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.',
   },

--- a/packages/expandable-card/src/ExpandableCard.story.tsx
+++ b/packages/expandable-card/src/ExpandableCard.story.tsx
@@ -23,7 +23,7 @@ const meta: StoryMetaType<typeof ExpandableCard> = {
       combineArgs: {
         darkMode: [false, true],
         description: [undefined, loremIpsum],
-        flagText: [undefined, 'title'],
+        flagText: [undefined, 'flagText'],
         isOpen: [false, true],
       },
     },
@@ -31,7 +31,7 @@ const meta: StoryMetaType<typeof ExpandableCard> = {
   args: {
     title: 'Title',
     description: loremIpsum,
-    flagText: 'title',
+    flagText: 'flagText',
     children:
       'Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.',
   },


### PR DESCRIPTION
Updates live example so that `title` does not look like an optional prop