### PR TITLE
`color` token use `satistfies`

### DIFF
--- a/.changeset/violet-cougars-nail.md
+++ b/.changeset/violet-cougars-nail.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tokens': patch
+---
+
+Uses `satisfies` to ensure correct object color tokens structure

--- a/.changeset/violet-cougars-nail.md
+++ b/.changeset/violet-cougars-nail.md
@@ -1,5 +1,4 @@
 ---
 '@leafygreen-ui/tokens': patch
 ---
-
-Uses `satisfies` to ensure correct object color tokens structure
+Adds `satisfies` to ensure consistent & correct `colors` token structure

--- a/packages/tokens/src/color/color.ts
+++ b/packages/tokens/src/color/color.ts
@@ -1,9 +1,10 @@
 import { Mode } from '../mode';
 
+import { ModeColorRecord } from './color.types';
 import { darkModeColors } from './darkModeColors';
 import { lightModeColors } from './lightModeColors';
 
 export const color = {
   [Mode.Dark]: darkModeColors,
   [Mode.Light]: lightModeColors,
-} as const;
+} as const satisfies Record<Mode, ModeColorRecord>;

--- a/packages/tokens/src/color/color.types.ts
+++ b/packages/tokens/src/color/color.types.ts
@@ -1,18 +1,9 @@
-const State = {
-  Default: 'default',
-  Hover: 'hover',
-  Focus: 'focus',
-} as const;
-
-type State = (typeof State)[keyof typeof State];
-
 const Type = {
   Background: 'background',
   Border: 'border',
   Icon: 'icon',
   Text: 'text',
 } as const;
-
 type Type = (typeof Type)[keyof typeof Type];
 
 const Variant = {
@@ -26,7 +17,18 @@ const Variant = {
   Success: 'success',
   Disabled: 'disabled',
 } as const;
-
 type Variant = (typeof Variant)[keyof typeof Variant];
+
+const State = {
+  Default: 'default',
+  Hover: 'hover',
+  Focus: 'focus',
+} as const;
+type State = (typeof State)[keyof typeof State];
+
+export type VariantColorRecord = Partial<
+  Record<Variant, Record<State, string>>
+>;
+export type ModeColorRecord = Record<Type, VariantColorRecord>;
 
 export { State, Type, Variant };

--- a/packages/tokens/src/color/darkModeColors.ts
+++ b/packages/tokens/src/color/darkModeColors.ts
@@ -1,6 +1,11 @@
 import { palette } from '@leafygreen-ui/palette';
 
-import { State, Variant } from './color.types';
+import {
+  ModeColorRecord,
+  State,
+  Variant,
+  VariantColorRecord,
+} from './color.types';
 
 const { black, blue, gray, green, red, white, yellow } = palette;
 
@@ -45,7 +50,7 @@ const darkModeBackgroundColors = {
     [State.Hover]: gray.dark2,
     [State.Focus]: gray.dark2,
   },
-};
+} satisfies VariantColorRecord;
 
 const darkModeBorderColors = {
   [Variant.Primary]: {
@@ -73,7 +78,7 @@ const darkModeBorderColors = {
     [State.Hover]: gray.dark2,
     [State.Focus]: gray.dark2,
   },
-};
+} satisfies VariantColorRecord;
 
 const darkModeIconColors = {
   [Variant.Primary]: {
@@ -116,9 +121,9 @@ const darkModeIconColors = {
     [State.Hover]: gray.dark1,
     [State.Focus]: gray.dark1,
   },
-};
+} satisfies VariantColorRecord;
 
-export const darkModeTextColors = {
+const darkModeTextColors = {
   [Variant.Primary]: {
     [State.Default]: gray.light2,
     [State.Hover]: gray.light2,
@@ -149,11 +154,11 @@ export const darkModeTextColors = {
     [State.Hover]: gray.dark1,
     [State.Focus]: gray.dark1,
   },
-};
+} satisfies VariantColorRecord;
 
 export const darkModeColors = {
   background: darkModeBackgroundColors,
   border: darkModeBorderColors,
   icon: darkModeIconColors,
   text: darkModeTextColors,
-};
+} satisfies ModeColorRecord;

--- a/packages/tokens/src/color/darkModeColors.ts
+++ b/packages/tokens/src/color/darkModeColors.ts
@@ -50,7 +50,7 @@ const darkModeBackgroundColors = {
     [State.Hover]: gray.dark2,
     [State.Focus]: gray.dark2,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 const darkModeBorderColors = {
   [Variant.Primary]: {
@@ -78,7 +78,7 @@ const darkModeBorderColors = {
     [State.Hover]: gray.dark2,
     [State.Focus]: gray.dark2,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 const darkModeIconColors = {
   [Variant.Primary]: {
@@ -121,7 +121,7 @@ const darkModeIconColors = {
     [State.Hover]: gray.dark1,
     [State.Focus]: gray.dark1,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 const darkModeTextColors = {
   [Variant.Primary]: {
@@ -154,11 +154,11 @@ const darkModeTextColors = {
     [State.Hover]: gray.dark1,
     [State.Focus]: gray.dark1,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 export const darkModeColors = {
   background: darkModeBackgroundColors,
   border: darkModeBorderColors,
   icon: darkModeIconColors,
   text: darkModeTextColors,
-} satisfies ModeColorRecord;
+} as const satisfies ModeColorRecord;

--- a/packages/tokens/src/color/lightModeColors.ts
+++ b/packages/tokens/src/color/lightModeColors.ts
@@ -50,7 +50,7 @@ const lightModeBackgroundColors = {
     [State.Hover]: gray.light2,
     [State.Focus]: gray.light2,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 const lightModBorderColors = {
   [Variant.Primary]: {
@@ -78,7 +78,7 @@ const lightModBorderColors = {
     [State.Hover]: gray.light1,
     [State.Focus]: gray.light1,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 const lightModeIconColors = {
   [Variant.Primary]: {
@@ -121,7 +121,7 @@ const lightModeIconColors = {
     [State.Hover]: gray.base,
     [State.Focus]: gray.base,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 const lightModeTextColors = {
   [Variant.Primary]: {
@@ -154,11 +154,11 @@ const lightModeTextColors = {
     [State.Hover]: gray.base,
     [State.Focus]: gray.base,
   },
-} satisfies VariantColorRecord;
+} as const satisfies VariantColorRecord;
 
 export const lightModeColors = {
   background: lightModeBackgroundColors,
   border: lightModBorderColors,
   icon: lightModeIconColors,
   text: lightModeTextColors,
-} satisfies ModeColorRecord;
+} as const satisfies ModeColorRecord;

--- a/packages/tokens/src/color/lightModeColors.ts
+++ b/packages/tokens/src/color/lightModeColors.ts
@@ -1,6 +1,11 @@
 import { palette } from '@leafygreen-ui/palette';
 
-import { State, Variant } from './color.types';
+import {
+  ModeColorRecord,
+  State,
+  Variant,
+  VariantColorRecord,
+} from './color.types';
 
 const { black, blue, gray, green, red, white, yellow } = palette;
 
@@ -45,7 +50,7 @@ const lightModeBackgroundColors = {
     [State.Hover]: gray.light2,
     [State.Focus]: gray.light2,
   },
-};
+} satisfies VariantColorRecord;
 
 const lightModBorderColors = {
   [Variant.Primary]: {
@@ -73,7 +78,7 @@ const lightModBorderColors = {
     [State.Hover]: gray.light1,
     [State.Focus]: gray.light1,
   },
-};
+} satisfies VariantColorRecord;
 
 const lightModeIconColors = {
   [Variant.Primary]: {
@@ -116,9 +121,9 @@ const lightModeIconColors = {
     [State.Hover]: gray.base,
     [State.Focus]: gray.base,
   },
-};
+} satisfies VariantColorRecord;
 
-export const lightModeTextColors = {
+const lightModeTextColors = {
   [Variant.Primary]: {
     [State.Default]: black,
     [State.Hover]: black,
@@ -149,11 +154,11 @@ export const lightModeTextColors = {
     [State.Hover]: gray.base,
     [State.Focus]: gray.base,
   },
-};
+} satisfies VariantColorRecord;
 
 export const lightModeColors = {
   background: lightModeBackgroundColors,
   border: lightModBorderColors,
   icon: lightModeIconColors,
   text: lightModeTextColors,
-};
+} satisfies ModeColorRecord;


### PR DESCRIPTION
## ✍️ Proposed changes

Adds `satisfies` to ensure consistent & correct `colors` token structure