### PR TITLE
Update Tooltip type docs

### DIFF
--- a/packages/tooltip/src/Tooltip/Tooltip.types.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.types.ts
@@ -54,6 +54,11 @@ export type TooltipProps = Omit<
     align?: Align;
     /**
      * A slot for the element used to trigger the `Tooltip`.
+     *
+     * Note: The component passed as `trigger` _must_ accept and render `children`,
+     * even if the general use of the component does not require children.
+     * The `tooltip` content is rendered (via `Popover`) as a child of the trigger,
+     * and if the trigger does not render any children, then the trigger will not be rendered.
      */
     trigger?: React.ReactElement | Function;
 


### PR DESCRIPTION
## ✍️ Proposed changes

It took me a while to debug that a Tooltip `trigger` component needed to render `children` in order to actually render the tooltip. Adding documentation for this.

### Future considerations
A potential-runtime warning could be the following:

```tsx
// Tooltip.tsx L294

// track a ref to an invisible element
const didRenderChildrenRef = useRef<HTMLDivElement>(null);

useEffect(() => {
  // log a warning if our invisible element did not render (signaling that our tooltip won't render either)
  if (!didRenderChildrenRef.current) {
    console.warn('Tooltip trigger element did not render children. To render a tooltip, the `trigger` element must accept and render `children`',
    );
  }
});

return React.cloneElement(trigger, {
  children: (
    <>
      {trigger.props.children}
      {tooltip}
      <DidRender ref={didRenderChildrenRef} /> // render an invisible element
    </>
  ),
  ...
});
```


where:

```tsx
const DidRender = forwardRef<HTMLDivElement>((_, ref) => {
  return <div ref={ref} style={{ display: 'none' }} />;
});

```