### PR TITLE
Hybrid Menu theme

### DIFF
--- a/.changeset/wicked-zebras-check.md
+++ b/.changeset/wicked-zebras-check.md
@@ -1,0 +1,7 @@
+---
+'@leafygreen-ui/menu': minor
+---
+
+- Adds `renderDarkMenu` prop to define whether a menu in Light mode should be dark (default) or light
+
+- Updates menu & menu-item styling to handle light, dark, and hybrid (dark-in-light mode) themes

--- a/packages/menu/src/Menu.stories.tsx
+++ b/packages/menu/src/Menu.stories.tsx
@@ -212,29 +212,6 @@ export const Controlled = {
   },
 } satisfies StoryObj<typeof Menu>;
 
-export const Controlled = {
-  render: () => {
-    const [open, setOpen] = useState(true);
-
-    return (
-      <Menu
-        open={open}
-        setOpen={setOpen}
-        trigger={<Button rightGlyph={<CaretDown />}>Menu</Button>}
-      >
-        <MenuItem>Lorem</MenuItem>
-        <MenuItem>Ipsum</MenuItem>
-        <MenuItem>Adipiscing</MenuItem>
-      </Menu>
-    );
-  },
-  parameters: {
-    chromatic: {
-      disableSnapshot: true,
-    },
-  },
-} satisfies StoryObj<typeof Menu>;
-
 export const Generated = {
   render: () => <></>,
   args: {

--- a/packages/menu/src/Menu/Menu.styles.ts
+++ b/packages/menu/src/Menu/Menu.styles.ts
@@ -2,11 +2,16 @@ import { transparentize } from 'polished';
 
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
-import { spacing } from '@leafygreen-ui/tokens';
+import { color, spacing } from '@leafygreen-ui/tokens';
 
 import { MenuTheme } from '../types';
 
-import { menuBackgroundColors } from './utils/useMenuTheme';
+export const menuBackgroundColors = {
+  [MenuTheme.Light]: color.light.background.primary.default,
+  [MenuTheme.Dark]: palette.gray.dark3,
+  /** The color of a dark menu in light mode */
+  [MenuTheme.Hybrid]: color.dark.background.primary.default,
+};
 
 interface MenuStyleArgs {
   theme: MenuTheme;

--- a/packages/menu/src/Menu/Menu.styles.ts
+++ b/packages/menu/src/Menu/Menu.styles.ts
@@ -1,24 +1,34 @@
+import { transparentize } from 'polished';
+
 import { css } from '@leafygreen-ui/emotion';
-import { Theme } from '@leafygreen-ui/lib';
 import { palette } from '@leafygreen-ui/palette';
+import { spacing } from '@leafygreen-ui/tokens';
 
-export const rootMenuStyle = css`
+import { MenuTheme } from '../types';
+
+import { menuBackgroundColors } from './utils/useMenuTheme';
+
+interface MenuStyleArgs {
+  theme: MenuTheme;
+}
+
+export const getMenuStyles = ({ theme }: MenuStyleArgs) => css`
   width: 210px;
-  border-radius: 12px;
+  border-radius: ${spacing[300]}px;
   overflow: auto;
-  padding: 14px 0;
-`;
+  padding: 14px 0; // TODO: spacing
+  border: 1px solid;
 
-export const rootMenuThemeStyles: Record<Theme, string> = {
-  [Theme.Light]: css`
-    background-color: ${palette.black};
-    border: 1px solid ${palette.black};
-  `,
-  [Theme.Dark]: css`
-    background-color: ${palette.gray.dark3};
-    border: 1px solid ${palette.gray.dark2};
-  `,
-};
+  background-color: ${menuBackgroundColors[theme]};
+
+  border-color: ${theme === MenuTheme.Light
+    ? 'transparent'
+    : palette.gray.dark2};
+
+  box-shadow: ${theme === MenuTheme.Light
+    ? '0px 2px 4px 1px ' + transparentize(0.85, palette.black)
+    : 'none'};
+`;
 
 export const scrollContainerStyle = css`
   overflow: auto;

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -7,7 +7,6 @@ import {
 } from '@leafygreen-ui/descendants';
 import { css, cx } from '@leafygreen-ui/emotion';
 import { useBackdropClick, useEventListener } from '@leafygreen-ui/hooks';
-import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { isDefined, keyMap } from '@leafygreen-ui/lib';
 import Popover, { Align, Justify } from '@leafygreen-ui/popover';
 
@@ -17,12 +16,9 @@ import {
 } from '../MenuContext/MenuContext';
 
 import { useMenuHeight } from './utils/useMenuHeight';
+import { useMenuTheme } from './utils/useMenuTheme';
 import { useHighlightReducer } from './HighlightReducer';
-import {
-  rootMenuStyle,
-  rootMenuThemeStyles,
-  scrollContainerStyle,
-} from './Menu.styles';
+import { getMenuStyles, scrollContainerStyle } from './Menu.styles';
 import { MenuProps } from './Menu.types';
 
 /**
@@ -69,8 +65,10 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   }: MenuProps,
   forwardRef,
 ) {
-  const renderDarkMode = renderDarkMenu || darkModeProp;
-  const { theme, darkMode } = useDarkMode(renderDarkMode);
+  const { theme, darkMode } = useMenuTheme({
+    darkModeProp,
+    renderDarkMenu,
+  });
 
   const popoverRef = useRef<HTMLUListElement | null>(null);
   const triggerRef = useRef<HTMLElement>(null);
@@ -188,8 +186,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
         >
           <div
             className={cx(
-              rootMenuStyle,
-              rootMenuThemeStyles[theme],
+              getMenuStyles({ theme }),
               css`
                 max-height: ${maxMenuHeightValue};
               `,

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -52,7 +52,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
     open: controlledOpen,
     setOpen: controlledSetOpen,
     darkMode: darkModeProp,
-    renderDarkMenu,
+    renderDarkMenu = true,
     children,
     className,
     refEl,

--- a/packages/menu/src/Menu/utils/useMenuTheme.ts
+++ b/packages/menu/src/Menu/utils/useMenuTheme.ts
@@ -1,15 +1,7 @@
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { Theme } from '@leafygreen-ui/lib';
-import { color } from '@leafygreen-ui/tokens';
 
 import { MenuTheme } from '../../types';
-
-export const menuBackgroundColors = {
-  [MenuTheme.Light]: color.light.background.primary.default,
-  [MenuTheme.Dark]: color.dark.background.secondary.default,
-  /** The color of a dark menu in light mode */
-  [MenuTheme.Hybrid]: color.dark.background.primary.default,
-};
 
 /**
  * Computes the hybrid theme to support dark-in-light-mode menus

--- a/packages/menu/src/Menu/utils/useMenuTheme.ts
+++ b/packages/menu/src/Menu/utils/useMenuTheme.ts
@@ -1,0 +1,38 @@
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+import { Theme } from '@leafygreen-ui/lib';
+import { color } from '@leafygreen-ui/tokens';
+
+import { MenuTheme } from '../../types';
+
+export const menuBackgroundColors = {
+  [MenuTheme.Light]: color.light.background.primary.default,
+  [MenuTheme.Dark]: color.dark.background.secondary.default,
+  /** The color of a dark menu in light mode */
+  [MenuTheme.Hybrid]: color.dark.background.primary.default,
+};
+
+/**
+ * Computes the hybrid theme to support dark-in-light-mode menus
+ */
+export const useMenuTheme = ({
+  darkModeProp,
+  renderDarkMenu,
+}: {
+  darkModeProp?: boolean;
+  renderDarkMenu?: boolean;
+}) => {
+  const { theme: baseTheme } = useDarkMode(darkModeProp);
+
+  const theme: MenuTheme = renderDarkMenu
+    ? baseTheme === Theme.Light
+      ? MenuTheme.Hybrid
+      : MenuTheme.Dark
+    : (baseTheme as MenuTheme);
+
+  const darkMode = theme !== MenuTheme.Light; //
+
+  return { theme, darkMode };
+};
+
+export const getBaseTheme = (menuTheme: MenuTheme): Theme =>
+  menuTheme === MenuTheme.Hybrid ? Theme.Dark : menuTheme;

--- a/packages/menu/src/MenuContext/MenuContext.types.ts
+++ b/packages/menu/src/MenuContext/MenuContext.types.ts
@@ -1,7 +1,7 @@
-import { Theme } from '@leafygreen-ui/lib';
+import { MenuTheme } from '../types';
 
 export interface MenuContextData {
-  theme: Theme;
+  theme: MenuTheme;
   darkMode: boolean;
   highlightIndex?: number;
 }

--- a/packages/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/menu/src/MenuItem/MenuItem.styles.ts
@@ -7,7 +7,8 @@ import { Theme } from '@leafygreen-ui/lib';
 import { palette } from '@leafygreen-ui/palette';
 import { color, spacing, Type as ElementType } from '@leafygreen-ui/tokens';
 
-import { Size } from '../types';
+import { getBaseTheme, menuBackgroundColors } from '../Menu/utils/useMenuTheme';
+import { MenuTheme, Size } from '../types';
 
 import { Variant } from './MenuItem.types';
 
@@ -34,10 +35,11 @@ const activeColors = {
 } as const satisfies Record<Theme, Record<ElementType, string>>;
 
 interface MenuItemStyleArgs {
-  theme: Theme;
+  theme: MenuTheme;
   size: Size;
   variant: Variant;
   active: boolean;
+  highlighted: boolean;
 }
 
 export const getMenuItemStyles = ({
@@ -45,28 +47,35 @@ export const getMenuItemStyles = ({
   size,
   active,
   variant,
+  highlighted,
 }: MenuItemStyleArgs) => css`
   width: 100%;
   min-height: ${size === Size.Large ? spacing[1200] : spacing[800]}px;
   padding-block: ${spacing[50]}px;
 
+  // Override the default input option colors
+  ${!highlighted &&
+  css`
+    background-color: ${menuBackgroundColors[theme]};
+  `}
+
   ${active &&
   css`
     &,
     &:hover {
-      background-color: ${activeColors[theme].background};
+      background-color: ${activeColors[getBaseTheme(theme)].background};
 
       &:before {
         transform: scaleY(1) translateY(-50%);
-        background-color: ${activeColors[theme].border};
+        background-color: ${activeColors[getBaseTheme(theme)].border};
       }
 
       .${titleClassName} {
-        color: ${activeColors[theme].text};
+        color: ${activeColors[getBaseTheme(theme)].text};
         font-weight: bold;
       }
       .${leftGlyphClassName} {
-        color: ${activeColors[theme].icon};
+        color: ${activeColors[getBaseTheme(theme)].icon};
       }
     }
   `}
@@ -74,19 +83,19 @@ export const getMenuItemStyles = ({
   ${variant === Variant.Destructive &&
   css`
     .${titleClassName} {
-      color: ${color[theme].text.error.default};
+      color: ${color[getBaseTheme(theme)].text.error.default};
     }
     .${leftGlyphClassName} {
-      color: ${color[theme].icon.error.default};
+      color: ${color[getBaseTheme(theme)].icon.error.default};
     }
 
     &:hover {
-      background-color: ${color[theme].background.error.hover};
+      background-color: ${color[getBaseTheme(theme)].background.error.hover};
       .${titleClassName} {
-        color: ${color[theme].text.error.hover};
+        color: ${color[getBaseTheme(theme)].text.error.hover};
       }
       .${leftGlyphClassName} {
-        color: ${color[theme].icon.error.hover};
+        color: ${color[getBaseTheme(theme)].icon.error.hover};
       }
     }
   `}

--- a/packages/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/menu/src/MenuItem/MenuItem.styles.ts
@@ -7,7 +7,8 @@ import { Theme } from '@leafygreen-ui/lib';
 import { palette } from '@leafygreen-ui/palette';
 import { color, spacing, Type as ElementType } from '@leafygreen-ui/tokens';
 
-import { getBaseTheme, menuBackgroundColors } from '../Menu/utils/useMenuTheme';
+import { menuBackgroundColors } from '../Menu/Menu.styles';
+import { getBaseTheme } from '../Menu/utils/useMenuTheme';
 import { MenuTheme, Size } from '../types';
 
 import { Variant } from './MenuItem.types';

--- a/packages/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/menu/src/MenuItem/MenuItem.styles.ts
@@ -112,16 +112,3 @@ export const getMenuItemContentStyles = ({
     padding-inline-start: ${spacing[300]}px;
   `}
 `;
-
-export const menuItemContainerStyles = css`
-  list-style: none;
-`;
-
-export const disabledIconStyle: Record<Theme, string> = {
-  [Theme.Light]: css`
-    color: ${palette.gray.dark2};
-  `,
-  [Theme.Dark]: css`
-    color: ${palette.gray.dark1};
-  `,
-};

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -74,6 +74,7 @@ export const MenuItem = InferredPolymorphic<MenuItemProps, 'button'>(
             size,
             active,
             variant,
+            highlighted: isHighlighted,
           })}
         >
           <InputOptionContent

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -1,3 +1,5 @@
+import { Theme } from '@leafygreen-ui/lib';
+
 export const Size = {
   Default: 'default',
   Large: 'large',
@@ -8,3 +10,10 @@ export type Size = (typeof Size)[keyof typeof Size];
 export type ElementOf<
   T extends React.ComponentType<React.PropsWithChildren<unknown>>,
 > = React.ReactComponentElement<T, React.ComponentPropsWithRef<T>>;
+
+/** Extension of {@link Theme} to support dark-in-light-mode menus */
+export const MenuTheme = {
+  ...Theme,
+  Hybrid: 'hybrid',
+} as const;
+export type MenuTheme = (typeof MenuTheme)[keyof typeof MenuTheme];


### PR DESCRIPTION
Depends on: https://github.com/mongodb/leafygreen-ui/pull/2369

## ✍️ Proposed changes

- Adds `renderDarkMenu` prop to define whether a menu in Light mode should be dark (default) or light
- Updates menu & menu-item styling to handle light, dark, and hybrid (dark-in-light mode) themes