### PR TITLE
LG-4144 | LG-4192: [CCP] TextArea

### DIFF
--- a/.changeset/early-buttons-agree.md
+++ b/.changeset/early-buttons-agree.md
@@ -1,0 +1,7 @@
+---
+'@lg-chat/message-feedback': minor
+---
+
+[LG-4144](https://jira.mongodb.org/browse/LG-4144)
+
+Updates spacing in `InlineMessageFeedback` component due to updated styling in `TextArea` component

--- a/.changeset/pretty-toes-tan.md
+++ b/.changeset/pretty-toes-tan.md
@@ -1,0 +1,31 @@
+---
+'@leafygreen-ui/text-area': major
+---
+
+[LG-4144](https://jira.mongodb.org/browse/LG-4144)
+
+1. `FormField` styling changes apply to `TextArea`. [See style changes here](https://github.com/mongodb/leafygreen-ui/blob/main/packages/form-field/CHANGELOG.md#102)
+
+2. A default `errorMessage` of `'This input needs your attention'` will render below text area when state is invalid.
+
+3. A default `successMessage` of `'Success'` will render when state is valid. `successMessage` prop accepts a custom string.
+
+4. Disabled `TextArea` component no longer renders the `disabled` attribute and instead relies on `aria-disabled` and `readonly` attributes.
+
+The last change is made to ensure that disabled components are still focusable to users using keyboard navigation.
+
+For more on `aria-disabled` see the [documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)
+
+#### Migration guide
+
+Functionally, migration should be seamless, however there may be unit/integration/e2e tests that relied on this behavior.
+
+##### Jest/RTL
+
+Generally, only this repo should need to test that these components have a specific attribute. We recommend updating unit tests to check that some event was or was not called.
+
+However, there are cases where this may still need to be tested. In cases where a test checks `expect(textArea).toBeDisabled()`, you can replace and use [test harnesses](https://github.com/mongodb/leafygreen-ui/blob/main/packages/text-area/README.md#test-harnesses).
+
+##### Cypress
+
+Similar to unit tests, you should generally test functionality and not implementation details. However, to test this in Cypress replace any `cy.get(textArea).should('be.disabled');` checks with `cy.get(textArea).invoke('attr', 'aria-disabled').should('eq', 'true');`

--- a/chat/message-feedback/src/InlineMessageFeedback/InlineMessageFeedback.styles.ts
+++ b/chat/message-feedback/src/InlineMessageFeedback/InlineMessageFeedback.styles.ts
@@ -15,8 +15,12 @@ export const labelStyles = css`
   padding-top: 3px; // to match icon button padding
 `;
 
+export const textAreaStyle = css`
+  margin-top: ${spacing[100]}px;
+`;
+
 export const actionContainerStyles = css`
-  margin-top: ${spacing[2]}px;
+  margin-top: ${spacing[200]}px;
   display: flex;
   gap: ${spacing[2]}px;
   justify-content: end;

--- a/chat/message-feedback/src/InlineMessageFeedback/InlineMessageFeedback.tsx
+++ b/chat/message-feedback/src/InlineMessageFeedback/InlineMessageFeedback.tsx
@@ -25,6 +25,7 @@ import {
   baseStyles,
   labelContainerStyles,
   labelStyles,
+  textAreaStyle,
 } from './InlineMessageFeedback.styles';
 import { InlineMessageFeedbackProps } from '.';
 
@@ -97,6 +98,7 @@ export const InlineMessageFeedback = forwardRef(
                 aria-labelledby={labelId}
                 /* eslint-disable-next-line jsx-a11y/no-autofocus */
                 autoFocus={true}
+                className={textAreaStyle}
                 {...textareaProps}
                 ref={(el: HTMLTextAreaElement) => {
                   if (textareaProps?.ref) {

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@leafygreen-ui/emotion": "^4.0.8",
+    "@leafygreen-ui/form-field": "^1.0.1",
     "@leafygreen-ui/hooks": "^8.1.3",
     "@leafygreen-ui/icon": "^12.1.0",
     "@leafygreen-ui/lib": "^13.4.0",

--- a/packages/text-area/src/TextArea/TextArea.spec.tsx
+++ b/packages/text-area/src/TextArea/TextArea.spec.tsx
@@ -5,12 +5,11 @@ import { axe } from 'jest-axe';
 
 import { getTestUtils } from '../utils';
 
-import { State, TextArea, TextAreaProps } from '.';
+import { TextArea, TextAreaProps } from '.';
 
 const onChange = jest.fn();
 
 const labelProp = 'Test Area Label';
-const errorMessage = 'This is an error message';
 const defaultProps = {
   className: 'test-text-area-class',
   description: 'This is the description',
@@ -85,30 +84,6 @@ describe('packages/text-area', () => {
     expect((textArea as HTMLTextAreaElement).value).toBe('a');
   });
 
-  describe('when the "state" prop is set to error, and an "errorMessage" is set', () => {
-    test('the error message appears in the DOM', () => {
-      const { isError, getErrorMessage } = renderTextArea({
-        state: State.Error,
-        errorMessage,
-      });
-
-      expect(isError()).toBe(true);
-      expect(getErrorMessage()).toHaveTextContent(errorMessage);
-    });
-  });
-
-  describe('when the "state" props is set to "none', () => {
-    test('error icon is not present', () => {
-      const { isError } = renderTextArea();
-      expect(isError()).toBe(false);
-    });
-
-    test('error message returns null', () => {
-      const { getErrorMessage } = renderTextArea();
-      expect(getErrorMessage()).not.toBeInTheDocument();
-    });
-  });
-
   test('onBlur is invoked when focus leaves the textarea', () => {
     const onBlur = jest.fn();
 
@@ -173,20 +148,6 @@ describe('packages/text-area', () => {
       userEvent.tab(); // focus
       userEvent.type(inputElement, `test`);
       expect(handleValidation).toHaveBeenCalledTimes(5); // blur + keypress * 4
-    });
-  });
-
-  describe('disabled', () => {
-    test('is true', () => {
-      const { isDisabled } = renderTextArea({ disabled: true });
-
-      expect(isDisabled()).toBe(true);
-    });
-
-    test('is false', () => {
-      const { isDisabled } = renderTextArea();
-
-      expect(isDisabled()).toBe(false);
     });
   });
 

--- a/packages/text-area/src/TextArea/TextArea.styles.ts
+++ b/packages/text-area/src/TextArea/TextArea.styles.ts
@@ -1,146 +1,18 @@
 import { css } from '@leafygreen-ui/emotion';
-import { Theme } from '@leafygreen-ui/lib';
-import { palette } from '@leafygreen-ui/palette';
-import {
-  focusRing,
-  fontFamilies,
-  fontWeights,
-  hoverRing,
-  spacing,
-  transitionDuration,
-} from '@leafygreen-ui/tokens';
+import { spacing } from '@leafygreen-ui/tokens';
 
-export const containerStyles = css`
+const TEXT_AREA_MIN_HEIGHT = 64;
+
+export const textAreaContainerStyles = css`
+  height: auto;
   display: flex;
-  flex-direction: column;
+  padding: 0;
 `;
 
-export const textAreaStyle = css`
-  font-family: ${fontFamilies.default};
+export const textAreaStyles = css`
   width: 100%;
-  min-height: ${spacing[6]}px;
-  resize: none;
-  margin: 0;
-  padding: 8px 12px 1px 12px;
-  font-size: 14px;
-  font-weight: ${fontWeights.regular};
-  line-height: 16px;
-  border: 1px solid;
-  border-radius: 6px;
-  transition: ${transitionDuration.default}ms ease-in-out;
-  transition-property: border-color, box-shadow;
-  margin-top: 4px;
-
-  &:focus {
-    outline: none;
-    border-color: transparent;
-    box-shadow: ${focusRing[Theme.Light].input};
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-  }
-`;
-
-export const errorContainerStyle = css`
+  min-height: ${TEXT_AREA_MIN_HEIGHT}px;
   display: flex;
-  height: 20px;
-  margin-top: 5px;
-  align-items: center;
-  font-weight: ${fontWeights.regular};
+  resize: none;
+  padding: ${spacing[200]}px ${spacing[300]}px;
 `;
-
-export const errorMessageLabelStyles = css`
-  line-height: 1;
-`;
-
-export const errorIconStyle = css`
-  margin-right: 3px;
-`;
-
-interface ColorSets {
-  textArea: string;
-  errorBorder: string;
-  errorIcon: string;
-}
-
-export const colorSets: Record<Theme, ColorSets> = {
-  [Theme.Light]: {
-    textArea: css`
-      color: ${palette.gray.dark3};
-      background-color: ${palette.white};
-      border-color: ${palette.gray.base};
-
-      &:hover:not(:disabled):not(:focus) {
-        border-color: ${palette.gray.base};
-        box-shadow: ${hoverRing[Theme.Light].gray};
-      }
-
-      &:disabled {
-        color: ${palette.gray.base};
-        background-color: ${palette.gray.light2};
-        border-color: ${palette.gray.light1};
-
-        &::placeholder {
-          color: inherit;
-        }
-      }
-    `,
-
-    errorBorder: css`
-      border-color: ${palette.red.base};
-
-      &:hover:not(:disabled):not(:focus) {
-        border-color: ${palette.red.base};
-        box-shadow: ${hoverRing[Theme.Light].red};
-      }
-
-      &:disabled {
-        border-color: ${palette.gray.light1};
-      }
-    `,
-
-    errorIcon: css`
-      color: ${palette.red.base};
-    `,
-  },
-  [Theme.Dark]: {
-    textArea: css`
-      color: ${palette.gray.light3};
-      background-color: ${palette.gray.dark4};
-      border-color: ${palette.gray.base};
-
-      &:hover:not(:disabled):not(:focus) {
-        border-color: ${palette.gray.base};
-        box-shadow: ${hoverRing[Theme.Dark].gray};
-      }
-
-      &:disabled {
-        color: ${palette.gray.dark1};
-        background-color: ${palette.gray.dark3};
-        border-color: ${palette.gray.dark2};
-
-        &::placeholder {
-          color: inherit;
-        }
-      }
-    `,
-
-    errorBorder: css`
-      border-color: ${palette.red.light1};
-
-      &:hover:not(:disabled):not(:focus) {
-        border-color: ${palette.red.light1};
-        box-shadow: ${hoverRing[Theme.Dark].red};
-      }
-
-      &:disabled {
-        border-color: ${palette.gray.dark2};
-      }
-    `,
-
-    errorIcon: css`
-      color: ${palette.red.light1};
-    `,
-  },
-};

--- a/packages/text-area/src/TextArea/TextArea.tsx
+++ b/packages/text-area/src/TextArea/TextArea.tsx
@@ -1,30 +1,14 @@
 import React, { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { cx } from '@leafygreen-ui/emotion';
+import { FormField, FormFieldInputContainer } from '@leafygreen-ui/form-field';
 import { useIdAllocator, useValidation } from '@leafygreen-ui/hooks';
-import Warning from '@leafygreen-ui/icon/dist/Warning';
-import LeafyGreenProvider, {
-  useDarkMode,
-} from '@leafygreen-ui/leafygreen-provider';
-import {
-  bodyTypeScaleStyles,
-  Description,
-  Error,
-  Label,
-  useUpdatedBaseFontSize,
-} from '@leafygreen-ui/typography';
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 
 import { LGIDS_TEXT_AREA } from '../constants';
 
-import {
-  colorSets,
-  containerStyles,
-  errorContainerStyle,
-  errorIconStyle,
-  errorMessageLabelStyles,
-  textAreaStyle,
-} from './TextArea.styles';
+import { textAreaContainerStyles, textAreaStyles } from './TextArea.styles';
 import { State, TextAreaProps } from './TextArea.types';
 
 /**
@@ -43,6 +27,7 @@ import { State, TextAreaProps } from './TextArea.types';
  * @param props.onBlur Callback to be executed when the input stops being focused.
  * @param props.placeholder The placeholder text shown in the input field before the user begins typing.
  * @param props.errorMessage The error message shown below the input element if the value is invalid.
+ * @param props.successMessage The success message shown below the input element if the value is valid.
  * @param props.state The current state of the TextArea. This can be `none` or `error`.
  * @param props.value The current value of the input field. If a value is passed to this prop, component will be controlled by consumer.
  * @param props.className ClassName supplied to the TextArea container.
@@ -61,7 +46,8 @@ export const TextArea: TextArea = forwardRef<
     label,
     description,
     className,
-    errorMessage,
+    errorMessage = 'This input needs your attention',
+    successMessage = 'Success',
     darkMode: darkModeProp,
     disabled = false,
     state = State.None,
@@ -70,7 +56,9 @@ export const TextArea: TextArea = forwardRef<
     onChange,
     onBlur,
     handleValidation,
+    'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
+    'aria-invalid': ariaInvalid,
     baseFontSize: baseFontSizeProp,
     'data-lgid': dataLgId = LGIDS_TEXT_AREA.root,
     defaultValue = '',
@@ -80,7 +68,7 @@ export const TextArea: TextArea = forwardRef<
 ) {
   const baseFontSize = useUpdatedBaseFontSize(baseFontSizeProp);
   const id = useIdAllocator({ prefix: 'textarea', id: idProp });
-  const { darkMode, theme } = useDarkMode(darkModeProp);
+  const { darkMode } = useDarkMode(darkModeProp);
 
   const isControlled = typeof controlledValue === 'string';
   const [uncontrolledValue, setValue] = useState(defaultValue);
@@ -89,7 +77,7 @@ export const TextArea: TextArea = forwardRef<
   // Validation
   const validation = useValidation<HTMLTextAreaElement>(handleValidation);
 
-  const onBlurHandler: React.FocusEventHandler<HTMLTextAreaElement> = e => {
+  const handleBlur: React.FocusEventHandler<HTMLTextAreaElement> = e => {
     if (onBlur) {
       onBlur(e);
     }
@@ -97,7 +85,7 @@ export const TextArea: TextArea = forwardRef<
     validation.onBlur(e);
   };
 
-  const onValueChange: React.ChangeEventHandler<HTMLTextAreaElement> = e => {
+  const handleChange: React.ChangeEventHandler<HTMLTextAreaElement> = e => {
     if (onChange) {
       onChange(e);
     }
@@ -115,62 +103,43 @@ export const TextArea: TextArea = forwardRef<
     );
   }
 
+  const ariaProps = {
+    'aria-invalid': ariaInvalid,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+  } as const;
+
+  const formFieldProps = {
+    baseFontSize,
+    className,
+    darkMode,
+    'data-lgid': dataLgId,
+    description,
+    disabled,
+    errorMessage,
+    id,
+    label,
+    state,
+    successMessage,
+    ...ariaProps,
+  } as const;
+
+  const textAreaProps = {
+    className: textAreaStyles,
+    onBlur: handleBlur,
+    onChange: handleChange,
+    ref: forwardedRef,
+    title: label != null ? label : undefined,
+    value,
+    ...rest,
+  } as const;
+
   return (
-    <LeafyGreenProvider
-      darkMode={darkMode}
-      // TODO: We cannot simply pass baseFontSize to the Provider, since the updatedBaseFontSize values are not in line with those accepted by the Provider.
-      // Once we fix this in this Provider, we should update to pass baseFontSize here rather than coercing the value.
-      // This works as-is because all of the Typography elements are using useUpdatedBaseFontSize to convert 14 to 13px.
-      baseFontSize={baseFontSize === 16 ? 16 : 14}
-    >
-      <div className={cx(containerStyles, className)} data-lgid={dataLgId}>
-        {label && (
-          <Label htmlFor={id} disabled={disabled}>
-            {label}
-          </Label>
-        )}
-        {description && (
-          <Description disabled={disabled}>{description}</Description>
-        )}
-        <textarea
-          {...rest}
-          aria-labelledby={ariaLabelledby}
-          ref={forwardedRef}
-          title={label != null ? label : undefined}
-          id={id}
-          className={cx(
-            textAreaStyle,
-            bodyTypeScaleStyles[baseFontSize],
-            colorSets[theme].textArea,
-            {
-              [colorSets[theme].errorBorder]:
-                state === State.Error && !disabled,
-            },
-          )}
-          disabled={disabled}
-          onChange={onValueChange}
-          onBlur={onBlurHandler}
-          value={value}
-          aria-invalid={state === State.Error}
-        />
-        {!disabled && state === State.Error && errorMessage && (
-          <div className={errorContainerStyle}>
-            <Warning
-              className={cx(errorIconStyle, colorSets[theme].errorIcon)}
-            />
-            <Error
-              className={cx(
-                bodyTypeScaleStyles[baseFontSize],
-                errorMessageLabelStyles,
-              )}
-              data-lgid={LGIDS_TEXT_AREA.errorMessage}
-            >
-              {errorMessage}
-            </Error>
-          </div>
-        )}
-      </div>
-    </LeafyGreenProvider>
+    <FormField {...formFieldProps}>
+      <FormFieldInputContainer className={textAreaContainerStyles}>
+        <textarea {...textAreaProps} />
+      </FormFieldInputContainer>
+    </FormField>
   );
 });
 
@@ -182,5 +151,6 @@ TextArea.propTypes = {
   label: PropTypes.string,
   description: PropTypes.string,
   errorMessage: PropTypes.string,
+  successMessage: PropTypes.string,
   state: PropTypes.oneOf(Object.values(State)),
 };

--- a/packages/text-area/src/TextArea/TextArea.types.ts
+++ b/packages/text-area/src/TextArea/TextArea.types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { FormFieldState } from '@leafygreen-ui/form-field';
 import {
   DarkModeProps,
   Either,
@@ -8,11 +9,7 @@ import {
 } from '@leafygreen-ui/lib';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
 
-export const State = {
-  None: 'none',
-  Error: 'error',
-} as const;
-
+export const State = FormFieldState;
 export type State = (typeof State)[keyof typeof State];
 
 export interface BaseTextAreaProps
@@ -37,7 +34,7 @@ export interface BaseTextAreaProps
   description?: React.ReactNode;
 
   /**
-   * Whether or not the field is currently disabled.
+   * Whether or not the field is disabled. This will set the `aria-disabled` and `readonly` attributes on the input, not the `disabled` attribute.
    * @default false
    */
   disabled?: boolean;
@@ -62,6 +59,11 @@ export interface BaseTextAreaProps
    * The message shown below the input element if the value is invalid.
    */
   errorMessage?: string;
+
+  /**
+   * The message shown below the input element if the value is valid.
+   */
+  successMessage?: string;
 
   /**
    * Callback called whenever validation should be run.

--- a/packages/text-area/src/constants.ts
+++ b/packages/text-area/src/constants.ts
@@ -2,5 +2,4 @@ const LGID_ROOT = 'lg-text_area';
 
 export const LGIDS_TEXT_AREA = {
   root: LGID_ROOT,
-  errorMessage: `${LGID_ROOT}-error_message`,
 } as const;

--- a/packages/text-area/src/utils/getTestUtils/getTestUtils.spec.tsx
+++ b/packages/text-area/src/utils/getTestUtils/getTestUtils.spec.tsx
@@ -46,7 +46,7 @@ function renderMultipleInputs() {
   );
 }
 
-describe('packages/text-input', () => {
+describe('packages/text-area', () => {
   describe('getTestUtils', () => {
     test('throws error if LG TextArea is not found', () => {
       render(<TextArea data-lgid="lg-text_output" label="hey" />);

--- a/packages/text-area/src/utils/getTestUtils/getTestUtils.ts
+++ b/packages/text-area/src/utils/getTestUtils/getTestUtils.ts
@@ -1,5 +1,6 @@
 import { getByLgId, queryBySelector } from '@lg-tools/test-harnesses';
 
+import { LGIDS_FORM_FIELD } from '@leafygreen-ui/form-field';
 import { LGIDS_TYPOGRAPHY } from '@leafygreen-ui/typography';
 
 import { LGIDS_TEXT_AREA } from '../../constants';
@@ -44,14 +45,21 @@ export const getTestUtils = (
    */
   const getErrorMessage = queryBySelector<HTMLElement>(
     element,
-    `[data-lgid="${LGIDS_TEXT_AREA.errorMessage}"]`,
+    `[data-lgid="${LGIDS_FORM_FIELD.errorMessage}"]`,
   );
 
   /**
-   * Returns the disabled attribute on the input.
+   * Returns the aria-disabled attribute on the input.
    */
-  const isInputDisabled = () => {
-    return getInput.disabled;
+  const isInputAriaDisabled = () => {
+    return getInput.getAttribute('aria-disabled') === 'true';
+  };
+
+  /**
+   * Returns the aria-disabled attribute on the input.
+   */
+  const isInputReadOnly = () => {
+    return getInput.readOnly;
   };
 
   /**
@@ -78,7 +86,7 @@ export const getTestUtils = (
     getDescription: () => getDescription,
     getInput: () => getInput,
     getErrorMessage: () => getErrorMessage,
-    isDisabled: () => isInputDisabled(),
+    isDisabled: () => isInputAriaDisabled() && isInputReadOnly(),
     isError: () => isError(),
     getInputValue: () => getInputValue(),
   };

--- a/packages/text-area/tsconfig.json
+++ b/packages/text-area/tsconfig.json
@@ -19,16 +19,13 @@
       "path": "../emotion"
     },
     {
+      "path": "../form-field"
+    },
+    {
       "path": "../hooks"
     },
     {
-      "path": "../icon"
-    },
-    {
       "path": "../lib"
-    },
-    {
-      "path": "../palette"
     },
     {
       "path": "../tokens"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7346,10 +7346,10 @@ camelcase@^7.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
-caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001585, caniuse-lite@^1.0.30001587:
-  version "1.0.30001603"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001603.tgz#605046a5bdc95ba4a92496d67e062522dce43381"
-  integrity sha512-iL2iSS0eDILMb9n5yKQoTBim9jMZ0Yrk8g0N9K7UzYyWnfIKzXBZD5ngpM37ZcL/cv0Mli8XtVMRYMQAfFpi5Q==
+caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001541, caniuse-lite@^1.0.30001585, caniuse-lite@^1.0.30001587:
+  version "1.0.30001600"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz#93a3ee17a35aa6a9f0c6ef1b2ab49507d1ab9079"
+  integrity sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## ✍️ Proposed changes

`TextArea`
- `FormField` styling applies to `TextArea`
- passes aria props to `FormField`
- adds `successMessage` prop
- adds default state messages

🎟 _Jira ticket:_ [LG-4144](https://jira.mongodb.org/browse/LG-4144) | [LG-4192](https://jira.mongodb.org/browse/LG-4192)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

- Figma: https://www.figma.com/file/8M2FIDohVwZhC05jn0z17K/LG-2103%3A-Text-input-error-state?type=design&node-id=14674-86000&mode=design&t=RVhTpuWS4QhysQAO-4
- Review storybook and chromatic
