### PR TITLE
Disable DatePickerMenu Chromatic snapshots

### DIFF
--- a/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.stories.tsx
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenu.stories.tsx
@@ -58,6 +58,7 @@ const meta: StoryMetaType<typeof DatePickerMenu, DecoratorArgs> = {
     default: null,
     chromatic: {
       delay: transitionDuration.slower,
+      disableSnapshot: true,
     },
   },
   args: {


### PR DESCRIPTION
`DatePickerMenu` snapshots are flaky. Disabling them until we can make them more reliable 