### PR TITLE
LG-4147: forceRenderAllTabPanels prop

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -99,9 +99,10 @@ test('tabs', () => {
     </Tabs>
   );
 
-  const { getAllTabsInTabList, getTabUtilsByName, getSelectedPanel } = getTestUtils();
+  const { getAllTabPanelsInDOM, getAllTabsInTabList, getSelectedPanel, getTabUtilsByName } = getTestUtils();
 
   expect(getAllTabsInTabList()).toHaveLength(3);
+  expect(getAllTabPanelsInDOM()).toHaveLength(1);
 
   const firstTabUtils = getTabUtilsByName('First');
   expect(firstTabUtils.isSelected()).toBeTruthy();
@@ -144,7 +145,7 @@ test('tabs', () => {
           Content C
         </Tab>
       </Tabs>
-      <Tabs aria-label="Label XY" data-lgid="tabs-xy">
+      <Tabs aria-label="Label XY" data-lgid="tabs-xy" forceRenderAllTabPanels={true}>
         <Tab name="X">
           Content X
         </Tab>
@@ -160,11 +161,13 @@ test('tabs', () => {
 
   // First tabs
   expect(testUtils1.getAllTabsInTabList()).toHaveLength(3);
+  expect(testUtils1.getAllTabPanelsInDOM()).toHaveLength(1);
   expect(testUtils1.getSelectedPanel()).toHaveTextContent('Content A');
 
   // Second tabs
-  expect(testUtils1.getAllTabsInTabList()).toHaveLength(2);
-  expect(testUtils1.getSelectedPanel()).toHaveTextContent('Content Y');
+  expect(testUtils2.getAllTabsInTabList()).toHaveLength(2);
+  expect(testUtils2.getAllTabPanelsInDOM()).toHaveLength(2);
+  expect(testUtils2.getSelectedPanel()).toHaveTextContent('Content Y');
 });
 ```
 
@@ -172,21 +175,23 @@ test('tabs', () => {
 
 ```tsx
 const {
+  getAllTabPanelsInDOM,
   getAllTabsInTabList,
   getTabUtilsByName: { getTab, isSelected, isDisabled },
   getSelectedPanel,
 } = getTestUtils();
 ```
 
-| Util                    | Description                                          | Returns                 |
-| ----------------------- | ---------------------------------------------------- | ----------------------- |
-| `getAllTabsInTabList()` | Returns an array of tabs                             | `Array<HTMLElement>`    |
-| `getSelectedPanel()`    | Returns the selected tab panel                       | `HTMLElement` \| `null` |
-| `getTabUtilsByName()`   | Returns tab utils if tab with matching name is found | `TabUtils` \| `null`    |
-| TabUtils                |                                                      |                         |
-| `getTab()`              | Returns the tab                                      | `HTMLElement`           |
-| `isSelected()`          | Returns whether the tab is selected                  | `boolean`               |
-| `isDisabled()`          | Returns whether the tab is disabled                  | `boolean`               |
+| Util                     | Description                                          | Returns                 |
+| ------------------------ | ---------------------------------------------------- | ----------------------- |
+| `getAllTabPanelsInDOM()` | Returns an array of tab panels                       | `Array<HTMLElement>`    |
+| `getAllTabsInTabList()`  | Returns an array of tabs                             | `Array<HTMLElement>`    |
+| `getSelectedPanel()`     | Returns the selected tab panel                       | `HTMLElement` \| `null` |
+| `getTabUtilsByName()`    | Returns tab utils if tab with matching name is found | `TabUtils` \| `null`    |
+| TabUtils                 |                                                      |                         |
+| `getTab()`               | Returns the tab                                      | `HTMLElement`           |
+| `isSelected()`           | Returns whether the tab is selected                  | `boolean`               |
+| `isDisabled()`           | Returns whether the tab is disabled                  | `boolean`               |
 
 ## Reference
 

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { useTabsContext } from '../context';
+
 import { TabProps } from './Tab.types';
 
 /**
@@ -20,14 +22,20 @@ import { TabProps } from './Tab.types';
  * @param props.to Destination when name is rendered as `Link` tag.
  *
  */
-function Tab({ selected, children, ...rest }: TabProps) {
+function Tab({ children, disabled, selected, ...rest }: TabProps) {
   // default and name are not an HTML properties
   // onClick applies to TabTitle component, not Tab component
   delete rest.default, delete rest.name, delete rest.onClick, delete rest.href;
 
+  const { forceRenderAllTabPanels } = useTabsContext();
+
+  const shouldRender = !disabled && (forceRenderAllTabPanels || selected);
+
+  if (!shouldRender) return null;
+
   return (
     <div {...rest} role="tabpanel">
-      {selected ? children : null}
+      {children}
     </div>
   );
 }

--- a/packages/tabs/src/TabPanel/TabPanel.styles.ts
+++ b/packages/tabs/src/TabPanel/TabPanel.styles.ts
@@ -1,0 +1,5 @@
+import { css } from '@leafygreen-ui/emotion';
+
+export const hiddenTabPanelStyle = css`
+  display: none;
+`;

--- a/packages/tabs/src/TabPanel/TabPanel.tsx
+++ b/packages/tabs/src/TabPanel/TabPanel.tsx
@@ -1,27 +1,36 @@
 import React, { useMemo } from 'react';
 
 import { useDescendant } from '@leafygreen-ui/descendants';
+import { cx } from '@leafygreen-ui/emotion';
 
 import {
   TabPanelDescendantsContext,
   useTabDescendantsContext,
+  useTabsContext,
 } from '../context';
 
+import { hiddenTabPanelStyle } from './TabPanel.styles';
 import { TabPanelProps } from './TabPanel.types';
 
-const TabPanel = ({ child, selectedIndex }: TabPanelProps) => {
+const TabPanel = ({ child }: TabPanelProps) => {
   const { id, index, ref } = useDescendant(TabPanelDescendantsContext);
   const { tabDescendants } = useTabDescendantsContext();
+  const { selectedIndex } = useTabsContext();
 
   const relatedTab = useMemo(() => {
     return tabDescendants.find(tabDescendant => tabDescendant.index === index);
   }, [tabDescendants, index]);
 
+  const selected = index === selectedIndex;
+
   return (
     <div ref={ref}>
       {React.cloneElement(child, {
         id,
-        selected: !child.props.disabled && index === selectedIndex,
+        selected: index === selectedIndex,
+        className: cx({
+          [hiddenTabPanelStyle]: !selected,
+        }),
         ['aria-labelledby']: relatedTab?.id,
       })}
     </div>

--- a/packages/tabs/src/TabPanel/TabPanel.types.ts
+++ b/packages/tabs/src/TabPanel/TabPanel.types.ts
@@ -1,4 +1,3 @@
 export interface TabPanelProps {
   child: React.ReactElement;
-  selectedIndex: number;
 }

--- a/packages/tabs/src/TabTitle/TabTitle.tsx
+++ b/packages/tabs/src/TabTitle/TabTitle.tsx
@@ -13,6 +13,7 @@ import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 import {
   TabDescendantsContext,
   useTabPanelDescendantsContext,
+  useTabsContext,
 } from '../context';
 
 import {
@@ -25,22 +26,14 @@ import { BaseTabTitleProps } from './TabTitle.types';
 
 const TabTitle = InferredPolymorphic<BaseTabTitleProps, 'button'>(
   (
-    {
-      as,
-      children,
-      className,
-      darkMode,
-      disabled = false,
-      onClick,
-      selectedIndex,
-      ...rest
-    },
+    { as, children, className, darkMode, disabled = false, onClick, ...rest },
     fwdRef,
   ) => {
     const baseFontSize: BaseFontSize = useUpdatedBaseFontSize();
     const { Component } = useInferredPolymorphic(as, rest, 'button');
     const { index, ref, id } = useDescendant(TabDescendantsContext);
     const { tabPanelDescendants } = useTabPanelDescendantsContext();
+    const { selectedIndex } = useTabsContext();
 
     const theme = darkMode ? Theme.Dark : Theme.Light;
     const selected = index === selectedIndex;

--- a/packages/tabs/src/TabTitle/TabTitle.types.ts
+++ b/packages/tabs/src/TabTitle/TabTitle.types.ts
@@ -5,6 +5,5 @@ export interface BaseTabTitleProps {
   className?: string;
   disabled?: boolean;
   isAnyTabFocused?: boolean;
-  selectedIndex: number;
   [key: string]: any;
 }

--- a/packages/tabs/src/Tabs.spec.tsx
+++ b/packages/tabs/src/Tabs.spec.tsx
@@ -74,6 +74,49 @@ describe('packages/tabs', () => {
 
       expect(getByTestId('inline-children')).toBeInTheDocument();
     });
+
+    describe('forceRenderAllTabPanels', () => {
+      test('renders only selected panel in DOM when prop is false', () => {
+        const { getAllTabsInTabList, getAllTabPanelsInDOM, getSelectedPanel } =
+          renderTabs({
+            forceRenderAllTabPanels: false,
+          });
+        const tabs = getAllTabsInTabList();
+        const tabPanels = getAllTabPanelsInDOM();
+        expect(tabs).toHaveLength(3);
+        expect(tabPanels).toHaveLength(1);
+
+        const selectedPanel = getSelectedPanel();
+        const hiddenPanels = tabPanels.filter(
+          panel => panel.id !== selectedPanel?.id,
+        );
+
+        expect(selectedPanel).toBeVisible();
+        expect(hiddenPanels).toHaveLength(0);
+      });
+
+      test('renders all tab panels in DOM but only selected panel is visible when prop is true', () => {
+        const { getAllTabsInTabList, getAllTabPanelsInDOM, getSelectedPanel } =
+          renderTabs({
+            forceRenderAllTabPanels: true,
+          });
+        const tabs = getAllTabsInTabList();
+        const tabPanels = getAllTabPanelsInDOM();
+        expect(tabs).toHaveLength(3);
+        expect(tabPanels).toHaveLength(3);
+
+        const selectedPanel = getSelectedPanel();
+        const hiddenPanels = tabPanels.filter(
+          panel => panel.id !== selectedPanel?.id,
+        );
+
+        expect(selectedPanel).toBeVisible();
+        hiddenPanels.forEach(panel => {
+          expect(panel).not.toBeVisible();
+          expect(panel).toBeInTheDocument();
+        });
+      });
+    });
   });
 
   describe('when controlled', () => {

--- a/packages/tabs/src/Tabs.stories.tsx
+++ b/packages/tabs/src/Tabs.stories.tsx
@@ -88,13 +88,14 @@ const meta: StoryMetaType<typeof Tabs> = {
         </CardWithMargin>
       </Tab>,
     ],
+    forceRenderAllTabPanels: false,
   },
   argTypes: {
     as: storybookArgTypes.as,
+    forceRenderAllTabPanels: { control: 'boolean' },
     selected: { control: 'number' },
   },
   // TODO: Add subcomponent controls for Tab when supported by Storybook
-  // @ts-expect-error
   subcomponents: { tab: Tab },
 };
 export default meta;

--- a/packages/tabs/src/Tabs/Tabs.tsx
+++ b/packages/tabs/src/Tabs/Tabs.tsx
@@ -16,7 +16,11 @@ import { BaseFontSize } from '@leafygreen-ui/tokens';
 import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 
 import { LGIDS_TABS } from '../constants';
-import { TabDescendantsContext, TabPanelDescendantsContext } from '../context';
+import {
+  TabDescendantsContext,
+  TabPanelDescendantsContext,
+  TabsContext,
+} from '../context';
 import TabPanel from '../TabPanel';
 import TabTitle from '../TabTitle';
 import { getActiveAndEnabledIndices } from '../utils';
@@ -60,6 +64,7 @@ const Tabs = (props: AccessibleTabsProps) => {
     inlineChildren,
     selected: controlledSelected,
     setSelected: setControlledSelected,
+    forceRenderAllTabPanels = false,
     'data-lgid': dataLgId = LGIDS_TABS.root,
     'aria-labelledby': ariaLabelledby,
     'aria-label': ariaLabel,
@@ -143,7 +148,6 @@ const Tabs = (props: AccessibleTabsProps) => {
             handleClickTab(event, index);
           }
         : undefined,
-      selectedIndex: selected,
       ...rest,
     } as const;
 
@@ -155,7 +159,7 @@ const Tabs = (props: AccessibleTabsProps) => {
       return child;
     }
 
-    return <TabPanel child={child} selectedIndex={selected} />;
+    return <TabPanel child={child} />;
   });
 
   return (
@@ -170,33 +174,40 @@ const Tabs = (props: AccessibleTabsProps) => {
           descendants={tabPanelDescendants}
           dispatch={tabPanelDispatch}
         >
-          <div {...rest} className={className} data-lgid={dataLgId}>
-            <div className={tabContainerStyle} id={id}>
-              <div
-                className={cx(
-                  getListThemeStyles(theme),
-                  tabListElementClassName,
-                )}
-                data-lgid={LGIDS_TABS.tabList}
-                role="tablist"
-                aria-orientation="horizontal"
-                {...accessibilityProps}
-              >
-                {renderedTabs}
-              </div>
-              <div className={inlineChildrenContainerStyle}>
-                <div className={inlineChildrenWrapperStyle}>
-                  {inlineChildren}
+          <TabsContext.Provider
+            value={{
+              forceRenderAllTabPanels,
+              selectedIndex: selected,
+            }}
+          >
+            <div {...rest} className={className} data-lgid={dataLgId}>
+              <div className={tabContainerStyle} id={id}>
+                <div
+                  className={cx(
+                    getListThemeStyles(theme),
+                    tabListElementClassName,
+                  )}
+                  data-lgid={LGIDS_TABS.tabList}
+                  role="tablist"
+                  aria-orientation="horizontal"
+                  {...accessibilityProps}
+                >
+                  {renderedTabs}
+                </div>
+                <div className={inlineChildrenContainerStyle}>
+                  <div className={inlineChildrenWrapperStyle}>
+                    {inlineChildren}
+                  </div>
                 </div>
               </div>
+              <div
+                className={tabPanelsElementClassName}
+                data-lgid={LGIDS_TABS.tabPanels}
+              >
+                {renderedTabPanels}
+              </div>
             </div>
-            <div
-              className={tabPanelsElementClassName}
-              data-lgid={LGIDS_TABS.tabPanels}
-            >
-              {renderedTabPanels}
-            </div>
-          </div>
+          </TabsContext.Provider>
         </DescendantsProvider>
       </DescendantsProvider>
     </LeafyGreenProvider>

--- a/packages/tabs/src/Tabs/Tabs.types.ts
+++ b/packages/tabs/src/Tabs/Tabs.types.ts
@@ -1,42 +1,16 @@
-import { Either, HTMLElementProps, LgIdProps } from '@leafygreen-ui/lib';
+import {
+  DarkModeProps,
+  Either,
+  HTMLElementProps,
+  LgIdProps,
+} from '@leafygreen-ui/lib';
 import { PolymorphicAs } from '@leafygreen-ui/polymorphic';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
 
-export interface TabsProps extends HTMLElementProps<'div'>, LgIdProps {
-  /**
-   * Content that will appear inside of Tabs component.
-   * Should be comprised of at least two `<Tab />` components.
-   */
-  children: React.ReactNode;
-
-  /**
-   * Content that will appear inline after the `<Tab />` components. `inlineChildren` are wrapped in a flexbox container.
-   */
-  inlineChildren?: React.ReactNode;
-
-  /**
-   * Callback to be executed when Tab is selected. Receives index of activated Tab as the first argument.
-   *
-   * @type (index: number) => void
-   */
-  setSelected?: React.Dispatch<number>;
-
-  /**
-   * Index of the Tab that should appear active. If value passed to selected prop, component will be controlled by consumer.
-   */
-  selected?: number;
-
-  /**
-   * determines if component will appear for Dark Mode
-   * @default false
-   */
-  darkMode?: boolean;
-
-  /**
-   * HTML Element that wraps title in Tab List.
-   */
-  as?: PolymorphicAs;
-
+export interface TabsProps
+  extends HTMLElementProps<'div'>,
+    DarkModeProps,
+    LgIdProps {
   /**
    * Accessible label that describes the set of tabs
    */
@@ -48,9 +22,46 @@ export interface TabsProps extends HTMLElementProps<'div'>, LgIdProps {
   ['aria-labelledby']?: string;
 
   /**
+   * HTML Element that wraps title in Tab List.
+   */
+  as?: PolymorphicAs;
+
+  /**
    * The base font size of the title and text rendered in children.
    */
   baseFontSize?: BaseFontSize;
+
+  /**
+   * Content that will appear inside of Tabs component.
+   * Should be comprised of at least two `<Tab />` components.
+   */
+  children: React.ReactNode;
+
+  /**
+   * When set to true, all tab panels will forcibly render in DOM.
+   * Tab panels that are not selected will be hidden with `display: none;`
+   * This will not apply for disabled tabs
+   *
+   * @default false
+   */
+  forceRenderAllTabPanels?: boolean;
+
+  /**
+   * Content that will appear inline after the `<Tab />` components. `inlineChildren` are wrapped in a flexbox container.
+   */
+  inlineChildren?: React.ReactNode;
+
+  /**
+   * Index of the Tab that should appear active. If value passed to selected prop, component will be controlled by consumer.
+   */
+  selected?: number;
+
+  /**
+   * Callback to be executed when Tab is selected. Receives index of activated Tab as the first argument.
+   *
+   * @type (index: number) => void
+   */
+  setSelected?: React.Dispatch<number>;
 }
 
 type AriaLabels = 'aria-label' | 'aria-labelledby';

--- a/packages/tabs/src/context/TabsContext.ts
+++ b/packages/tabs/src/context/TabsContext.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export interface TabsContextProps {
+  forceRenderAllTabPanels: boolean;
+  selectedIndex: number;
+}
+
+export const TabsContext = createContext<TabsContextProps>({
+  forceRenderAllTabPanels: false,
+  selectedIndex: 0,
+});
+
+export const useTabsContext = () => {
+  return useContext(TabsContext);
+};

--- a/packages/tabs/src/context/index.ts
+++ b/packages/tabs/src/context/index.ts
@@ -6,3 +6,4 @@ export {
   TabPanelDescendantsContext,
   useTabPanelDescendantsContext,
 } from './TabPanelDescendantsContext';
+export { TabsContext, TabsContextProps, useTabsContext } from './TabsContext';

--- a/packages/tabs/src/utils/getTestUtils/getTestUtils.spec.tsx
+++ b/packages/tabs/src/utils/getTestUtils/getTestUtils.spec.tsx
@@ -120,6 +120,16 @@ describe('packages/tabs/getTestUtils', () => {
       });
     });
 
+    describe('getAllTabPanelsInDOM', () => {
+      test('returns all tab panels in DOM', () => {
+        renderTabs();
+        const { getAllTabPanelsInDOM } = getTestUtils();
+        const allTabPanels = getAllTabPanelsInDOM();
+
+        expect(allTabPanels).toHaveLength(1);
+      });
+    });
+
     describe('getSelectedPanel', () => {
       test('is in the document', () => {
         renderTabs();

--- a/packages/tabs/src/utils/getTestUtils/getTestUtils.ts
+++ b/packages/tabs/src/utils/getTestUtils/getTestUtils.ts
@@ -15,7 +15,6 @@ export const getTestUtils = (
 
   /**
    * Queries the `element` for the tab list element. Will throw if no element is found.
-   *
    * Then, finds and returns all elements with role=tab. Will throw if no tabs are found.
    */
   const getAllTabsInTabList = (): Array<HTMLElement> => {
@@ -56,18 +55,50 @@ export const getTestUtils = (
   };
 
   /**
-   * Queries the `element` for the selected panel. Returns null if selected panel is not found.
+   * Queries the `element` for the tab panels element. Will throw if no element is found.
+   * Then, finds and returns all elements with role=tabpanel. Will throw if no tab panels are found.
+   */
+  const getAllTabPanelsInDOM = () => {
+    const tabPanels = queryBySelector<HTMLElement>(
+      element,
+      `[data-lgid=${LGIDS_TABS.tabPanels}]`,
+    );
+
+    if (!tabPanels) {
+      throw new Error('Unable to find tab panels container');
+    }
+
+    const allTabPanels =
+      tabPanels.querySelectorAll<HTMLElement>('[role="tabpanel"]');
+
+    if (allTabPanels.length === 0) {
+      throw new Error(
+        'Unable to find any tabpanel elements in tab panels container',
+      );
+    }
+
+    return Array.from(allTabPanels);
+  };
+
+  /**
+   * Gets all tab panels and filters for the displayed tab panel. Returns null if selected panel is not found.
    */
   const getSelectedPanel = () => {
-    return queryBySelector<HTMLElement>(
-      element,
-      '[role="tabpanel"]:not(:empty)',
+    const allTabPanels = getAllTabPanelsInDOM();
+
+    const visibleTabPanel = allTabPanels.find(
+      tabPanel => getComputedStyle(tabPanel).display !== 'none',
     );
+
+    if (!visibleTabPanel) return null;
+
+    return visibleTabPanel;
   };
 
   return {
     getAllTabsInTabList: () => getAllTabsInTabList(),
     getTabUtilsByName: (name: string) => getTabUtilsByName(name),
+    getAllTabPanelsInDOM: () => getAllTabPanelsInDOM(),
     getSelectedPanel: () => getSelectedPanel(),
   };
 };

--- a/packages/tabs/src/utils/getTestUtils/getTestUtils.types.ts
+++ b/packages/tabs/src/utils/getTestUtils/getTestUtils.types.ts
@@ -27,6 +27,11 @@ export interface TestUtilsReturnType {
   getTabUtilsByName: (name: string) => TabUtils | null;
 
   /**
+   * Returns an array of tab panels in the tab panels container.
+   */
+  getAllTabPanelsInDOM: () => Array<HTMLElement>;
+
+  /**
    * Returns selected tab panel or null if a selected tab panel is not found
    */
   getSelectedPanel: () => HTMLElement | null;


### PR DESCRIPTION
## ✍️ Proposed changes

`Tabs` changes
- adds `forceRenderAllTabPanels` prop with default value of `false` to `Tabs` component

`Tab` changes
- adds private `_shouldRender` prop to `Tab` component
  - in `Tab`, conditionally renders entire `tabpanel` instead of `children`
  - `_shouldRender` is true if:
    - tab is not disabled, and
    - either `forceRenderAllTabPanels` is propagated to children or tab is selected. if the former, tab is hidden with css

Test utils changes
- adds `getAllTabPanelsInDOM test util
- updates how `getSelectedPanel` queries for selected tab panel

Will make final changeset after all tabs changes are merged to integration branch

🎟 _Jira ticket:_ [LG-4147](https://jira.mongodb.org/browse/LG-4147)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
