### PR TITLE
Allow `defaultValue` to be used in `TextArea`

### DIFF
--- a/.changeset/chilled-seahorses-pay.md
+++ b/.changeset/chilled-seahorses-pay.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/text-area': patch
+---
+
+Allow defaultValue to be used in TextArea

--- a/packages/text-area/src/TextArea/TextArea.spec.tsx
+++ b/packages/text-area/src/TextArea/TextArea.spec.tsx
@@ -62,6 +62,19 @@ describe('packages/text-area', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  test('setting a defaultValue sets a default initial value and can be changed after', () => {
+    const { textArea } = renderTextArea({
+      defaultValue: 'a fun default value',
+    });
+    expect((textArea as HTMLTextAreaElement).value).toBe('a fun default value');
+
+    fireEvent.change(textArea, {
+      target: { value: 'a' },
+    });
+
+    expect((textArea as HTMLTextAreaElement).value).toBe('a');
+  });
+
   describe('when the "state" prop is set to error, and an "errorMessage" is set', () => {
     test('the error message appears in the DOM', () => {
       const { container } = renderTextArea({

--- a/packages/text-area/src/TextArea/TextArea.tsx
+++ b/packages/text-area/src/TextArea/TextArea.tsx
@@ -47,6 +47,7 @@ import { State, TextAreaProps } from './TextArea.types';
  * @param props.darkMode Determines whether or not the component appears in dark theme.
  * @param props.handleValidation Validation callback used to validate input.
  * @param props.baseFontSize Override the global `baseFontSize` set in LeafygreenProvider. This will only change the font size of the input text, not the label or description.
+ * @param props.defaultValue The default value of the input field. Unlike value, component will not be controlled if defaultValue is passed.
  */
 
 type TextArea = React.ForwardRefExoticComponent<TextAreaProps>;
@@ -69,6 +70,7 @@ export const TextArea: TextArea = forwardRef<
     handleValidation,
     'aria-labelledby': ariaLabelledby,
     baseFontSize: baseFontSizeProp,
+    defaultValue = '',
     ...rest
   }: TextAreaProps,
   forwardedRef: React.Ref<HTMLTextAreaElement>,
@@ -78,7 +80,7 @@ export const TextArea: TextArea = forwardRef<
   const { darkMode, theme } = useDarkMode(darkModeProp);
 
   const isControlled = typeof controlledValue === 'string';
-  const [uncontrolledValue, setValue] = useState('');
+  const [uncontrolledValue, setValue] = useState(defaultValue);
   const value = isControlled ? controlledValue : uncontrolledValue;
 
   // Validation


### PR DESCRIPTION
## ✍️ Proposed changes

Currently, the way `uncontrolledValue` is handled prevents `defaultValue` from working. I added `defaultValue` as the initial state for `uncontrolledValue` so that an initial value can be set while also allowing future edits from the user.

Not sure if I should have used `rest?.defaultValue` instead of just adding it, but since `className` is also not in `packages/text-area/src/TextArea/TextArea.types.ts` I thought it might be ok. Let me know if you want me to change that :D 

🎟 _Jira ticket:_ N/A

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes