### PR TITLE
LG-3940: NumberInput onBlur runs with arrow buttons

### DIFF
--- a/.changeset/short-games-double.md
+++ b/.changeset/short-games-double.md
@@ -2,4 +2,5 @@
 '@leafygreen-ui/number-input': patch
 ---
 
-onBlur runs with arrow buttons
+Fixes a bug where onBlur would not get invoked when arrow buttons were blurred.
+[LG-3940](https://jira.mongodb.org/browse/LG-3940)

--- a/.changeset/short-games-double.md
+++ b/.changeset/short-games-double.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/number-input': patch
+---
+
+onBlur runs with arrow buttons

--- a/packages/number-input/src/Arrows/Arrow.tsx
+++ b/packages/number-input/src/Arrows/Arrow.tsx
@@ -21,6 +21,7 @@ export const Arrow = ({
   disabled,
   onClick,
   onKeyDown,
+  onBlur,
   direction,
 }: ArrowProps) => {
   const { theme } = useDarkMode();
@@ -30,6 +31,7 @@ export const Arrow = ({
       aria-label={`${direction} number`}
       onClick={() => onClick(direction)}
       onKeyDown={onKeyDown}
+      onBlur={onBlur}
       className={cx(arrowBaseStyles, arrowThemeStyles[theme])}
       type="button"
       tabIndex={-1} // Mimicking native behavior; you cannot focus on an arrow.

--- a/packages/number-input/src/Arrows/Arrow.tsx
+++ b/packages/number-input/src/Arrows/Arrow.tsx
@@ -21,7 +21,6 @@ export const Arrow = ({
   disabled,
   onClick,
   onKeyDown,
-  onBlur,
   direction,
 }: ArrowProps) => {
   const { theme } = useDarkMode();
@@ -31,7 +30,6 @@ export const Arrow = ({
       aria-label={`${direction} number`}
       onClick={() => onClick(direction)}
       onKeyDown={onKeyDown}
-      onBlur={onBlur}
       className={cx(arrowBaseStyles, arrowThemeStyles[theme])}
       type="button"
       tabIndex={-1} // Mimicking native behavior; you cannot focus on an arrow.

--- a/packages/number-input/src/Arrows/Arrow.tsx
+++ b/packages/number-input/src/Arrows/Arrow.tsx
@@ -34,7 +34,7 @@ export const Arrow = ({
       type="button"
       tabIndex={-1} // Mimicking native behavior; you cannot focus on an arrow.
       disabled={disabled}
-      data-testid={`lg-number_input-${direction}-button`}
+      data-testid={`lg-number_input-${direction}_button`}
     >
       <Icon
         className={cx({

--- a/packages/number-input/src/Arrows/Arrow.tsx
+++ b/packages/number-input/src/Arrows/Arrow.tsx
@@ -34,6 +34,7 @@ export const Arrow = ({
       type="button"
       tabIndex={-1} // Mimicking native behavior; you cannot focus on an arrow.
       disabled={disabled}
+      data-testid={`lg-number_input-${direction}-button`}
     >
       <Icon
         className={cx({

--- a/packages/number-input/src/Arrows/Arrows.tsx
+++ b/packages/number-input/src/Arrows/Arrows.tsx
@@ -16,7 +16,12 @@ import { ArrowsProps } from './Arrows.types';
  * @internal
  */
 
-export const Arrows = ({ disabled, onClick, onKeyDown }: ArrowsProps) => {
+export const Arrows = ({
+  disabled,
+  onClick,
+  onKeyDown,
+  onBlur,
+}: ArrowsProps) => {
   return (
     <div
       className={cx(arrowsBaseStyles, {
@@ -29,12 +34,14 @@ export const Arrows = ({ disabled, onClick, onKeyDown }: ArrowsProps) => {
         direction={Direction.Increment}
         onClick={onClick}
         onKeyDown={onKeyDown}
+        onBlur={onBlur}
       />
       <Arrow
         disabled={disabled}
         direction={Direction.Decrement}
         onClick={onClick}
         onKeyDown={onKeyDown}
+        onBlur={onBlur}
       />
     </div>
   );

--- a/packages/number-input/src/Arrows/Arrows.tsx
+++ b/packages/number-input/src/Arrows/Arrows.tsx
@@ -16,12 +16,7 @@ import { ArrowsProps } from './Arrows.types';
  * @internal
  */
 
-export const Arrows = ({
-  disabled,
-  onClick,
-  onKeyDown,
-  onBlur,
-}: ArrowsProps) => {
+export const Arrows = ({ disabled, onClick, onKeyDown }: ArrowsProps) => {
   return (
     <div
       className={cx(arrowsBaseStyles, {
@@ -34,14 +29,12 @@ export const Arrows = ({
         direction={Direction.Increment}
         onClick={onClick}
         onKeyDown={onKeyDown}
-        onBlur={onBlur}
       />
       <Arrow
         disabled={disabled}
         direction={Direction.Decrement}
         onClick={onClick}
         onKeyDown={onKeyDown}
-        onBlur={onBlur}
       />
     </div>
   );

--- a/packages/number-input/src/Arrows/Arrows.types.ts
+++ b/packages/number-input/src/Arrows/Arrows.types.ts
@@ -15,11 +15,6 @@ export interface ArrowsProps {
    * Callback called when up/down arrows are pressed
    */
   onKeyDown: (e: React.KeyboardEvent) => void;
-
-  /**
-   * Callback called when buttons lose focus
-   */
-  onBlur?: (e: React.FocusEvent<HTMLElement>) => void;
 }
 
 export interface ArrowProps extends ArrowsProps {

--- a/packages/number-input/src/Arrows/Arrows.types.ts
+++ b/packages/number-input/src/Arrows/Arrows.types.ts
@@ -18,5 +18,8 @@ export interface ArrowsProps {
 }
 
 export interface ArrowProps extends ArrowsProps {
+  /**
+   * Direction of arrow: increment or decrement
+   */
   direction: Direction;
 }

--- a/packages/number-input/src/Arrows/Arrows.types.ts
+++ b/packages/number-input/src/Arrows/Arrows.types.ts
@@ -15,6 +15,11 @@ export interface ArrowsProps {
    * Callback called when up/down arrows are pressed
    */
   onKeyDown: (e: React.KeyboardEvent) => void;
+
+  /**
+   * Callback called when buttons lose focus
+   */
+  onBlur?: (e: React.FocusEvent<HTMLElement>) => void;
 }
 
 export interface ArrowProps extends ArrowsProps {

--- a/packages/number-input/src/Input/Input.tsx
+++ b/packages/number-input/src/Input/Input.tsx
@@ -43,6 +43,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     {
       value: valueProp,
       onChange: onChangeProp,
+      onBlur,
       disabled = false,
       size = Size.Default,
       state = State.None,
@@ -162,12 +163,12 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       }
     };
 
-    const handleOnFocus = () => {
+    const handleFocusContainer = () => {
       isFocusedRef.current = true;
       handleSetErrorTransition();
     };
 
-    const handleOnBlur = () => {
+    const handleBlurContainer = () => {
       isFocusedRef.current = false;
       handleRemoveErrorTransition();
     };
@@ -175,10 +176,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div
         ref={containerRef}
-        onMouseEnter={() => handleSetErrorTransition()}
-        onMouseLeave={() => handleRemoveErrorTransition()}
-        onFocus={() => handleOnFocus()}
-        onBlur={() => handleOnBlur()}
+        onMouseEnter={handleSetErrorTransition}
+        onMouseLeave={handleRemoveErrorTransition}
+        onFocus={handleFocusContainer}
+        onBlur={handleBlurContainer}
         aria-disabled={disabled}
         className={cx(
           wrapperClassName,
@@ -211,6 +212,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type="number"
           value={isControlled ? valueProp : value} // TODO: temp fix for useControlledValue hook. The hook was not returning the correct value when controlled. For example when typing 2e3 the hook would return 3 but it should return 2e3 like a native number input would.
           onChange={handleChange}
+          onBlur={onBlur}
           aria-disabled={disabled}
           readOnly={disabled}
           {...rest}
@@ -226,6 +228,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           disabled={disabled}
           onClick={handleValueChange}
           onKeyDown={handleArrowKeyDown}
+          onBlur={onBlur}
         />
       </div>
     );

--- a/packages/number-input/src/Input/Input.tsx
+++ b/packages/number-input/src/Input/Input.tsx
@@ -172,7 +172,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const handleBlur = (e: FocusEvent<HTMLDivElement>) => {
       isFocusedRef.current = false;
       handleRemoveErrorTransition();
-
+      // If newly focused element is a child of the input container, we do not invoke onBlur
       const inputContainer = e.currentTarget as Node;
       const possibleChildOfInputContainer = e.relatedTarget as Node | null;
       if (inputContainer.contains(possibleChildOfInputContainer)) return;

--- a/packages/number-input/src/Input/Input.tsx
+++ b/packages/number-input/src/Input/Input.tsx
@@ -1,5 +1,6 @@
 import React, {
   ChangeEvent,
+  FocusEvent,
   KeyboardEvent,
   useEffect,
   useRef,
@@ -163,14 +164,17 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       }
     };
 
-    const handleFocusContainer = () => {
+    const handleFocus = () => {
       isFocusedRef.current = true;
       handleSetErrorTransition();
     };
 
-    const handleBlurContainer = () => {
+    const handleBlur = (e: FocusEvent<HTMLDivElement>) => {
       isFocusedRef.current = false;
       handleRemoveErrorTransition();
+      if (onBlur) {
+        onBlur(e);
+      }
     };
 
     return (
@@ -178,8 +182,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref={containerRef}
         onMouseEnter={handleSetErrorTransition}
         onMouseLeave={handleRemoveErrorTransition}
-        onFocus={handleFocusContainer}
-        onBlur={handleBlurContainer}
+        onFocus={handleFocus}
+        onBlur={e => handleBlur(e)}
         aria-disabled={disabled}
         className={cx(
           wrapperClassName,
@@ -212,7 +216,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type="number"
           value={isControlled ? valueProp : value} // TODO: temp fix for useControlledValue hook. The hook was not returning the correct value when controlled. For example when typing 2e3 the hook would return 3 but it should return 2e3 like a native number input would.
           onChange={handleChange}
-          onBlur={onBlur}
           aria-disabled={disabled}
           readOnly={disabled}
           {...rest}
@@ -228,7 +231,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           disabled={disabled}
           onClick={handleValueChange}
           onKeyDown={handleArrowKeyDown}
-          onBlur={onBlur}
         />
       </div>
     );

--- a/packages/number-input/src/Input/Input.tsx
+++ b/packages/number-input/src/Input/Input.tsx
@@ -172,9 +172,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const handleBlur = (e: FocusEvent<HTMLDivElement>) => {
       isFocusedRef.current = false;
       handleRemoveErrorTransition();
-      if (onBlur) {
-        onBlur(e);
-      }
+
+      const inputContainer = e.currentTarget as Node;
+      const possibleChildOfInputContainer = e.relatedTarget as Node | null;
+      if (inputContainer.contains(possibleChildOfInputContainer)) return;
+      onBlur?.(e);
     };
 
     return (
@@ -183,7 +185,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         onMouseEnter={handleSetErrorTransition}
         onMouseLeave={handleRemoveErrorTransition}
         onFocus={handleFocus}
-        onBlur={e => handleBlur(e)}
+        onBlur={handleBlur}
         aria-disabled={disabled}
         className={cx(
           wrapperClassName,

--- a/packages/number-input/src/NumberInput.story.tsx
+++ b/packages/number-input/src/NumberInput.story.tsx
@@ -133,6 +133,13 @@ const Template: StoryFn<StoryNumberInputProps> = (
     setValue(e.target.value);
   };
 
+  const handleBlur = (e: React.FocusEvent<HTMLElement>) => {
+    // eslint-disable-next-line no-console
+    console.log('story: event: ', e.target.blur);
+    // eslint-disable-next-line no-console
+    console.log('story: ref', inputRef.current?.blur);
+  };
+
   return (
     <NumberInput
       {...rest}
@@ -142,6 +149,7 @@ const Template: StoryFn<StoryNumberInputProps> = (
       unitOptions={unitOptions}
       onSelectChange={handleSelectChange}
       onChange={handleChange}
+      onBlur={handleBlur}
       inputClassName={css`
         width: 100px;
       `}

--- a/packages/number-input/src/NumberInput/NumberInput.spec.tsx
+++ b/packages/number-input/src/NumberInput/NumberInput.spec.tsx
@@ -202,19 +202,6 @@ describe('packages/number-input', () => {
       expect((numberInput as HTMLInputElement).value).toBe('111');
     });
 
-    test('blur triggers onBlur callback', () => {
-      const { numberInput } = renderNumberInput({
-        label,
-        ...defaultProps,
-      });
-
-      userEvent.tab(); // focus
-      expect(numberInput).toHaveFocus();
-      userEvent.tab(); // blur
-
-      expect(defaultProps.onBlur).toHaveBeenCalledTimes(1);
-    });
-
     test('value changes when "up" arrow is clicked', () => {
       const { container, numberInput } = renderNumberInput({
         label,
@@ -241,6 +228,39 @@ describe('packages/number-input', () => {
 
       userEvent.click(upArrow as HTMLButtonElement);
       expect((numberInput as HTMLInputElement).value).toBe('-1');
+    });
+
+    describe('onBlur', () => {
+      test('callback triggers when focus leaves number input', () => {
+        const { numberInput } = renderNumberInput({
+          label,
+          ...defaultProps,
+        });
+
+        userEvent.tab(); // focus
+        expect(numberInput).toHaveFocus();
+        userEvent.tab(); // blur
+
+        expect(defaultProps.onBlur).toHaveBeenCalledTimes(1);
+      });
+
+      test('callback triggers when focus leaves arrow buttons', () => {
+        const { container, numberInput } = renderNumberInput({
+          label,
+          ...defaultProps,
+        });
+
+        const upArrow = container.querySelector(
+          'button[aria-label="decrement number"]',
+        );
+
+        userEvent.click(upArrow as HTMLButtonElement); // focus
+        expect(defaultProps.onBlur).toHaveBeenCalledTimes(1);
+        expect(upArrow).toHaveFocus();
+
+        userEvent.tab(); // blur
+        expect(defaultProps.onBlur).toHaveBeenCalledTimes(2);
+      });
     });
 
     test(`is disabled when disabled is passed`, () => {

--- a/packages/number-input/src/NumberInput/NumberInput.spec.tsx
+++ b/packages/number-input/src/NumberInput/NumberInput.spec.tsx
@@ -10,8 +10,8 @@ const label = 'This is the label text';
 const description = 'This is the description text';
 const errorMessage = 'error message';
 const arrowTestId = {
-  up: 'lg-number_input-increment-button',
-  down: 'lg-number_input-decrement-button',
+  up: 'lg-number_input-increment_button',
+  down: 'lg-number_input-decrement_button',
 };
 
 const defaultProps = {
@@ -214,7 +214,7 @@ describe('packages/number-input', () => {
 
       const upArrow = getByTestId(arrowTestId.up);
 
-      userEvent.click(upArrow as HTMLButtonElement);
+      userEvent.click(upArrow);
       expect((numberInput as HTMLInputElement).value).toBe('1');
     });
 
@@ -226,7 +226,7 @@ describe('packages/number-input', () => {
 
       const downArrow = getByTestId(arrowTestId.down);
 
-      userEvent.click(downArrow as HTMLButtonElement);
+      userEvent.click(downArrow);
       expect((numberInput as HTMLInputElement).value).toBe('-1');
     });
 
@@ -256,10 +256,34 @@ describe('packages/number-input', () => {
 
         const upArrow = getByTestId(arrowTestId.up);
 
-        userEvent.click(upArrow as HTMLButtonElement); // focus
+        userEvent.click(upArrow); // focus
         expect(upArrow).toHaveFocus();
 
         userEvent.tab(); // blur
+        expect(onBlur).toHaveBeenCalledTimes(1);
+      });
+
+      test('callback does not trigger when focus changes to adjacent elements within number input', () => {
+        const onBlur = jest.fn();
+        const { getByTestId, numberInput } = renderNumberInput({
+          label,
+          onBlur,
+          ...defaultProps,
+        });
+
+        const upArrow = getByTestId(arrowTestId.up);
+        const downArrow = getByTestId(arrowTestId.down);
+
+        userEvent.tab(); // focus
+        expect(numberInput).toHaveFocus();
+
+        userEvent.click(upArrow); // focus on up arrow
+        expect(upArrow).toHaveFocus();
+
+        userEvent.click(downArrow); // focus on down arrow
+        expect(downArrow).toHaveFocus();
+
+        userEvent.tab(); //blur
         expect(onBlur).toHaveBeenCalledTimes(1);
       });
     });

--- a/packages/number-input/src/NumberInput/NumberInput.spec.tsx
+++ b/packages/number-input/src/NumberInput/NumberInput.spec.tsx
@@ -9,12 +9,14 @@ import { NumberInput } from '.';
 const label = 'This is the label text';
 const description = 'This is the description text';
 const errorMessage = 'error message';
+const arrowTestId = {
+  up: 'lg-number_input-increment-button',
+  down: 'lg-number_input-decrement-button',
+};
 
 const defaultProps = {
   className: 'number-input-class',
   placeholder: 'This is some placeholder text',
-  onChange: jest.fn(),
-  onBlur: jest.fn(),
 };
 
 const unitProps = {
@@ -133,8 +135,10 @@ describe('packages/number-input', () => {
     });
 
     test('value change triggers onChange callback', () => {
+      const onChange = jest.fn();
       const { numberInput } = renderNumberInput({
         label,
+        onChange,
         ...defaultProps,
       });
 
@@ -145,7 +149,7 @@ describe('packages/number-input', () => {
       });
 
       expect((numberInput as HTMLInputElement).value).toBe('1');
-      expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
 
     test('correct value is returned when using "e"', () => {
@@ -203,37 +207,35 @@ describe('packages/number-input', () => {
     });
 
     test('value changes when "up" arrow is clicked', () => {
-      const { container, numberInput } = renderNumberInput({
+      const { getByTestId, numberInput } = renderNumberInput({
         label,
         ...defaultProps,
       });
 
-      const upArrow = container.querySelector(
-        'button[aria-label="increment number"]',
-      );
+      const upArrow = getByTestId(arrowTestId.up);
 
       userEvent.click(upArrow as HTMLButtonElement);
       expect((numberInput as HTMLInputElement).value).toBe('1');
     });
 
     test('value changes when "down" arrow is clicked', () => {
-      const { container, numberInput } = renderNumberInput({
+      const { getByTestId, numberInput } = renderNumberInput({
         label,
         ...defaultProps,
       });
 
-      const upArrow = container.querySelector(
-        'button[aria-label="decrement number"]',
-      );
+      const downArrow = getByTestId(arrowTestId.down);
 
-      userEvent.click(upArrow as HTMLButtonElement);
+      userEvent.click(downArrow as HTMLButtonElement);
       expect((numberInput as HTMLInputElement).value).toBe('-1');
     });
 
     describe('onBlur', () => {
       test('callback triggers when focus leaves number input', () => {
+        const onBlur = jest.fn();
         const { numberInput } = renderNumberInput({
           label,
+          onBlur,
           ...defaultProps,
         });
 
@@ -241,25 +243,24 @@ describe('packages/number-input', () => {
         expect(numberInput).toHaveFocus();
         userEvent.tab(); // blur
 
-        expect(defaultProps.onBlur).toHaveBeenCalledTimes(1);
+        expect(onBlur).toHaveBeenCalledTimes(1);
       });
 
       test('callback triggers when focus leaves arrow buttons', () => {
-        const { container, numberInput } = renderNumberInput({
+        const onBlur = jest.fn();
+        const { getByTestId } = renderNumberInput({
           label,
+          onBlur,
           ...defaultProps,
         });
 
-        const upArrow = container.querySelector(
-          'button[aria-label="decrement number"]',
-        );
+        const upArrow = getByTestId(arrowTestId.up);
 
         userEvent.click(upArrow as HTMLButtonElement); // focus
-        expect(defaultProps.onBlur).toHaveBeenCalledTimes(1);
         expect(upArrow).toHaveFocus();
 
         userEvent.tab(); // blur
-        expect(defaultProps.onBlur).toHaveBeenCalledTimes(2);
+        expect(onBlur).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/number-input/src/NumberInput/NumberInput.types.ts
+++ b/packages/number-input/src/NumberInput/NumberInput.types.ts
@@ -115,7 +115,7 @@ export interface BaseNumberInputProps
   /**
    * Callback fired when the input or arrows lose focus
    */
-  onBlur?: FocusEventHandler<HTMLElement>;
+  onBlur?: FocusEventHandler<HTMLDivElement>;
 
   /**
    * id associated with the PasswordInput component, referenced by `<label>` with the `for` attribute.

--- a/packages/number-input/src/NumberInput/NumberInput.types.ts
+++ b/packages/number-input/src/NumberInput/NumberInput.types.ts
@@ -1,4 +1,8 @@
-import { ChangeEventHandler, ComponentPropsWithoutRef } from 'react';
+import {
+  ChangeEventHandler,
+  ComponentPropsWithoutRef,
+  FocusEventHandler,
+} from 'react';
 
 import { AriaLabelPropsWithLabel } from '@leafygreen-ui/a11y';
 import { DarkModeProps } from '@leafygreen-ui/lib';
@@ -107,6 +111,11 @@ export interface BaseNumberInputProps
    * Callback fired when the input value changes
    */
   onChange?: ChangeEventHandler<HTMLInputElement>;
+
+  /**
+   * Callback fired when the input or arrows lose focus
+   */
+  onBlur?: FocusEventHandler<HTMLElement>;
 
   /**
    * id associated with the PasswordInput component, referenced by `<label>` with the `for` attribute.


### PR DESCRIPTION
## ✍️ Proposed changes

In the `NumberInput` component, the `onBlur` callback was not being invoked when the arrow buttons were clicked. The `onBlur` was being passed in with the rest of the props directly to the input, and this change will now pass it to both the input and the arrows.


🎟 _Jira ticket:_ [LG-3940](https://jira.mongodb.org/browse/LG-3940)
  _Linked to_: [BAAS-27278](https://jira.mongodb.org/browse/BAAS-27278) 

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes


## 🧪 How to test changes

I added storybook changes, so this can be tested by adding/removing focus on the arrow buttons and reviewing the console log entries.

https://github.com/mongodb/leafygreen-ui/assets/52300529/b3050fb6-565d-4c4d-bf4c-1781f969d999


