### PR TITLE
LG-4325: Exposes `onCopy` callback so that consuming applications can respond to clipboard events

### DIFF
--- a/.changeset/honest-buses-explode.md
+++ b/.changeset/honest-buses-explode.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/copyable': minor
+---
+
+Exposes `onCopy` callback so that consuming applications can respond to successful clipboard events

--- a/packages/copyable/src/Copyable.stories.tsx
+++ b/packages/copyable/src/Copyable.stories.tsx
@@ -49,7 +49,7 @@ export default meta;
 
 export const LiveExample: StoryType<typeof Copyable> = args => (
   <div>
-    <Copyable {...args} />
+    <Copyable {...args} onCopy={e => console.log(e)} />
   </div>
 );
 

--- a/packages/copyable/src/Copyable.stories.tsx
+++ b/packages/copyable/src/Copyable.stories.tsx
@@ -49,7 +49,7 @@ export default meta;
 
 export const LiveExample: StoryType<typeof Copyable> = args => (
   <div>
-    <Copyable {...args} onCopy={e => console.log(e)} />
+    <Copyable {...args} />
   </div>
 );
 

--- a/packages/copyable/src/Copyable/Copyable.tsx
+++ b/packages/copyable/src/Copyable/Copyable.tsx
@@ -38,14 +38,15 @@ import {
 import { CopyableProps, Size } from './Copyable.types';
 
 export default function Copyable({
-  darkMode: darkModeProp,
   children,
-  label,
-  description,
   className,
   copyable = true,
-  size: SizeProp,
+  darkMode: darkModeProp,
+  description,
+  label,
+  onCopy,
   shouldTooltipUsePortal = true,
+  size: SizeProp,
 }: CopyableProps) {
   const { theme, darkMode } = useDarkMode(darkModeProp);
   const [copied, setCopied] = useState(false);
@@ -83,6 +84,10 @@ export default function Copyable({
     const clipboard = new ClipboardJS(buttonRef, {
       text: () => children,
       container: portalContainer,
+    });
+
+    clipboard.on('success', (event: React.ClipboardEvent<HTMLDivElement>) => {
+      onCopy?.(event);
     });
 
     if (copied) {
@@ -165,7 +170,9 @@ export default function Copyable({
                   variant="default"
                   darkMode={darkMode}
                   className={buttonStyle}
-                  onClick={() => setCopied(true)}
+                  onClick={() => {
+                    setCopied(true);
+                  }}
                   leftGlyph={<CopyIcon size="large" className={iconStyle} />}
                 >
                   Copy

--- a/packages/copyable/src/Copyable/Copyable.tsx
+++ b/packages/copyable/src/Copyable/Copyable.tsx
@@ -90,6 +90,10 @@ export default function Copyable({
       onCopy?.(event);
     });
 
+    clipboard.on('error', (event: React.ClipboardEvent<HTMLDivElement>) => {
+      onCopy?.(event);
+    });
+
     if (copied) {
       const timeoutId = setTimeout(() => {
         setCopied(false);


### PR DESCRIPTION
## ✍️ Proposed changes

LG-4325: Exposes `onCopy` callback so that consuming applications can respond to successful clipboard events

🎟 _Jira ticket:_ [LG-4325](https://jira.mongodb.org/browse/[LG-4325)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
