### PR TITLE
LG-3988: expose portalRef from Popover and Portal props

### DIFF
--- a/.changeset/few-geckos-think.md
+++ b/.changeset/few-geckos-think.md
@@ -3,5 +3,5 @@
 '@leafygreen-ui/portal': minor
 ---
 
-Manually forward `_ref` to `Portal` component and expose `portalRef` in `Popover` component
+Manually forward `portalRef` to `Portal` component and expose `portalRef` in `Popover` component
 [LG-3988](https://jira.mongodb.org/browse/LG-3988)

--- a/.changeset/few-geckos-think.md
+++ b/.changeset/few-geckos-think.md
@@ -1,0 +1,7 @@
+---
+'@leafygreen-ui/popover': minor
+'@leafygreen-ui/portal': minor
+---
+
+Manually forward `_ref` to `Portal` component and expose `portalRef` in `Popover` component
+[LG-3988](https://jira.mongodb.org/browse/LG-3988)

--- a/packages/popover/src/Popover.stories.tsx
+++ b/packages/popover/src/Popover.stories.tsx
@@ -181,13 +181,13 @@ LiveExample.parameters = {
   },
 };
 
-// @ts-expect-error - Portal props (usePortal)
 export const ScrollableContainer: StoryFn<PopoverStoryProps> = ({
   refButtonPosition,
   buttonText,
   ...args
 }: PopoverStoryProps) => {
   const [active, setActive] = useState<boolean>(false);
+  const portalRef = useRef<HTMLElement | null>(null);
   const portalContainer = useRef<HTMLDivElement | null>(null);
 
   const position = referenceElPositions[refButtonPosition];
@@ -205,6 +205,7 @@ export const ScrollableContainer: StoryFn<PopoverStoryProps> = ({
             {...args}
             active={active}
             portalContainer={portalContainer.current}
+            portalRef={portalRef}
             scrollContainer={portalContainer.current}
           >
             <div className={popoverStyle}>Popover content</div>

--- a/packages/popover/src/Popover.types.ts
+++ b/packages/popover/src/Popover.types.ts
@@ -186,6 +186,11 @@ export type PopoverProps = {
    * Number that controls the z-index of the popover element directly.
    */
   popoverZIndex?: number;
+
+  /**
+   * A ref for the portal element
+   */
+  portalRef?: React.MutableRefObject<HTMLElement | null>;
 } & PortalControlProps &
   TransitionLifecycleCallbacks;
 

--- a/packages/popover/src/Popover/Popover.spec.tsx
+++ b/packages/popover/src/Popover/Popover.spec.tsx
@@ -55,6 +55,17 @@ describe('packages/popover', () => {
     expect(ref.current).toBeDefined();
   });
 
+  test('accepts a portalRef', () => {
+    const portalRef = createRef<HTMLElement>();
+    render(
+      <Popover portalRef={portalRef} data-testid="popover-test-id">
+        Popover Content
+      </Popover>,
+    );
+
+    expect(portalRef.current).toBeDefined();
+  });
+
   test('displays popover when the "active" prop is set', () => {
     const { getByTestId } = renderPopover({ active: true });
     expect(getByTestId('popover-test-id')).toBeInTheDocument();

--- a/packages/popover/src/Popover/Popover.spec.tsx
+++ b/packages/popover/src/Popover/Popover.spec.tsx
@@ -55,15 +55,18 @@ describe('packages/popover', () => {
     expect(ref.current).toBeDefined();
   });
 
-  test('accepts a portalRef', () => {
+  test('accepts a portalRef', async () => {
     const portalRef = createRef<HTMLElement>();
-    render(
-      <Popover portalRef={portalRef} data-testid="popover-test-id">
-        Popover Content
-      </Popover>,
-    );
+    waitFor(() => {
+      render(
+        <Popover portalRef={portalRef} data-testid="popover-test-id">
+          Popover Content
+        </Popover>,
+      );
 
-    expect(portalRef.current).toBeDefined();
+      expect(portalRef.current).toBeDefined();
+      expect(portalRef.current).toBeInTheDocument();
+    });
   });
 
   test('displays popover when the "active" prop is set', () => {

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -71,6 +71,7 @@ export const contentClassName = createUniqueClassName('popover-content');
  * @param props.usePortal Boolean to describe if content should be portaled to end of DOM, or appear in DOM tree.
  * @param props.portalClassName Classname applied to root element of the portal.
  * @param props.portalContainer HTML element that the popover is portaled within.
+ * @param props.portalRef A ref for the Portal element.
  * @param props.scrollContainer HTML ancestor element that's scrollable to position the popover accurately within scrolling containers.
  */
 export const Popover = forwardRef<HTMLDivElement, PopoverComponentProps>(
@@ -88,6 +89,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverComponentProps>(
       usePortal = true,
       portalClassName,
       portalContainer: portalContainerProp,
+      portalRef,
       scrollContainer: scrollContainerProp,
       onEnter,
       onEntering,
@@ -262,11 +264,12 @@ export const Popover = forwardRef<HTMLDivElement, PopoverComponentProps>(
     `;
 
     const Root = usePortal ? Portal : Fragment;
-    const rootProps = usePortal
-      ? portalContainer
-        ? { container: portalContainer }
-        : { className: portalClassName ?? undefined }
-      : {};
+    const portalProps = {
+      className: portalContainer ? undefined : portalClassName,
+      container: portalContainer ?? undefined,
+      _ref: portalRef,
+    };
+    const rootProps = usePortal ? portalProps : {};
 
     let renderedChildren: null | React.ReactNode;
 

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -267,7 +267,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverComponentProps>(
     const portalProps = {
       className: portalContainer ? undefined : portalClassName,
       container: portalContainer ?? undefined,
-      _ref: portalRef,
+      portalRef,
     };
     const rootProps = usePortal ? portalProps : {};
 

--- a/packages/portal/src/Portal/Portal.spec.tsx
+++ b/packages/portal/src/Portal/Portal.spec.tsx
@@ -27,11 +27,12 @@ describe('packages/Portal', () => {
 
     render(
       <div>
-        <Portal _ref={portalRef}>Portal content</Portal>
+        <Portal portalRef={portalRef}>Portal content</Portal>
       </div>,
     );
 
-    expect(portalRef.current).not.toBeNull();
+    expect(portalRef.current).toBeDefined();
+    expect(portalRef.current).toBeInTheDocument();
   });
 
   test('should set custom container as portal ref if provided', () => {
@@ -40,7 +41,7 @@ describe('packages/Portal', () => {
 
     render(
       <div>
-        <Portal container={customContainer} _ref={portalRef}>
+        <Portal container={customContainer} portalRef={portalRef}>
           Portal content
         </Portal>
       </div>,

--- a/packages/portal/src/Portal/Portal.spec.tsx
+++ b/packages/portal/src/Portal/Portal.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { createRef, useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { cleanup, render } from '@testing-library/react';
 
@@ -21,6 +21,33 @@ describe('packages/Portal', () => {
 
     return el;
   }
+
+  test('should create and set a default container as portal ref if custom container is not provided', () => {
+    const portalRef = createRef<HTMLElement>();
+
+    render(
+      <div>
+        <Portal _ref={portalRef}>Portal content</Portal>
+      </div>,
+    );
+
+    expect(portalRef.current).not.toBeNull();
+  });
+
+  test('should set custom container as portal ref if provided', () => {
+    const customContainer = document.createElement('div');
+    const portalRef = createRef<HTMLElement>();
+
+    render(
+      <div>
+        <Portal container={customContainer} _ref={portalRef}>
+          Portal content
+        </Portal>
+      </div>,
+    );
+
+    expect(portalRef.current).toBe(customContainer);
+  });
 
   test(`appends portal content to document body`, () => {
     render(

--- a/packages/portal/src/Portal/Portal.tsx
+++ b/packages/portal/src/Portal/Portal.tsx
@@ -51,9 +51,9 @@ function Portal({
   children,
   className,
   container,
-  _ref,
+  portalRef,
 }: PortalProps): React.ReactPortal | null {
-  const portalContainer = usePortalContainer(container ?? undefined, _ref);
+  const portalContainer = usePortalContainer(container ?? undefined, portalRef);
 
   useIsomorphicLayoutEffect(() => {
     if (portalContainer && !container) {

--- a/packages/portal/src/Portal/Portal.tsx
+++ b/packages/portal/src/Portal/Portal.tsx
@@ -16,6 +16,8 @@ export function usePortalContainer(
   //  - A component's initial hydrated render should match the server render
   const [container, setContainer] = React.useState<HTMLElement | undefined>();
 
+  // if a `portalRef` is passed to portal component, wait to set the portalReference
+  // until after the initial render
   useIsomorphicLayoutEffect(() => {
     if (customContainer) {
       if (portalRef) {

--- a/packages/portal/src/Portal/Portal.tsx
+++ b/packages/portal/src/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MutableRefObject } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 
@@ -6,7 +6,10 @@ import { useIsomorphicLayoutEffect } from '@leafygreen-ui/hooks';
 
 import { PortalProps } from './Portal.types';
 
-export function usePortalContainer(customContainer?: HTMLElement) {
+export function usePortalContainer(
+  customContainer?: HTMLElement,
+  portalRef?: MutableRefObject<HTMLElement | null>,
+) {
   // Make container initially undefined so that the portal is not created
   // or rendered on initial render. This allows server-side rendering since:
   //  - ReactDOMServer cannot render portals
@@ -15,39 +18,52 @@ export function usePortalContainer(customContainer?: HTMLElement) {
 
   useIsomorphicLayoutEffect(() => {
     if (customContainer) {
+      if (portalRef) {
+        portalRef.current = customContainer;
+      }
+
       setContainer(customContainer);
-    } else {
-      const defaultContainer = document.createElement('div');
-      document.body.appendChild(defaultContainer);
 
-      setContainer(defaultContainer);
-
-      return () => {
-        defaultContainer.remove();
-      };
+      return;
     }
-  }, [customContainer]);
 
+    const defaultContainer = document.createElement('div');
+    document.body.appendChild(defaultContainer);
+    if (portalRef) {
+      portalRef.current = defaultContainer;
+    }
+
+    setContainer(defaultContainer);
+
+    return () => {
+      defaultContainer.remove();
+    };
+  }, [customContainer, portalRef]);
   return container;
 }
 
 /**
  * Portals transport their children to a div that is appended to the end of `document.body` to or a node that can be specified with a container prop.
  */
-function Portal(props: PortalProps): React.ReactPortal | null {
-  const container = usePortalContainer(props.container ?? undefined);
+function Portal({
+  children,
+  className,
+  container,
+  _ref,
+}: PortalProps): React.ReactPortal | null {
+  const portalContainer = usePortalContainer(container ?? undefined, _ref);
 
   useIsomorphicLayoutEffect(() => {
-    if (container && !props.container) {
-      container.className = props.className ?? '';
+    if (portalContainer && !container) {
+      portalContainer.className = className ?? '';
     }
-  }, [container, props.container, props.className]);
+  }, [container, portalContainer, className]);
 
-  if (!container) {
+  if (!portalContainer) {
     return null;
   }
 
-  return createPortal(props.children, container);
+  return createPortal(children, portalContainer);
 }
 
 Portal.displayName = 'Portal';

--- a/packages/portal/src/Portal/Portal.types.ts
+++ b/packages/portal/src/Portal/Portal.types.ts
@@ -4,7 +4,7 @@ import { OneOf } from '@leafygreen-ui/lib';
 
 export type PortalProps = {
   children?: React.ReactNode;
-  _ref?: React.MutableRefObject<HTMLElement | null>;
+  portalRef?: React.MutableRefObject<HTMLElement | null>;
 } & OneOf<
   {
     /**

--- a/packages/portal/src/Portal/Portal.types.ts
+++ b/packages/portal/src/Portal/Portal.types.ts
@@ -8,14 +8,14 @@ export type PortalProps = {
 } & OneOf<
   {
     /**
+     * `className` prop passed to the container element.
+     */
+    className?: never;
+    /**
      * A custom container element. By default, the container will be a `div` appended to the document body.
      * @required
      */
     container: HTMLElement;
-    /**
-     * `className` prop passed to the container element.
-     */
-    className?: never;
   },
   {
     /**

--- a/packages/portal/src/Portal/Portal.types.ts
+++ b/packages/portal/src/Portal/Portal.types.ts
@@ -4,6 +4,7 @@ import { OneOf } from '@leafygreen-ui/lib';
 
 export type PortalProps = {
   children?: React.ReactNode;
+  _ref?: React.MutableRefObject<HTMLElement | null>;
 } & OneOf<
   {
     /**


### PR DESCRIPTION
## ✍️ Proposed changes
- expose manual fwdref from `Portal`
- expose `portalRef` from `Popover` 

🎟 _Jira ticket:_ [LG-3988](https://jira.mongodb.org/browse/LG-3988)
[Part 1](https://github.com/mongodb/leafygreen-ui/pull/2239) | [Part 2](https://github.com/mongodb/leafygreen-ui/pull/2241)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
