### PR TITLE
Creates `waitForTransition` test utility

### DIFF
--- a/.changeset/strange-hounds-change.md
+++ b/.changeset/strange-hounds-change.md
@@ -1,0 +1,7 @@
+---
+'@leafygreen-ui/testing-lib': minor
+---
+
+Creates a `waitForTransition` test utility. Fires the `transitionend` event on a given element to ensure event handlers are called after CSS transitions complete. 
+
+This is useful for testing `onEntered` or `onExited` callbacks on `Transition` or `Popover` elements.

--- a/packages/testing-lib/package.json
+++ b/packages/testing-lib/package.json
@@ -17,7 +17,9 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@lg-tools/build": "0.5.1"
+    "@lg-tools/build": "0.5.1",
+    "@types/react-transition-group": "^4.4.5",
+    "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
     "@testing-library/react": "^12.0.0 || ^13.1.0 || ^14.0.0"

--- a/packages/testing-lib/package.json
+++ b/packages/testing-lib/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@leafygreen-ui/emotion": "^4.0.8",
     "@lg-tools/build": "0.5.1",
     "@types/react-transition-group": "^4.4.5",
     "react-transition-group": "^4.4.5"

--- a/packages/testing-lib/package.json
+++ b/packages/testing-lib/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@leafygreen-ui/emotion": "^4.0.8",
+    "@emotion/react": "^11.11.4",
     "@lg-tools/build": "0.5.1",
     "@types/react-transition-group": "^4.4.5",
     "react-transition-group": "^4.4.5"

--- a/packages/testing-lib/src/index.ts
+++ b/packages/testing-lib/src/index.ts
@@ -3,6 +3,7 @@ import * as jest from './jest';
 import * as JestDOM from './jest-dom';
 export { act, renderHook } from './RTLOverrides';
 export { waitForState } from './waitForState';
+export { waitForTransition } from './waitForTransition';
 
 export { Context, jest, JestDOM };
 

--- a/packages/testing-lib/src/waitForTransition/index.ts
+++ b/packages/testing-lib/src/waitForTransition/index.ts
@@ -1,0 +1,1 @@
+export { waitForTransition } from './waitForTransition';

--- a/packages/testing-lib/src/waitForTransition/waitForTransition.spec.tsx
+++ b/packages/testing-lib/src/waitForTransition/waitForTransition.spec.tsx
@@ -1,0 +1,117 @@
+import React, { createRef } from 'react';
+import { Transition } from 'react-transition-group';
+import { render, waitFor } from '@testing-library/react';
+
+import { css } from '@leafygreen-ui/emotion';
+
+import { waitForTransition } from '.';
+
+const ref = createRef<HTMLElement>();
+
+const callbacks = {
+  onEnter: jest.fn(),
+  onEntered: jest.fn(),
+  onEntering: jest.fn(),
+  onExit: jest.fn(),
+  onExited: jest.fn(),
+  onExiting: jest.fn(),
+};
+
+const renderTransitionElement = (in0: boolean) => {
+  const result = render(
+    <Transition
+      nodeRef={ref}
+      in={in0}
+      timeout={0}
+      onEntered={callbacks.onEntered}
+      onExited={callbacks.onExited}
+    >
+      {state => (
+        <div
+          data-testid="test-div"
+          className={css`
+            opacity: ${state === 'entered' ? 1 : 0};
+          `}
+        >
+          {state}
+        </div>
+      )}
+    </Transition>,
+  );
+
+  const rerender = (in1: boolean) =>
+    result.rerender(
+      <Transition
+        nodeRef={ref}
+        in={in1}
+        timeout={0}
+        onEntered={callbacks.onEntered}
+        onExited={callbacks.onExited}
+      >
+        {state => (
+          <div
+            data-testid="test-div"
+            className={css`
+              opacity: ${state === 'entered' ? 1 : 0};
+            `}
+          >
+            {state}
+          </div>
+        )}
+      </Transition>,
+    );
+
+  return {
+    ...result,
+    rerender,
+  };
+};
+
+describe('packages/testing-lib/waitForTransition', () => {
+  afterEach(() => {
+    Object.values(callbacks).forEach(cb => cb.mockReset());
+  });
+
+  describe('triggers react-transition-group handlers', () => {
+    test('onEntered', async () => {
+      const renderResult = renderTransitionElement(false);
+      const testDiv = await renderResult.findByTestId('test-div');
+
+      /** ENTER */
+      renderResult.rerender(true);
+
+      // onEnter will be called immediately
+      await waitFor(() => {
+        // onEntering will be called after a timeout
+        // but onEntered is not called until CSS transitions are finished
+        expect(callbacks.onEntered).not.toHaveBeenCalled();
+      });
+
+      await waitForTransition(testDiv);
+
+      // onEntered is finally called after we wait for the transition
+      expect(callbacks.onEntered).toHaveBeenCalledTimes(1);
+    });
+
+    test('onExited', async () => {
+      const renderResult = renderTransitionElement(false);
+      const testDiv = await renderResult.findByTestId('test-div');
+
+      await waitFor(() => /** ENTER */ renderResult.rerender(true));
+
+      /** EXIT */
+      renderResult.rerender(false);
+
+      // onExit will be called immediately
+      await waitFor(() => {
+        // onExiting will be called after a timeout
+        // but onExited is not called until CSS transitions are finished
+        expect(callbacks.onExited).not.toHaveBeenCalled();
+      });
+
+      await waitForTransition(testDiv);
+      // onEntered is finally called after we wait for the transition
+      expect(callbacks.onExited).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/testing-lib/src/waitForTransition/waitForTransition.spec.tsx
+++ b/packages/testing-lib/src/waitForTransition/waitForTransition.spec.tsx
@@ -1,8 +1,7 @@
 import React, { createRef } from 'react';
 import { Transition } from 'react-transition-group';
+import { css } from '@emotion/react';
 import { render, waitFor } from '@testing-library/react';
-
-import { css } from '@leafygreen-ui/emotion';
 
 import { waitForTransition } from '.';
 

--- a/packages/testing-lib/src/waitForTransition/waitForTransition.ts
+++ b/packages/testing-lib/src/waitForTransition/waitForTransition.ts
@@ -1,0 +1,21 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+
+import { act } from '../RTLOverrides';
+
+/**
+ * Fires the `transitionEnd` event on the provided element,
+ * triggering any event handlers attached to this CSS transition events.
+ *
+ * Ensures `onEnter`,`onEntering`,`onEntered`, `onExit`, `onExiting` and `onExited` handlers are fired when
+ * using `react-transition-group`
+ */
+export async function waitForTransition(
+  element?: HTMLElement | Parameters<typeof fireEvent.transitionEnd>[0],
+  options?: Parameters<typeof fireEvent.transitionEnd>[1],
+) {
+  if (element) {
+    await waitFor(() => {
+      act(() => fireEvent.transitionEnd(element, options));
+    });
+  }
+}

--- a/packages/testing-lib/src/waitForTransition/waitForTransition.ts
+++ b/packages/testing-lib/src/waitForTransition/waitForTransition.ts
@@ -6,7 +6,7 @@ import { act } from '../RTLOverrides';
  * Fires the `transitionEnd` event on the provided element,
  * triggering any event handlers attached to this CSS transition events.
  *
- * Ensures `onEnter`,`onEntering`,`onEntered`, `onExit`, `onExiting` and `onExited` handlers are fired when
+ * Ensures `onEntered`, `onExited` handlers are fired when
  * using `react-transition-group`
  */
 export async function waitForTransition(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3123,10 +3123,35 @@
     "@emotion/weak-memoize" "^0.3.1"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/react@^11.11.4":
+  version "11.11.4"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.4.tgz#3a829cac25c1f00e126408fab7f891f00ecc3c1d"
+  integrity sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.11.0"
+    "@emotion/cache" "^11.11.0"
+    "@emotion/serialize" "^1.1.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/serialize@^1.0.3", "@emotion/serialize@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.2.tgz#017a6e4c9b8a803bd576ff3d52a0ea6fa5a62b51"
   integrity sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==
+  dependencies:
+    "@emotion/hash" "^0.9.1"
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/unitless" "^0.8.1"
+    "@emotion/utils" "^1.2.1"
+    csstype "^3.0.2"
+
+"@emotion/serialize@^1.1.3":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.4.tgz#fc8f6d80c492cfa08801d544a05331d1cc7cd451"
+  integrity sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==
   dependencies:
     "@emotion/hash" "^0.9.1"
     "@emotion/memoize" "^0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7511,9 +7511,9 @@ camelcase@^7.0.0:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001585, caniuse-lite@^1.0.30001587:
-  version "1.0.30001625"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz#ead1b155ea691d6a87938754d3cb119c24465b03"
-  integrity sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==
+  version "1.0.30001628"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001628.tgz#90b6cd85ddc2e9f831de0225f4ca5a130c8d8222"
+  integrity sha512-S3BnR4Kh26TBxbi5t5kpbcUlLJb9lhtDXISDPwOfI+JoC+ik0QksvkZtUVyikw3hjnkgkMPSJ8oIM9yMm9vflA==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## ✍️ Proposed changes

Creates a `waitForTransition` test utility. Fires the `transitionend` event on a given element to ensure event handlers are called after CSS transitions complete. 

This is useful for testing `onEntered` or `onExited` callbacks on `Transition` or `Popover` elements.