### PR TITLE
 Polymorphic patches

### DIFF
--- a/.changeset/five-donkeys-fix.md
+++ b/.changeset/five-donkeys-fix.md
@@ -1,0 +1,7 @@
+---
+'@leafygreen-ui/polymorphic': patch
+---
+
+- `PolymorphicRef` extends `null`
+- `PolymorphicProps` extends `ComponentPropsWithRef`
+- Adds type specs for refs and event handlers

--- a/packages/polymorphic/src/InferredPolymorphic/InferredPolymorphic.types.spec.tsx
+++ b/packages/polymorphic/src/InferredPolymorphic/InferredPolymorphic.types.spec.tsx
@@ -5,15 +5,18 @@
  * and expect them to satisfy the type constraints
  *
  */
-/* eslint-disable @typescript-eslint/no-unused-vars, jest/no-disabled-tests */
+/* eslint-disable @typescript-eslint/no-unused-vars, jest/no-disabled-tests, padding-line-between-statements */
 
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import NextLink from 'next/link';
 
-import { PolymorphicAs } from '../Polymorphic/Polymorphic.types';
+import {
+  PolymorphicAs,
+  PolymorphicRef,
+} from '../Polymorphic/Polymorphic.types';
 import { NodeUrlLike } from '../utils/Polymorphic.utils';
 
-import { useInferredPolymorphicProps } from './hooks';
+import { useInferredPolymorphic, useInferredPolymorphicProps } from './hooks';
 import { InferredPolymorphic } from './InferredPolymorphic';
 import {
   AnchorLike,
@@ -536,6 +539,117 @@ describe.skip('Inferred Polymorphic types', () => {
       const { as, href } = useInferredPolymorphicProps(randAs, {});
       <MyInferredPoly as={as} href={href} />;
     }
+
+    // With Refs & Handlers
+    {
+      // undefined
+      const btnRef = React.createRef<HTMLButtonElement>();
+      const anchorRef = React.createRef<HTMLAnchorElement>();
+      const htmlElementRef = React.createRef<HTMLElement>();
+      const anyRef = React.createRef<any>();
+      const unknownRef = React.createRef();
+      const onBtnClick: MouseEventHandler<HTMLButtonElement> = () => {};
+      const onAnchorClick: MouseEventHandler<HTMLAnchorElement> = () => {};
+      const onElementClick: MouseEventHandler<HTMLElement> = () => {};
+      const onAnyClick: MouseEventHandler = () => {};
+
+      {
+        <MyInferredPoly ref={btnRef} />;
+        <MyInferredPoly onClick={onBtnClick} />;
+        <MyInferredPoly href="" onClick={onAnchorClick} />;
+        // @ts-expect-error - when passing a ref, `as` must be explicit
+        <MyInferredPoly href="" ref={anchorRef} />;
+        // @ts-expect-error
+        <MyInferredPoly ref={anchorRef} />;
+        // when passing a ref, `as` must be explicit
+        <MyInferredPoly href="" ref={btnRef} />;
+      }
+
+      // anchor
+      {
+        <MyInferredPoly as={'a'} href={'mongodb.design'} ref={anchorRef} />;
+        <MyInferredPoly
+          as={'a'}
+          href={'mongodb.design'}
+          ref={anchorRef}
+          onClick={onAnchorClick}
+        />;
+        <MyInferredPoly
+          as={'a'}
+          href={'mongodb.design'}
+          // @ts-expect-error - incorrect ref type
+          ref={React.createRef<HTMLButtonElement>()}
+        />;
+
+        <MyInferredPoly
+          as={'a'}
+          href={'mongodb.design'}
+          // @ts-expect-error - incorrect handler type
+          onClick={onBtnClick}
+        />;
+      }
+
+      // button
+      {
+        <MyInferredPoly as={'button'} ref={btnRef} />;
+        <MyInferredPoly as={'button'} onClick={onBtnClick} />;
+        <MyInferredPoly as={'button'} onClick={onBtnClick} ref={btnRef} />;
+        // @ts-expect-error - incorrect ref type
+        <MyInferredPoly as={'button'} ref={anchorRef} />;
+        // @ts-expect-error - incorrect handler type
+        <MyInferredPoly as={'button'} onClick={onAnchorClick} />;
+        // @ts-expect-error - incorrect handler type
+        <MyInferredPoly as={'button'} onClick={onAnchorClick} ref={btnRef} />;
+      }
+
+      {
+        <MyInferredPoly
+          as={TestArbitraryComponent}
+          someProp={'lorem'}
+          ref={unknownRef}
+        />;
+
+        <MyInferredPoly
+          as={TestArbitraryComponent}
+          someProp={'lorem'}
+          ref={btnRef}
+        />;
+
+        <MyInferredPoly
+          as={TestArbitraryComponent}
+          someProp={'lorem'}
+          ref={anyRef}
+        />;
+
+        <MyInferredPoly
+          as={TestArbitraryComponent}
+          someProp={'lorem'}
+          // @ts-expect-error onClick is not a prop on TestArbitraryComponent
+          onClick={onBtnClick}
+        />;
+      }
+
+      {
+        const arbAs: PolymorphicAs = getRandAs();
+        const arbRef = btnRef as PolymorphicRef<typeof arbAs>;
+
+        <MyInferredPoly as={arbAs} ref={anyRef} />;
+        <MyInferredPoly as={arbAs} ref={arbRef} />;
+        <MyInferredPoly as={arbAs} ref={arbRef} onClick={onAnyClick} />;
+
+        // @ts-expect-error - ref type can't be unknown
+        <MyInferredPoly as={arbAs} ref={unknownRef} />;
+        // @ts-expect-error - ref type can't be explicit
+        <MyInferredPoly as={arbAs} ref={btnRef} />;
+        // @ts-expect-error - `as` can be SVG, which is not extended by HTMLElement
+        <MyInferredPoly as={arbAs} ref={htmlElementRef} />;
+
+        // @ts-expect-error - handler must match as prop
+        <MyInferredPoly as={arbAs} ref={arbRef} onClick={onBtnClick} />;
+        // @ts-expect-error `as` can be SVG, which is not extended by HTMLElement
+        <MyInferredPoly as={arbAs} ref={arbRef} onClick={onElementClick} />;
+      }
+    }
   });
 
   test('InferredPolymorphic factory', () => {
@@ -544,17 +658,17 @@ describe.skip('Inferred Polymorphic types', () => {
       variant?: 'default' | 'primary';
     }
     const MyInferredPoly = InferredPolymorphic<MyProps, 'button'>(
-      ({ as: asProp, ...props }) => {
-        const { as, href, ...rest } = useInferredPolymorphicProps(
-          asProp,
-          props,
-        );
+      ({ as: asProp, ...props }, fwdRef) => {
+        const { as, rest } = useInferredPolymorphic(asProp, props);
 
+        as satisfies PolymorphicAs;
         rest.value satisfies MyProps['value'];
         rest.variant satisfies MyProps['variant'];
         rest.href satisfies string | undefined;
         rest.target satisfies string | undefined;
         rest.rel satisfies string | undefined;
+        fwdRef satisfies React.RefObject<PolymorphicAs> | null;
+        fwdRef satisfies React.RefObject<typeof as> | null;
 
         return <></>;
       },

--- a/packages/polymorphic/src/InferredPolymorphic/InferredPolymorphic.types.ts
+++ b/packages/polymorphic/src/InferredPolymorphic/InferredPolymorphic.types.ts
@@ -1,5 +1,5 @@
 import {
-  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
   ComponentType,
   ReactElement,
   WeakValidationMap,
@@ -32,14 +32,14 @@ export interface AnchorLikeProps<TAsProp extends AnchorLike | undefined> {
 export type InferredAnchorProps = {
   href: string;
   as?: 'a';
-} & ComponentPropsWithoutRef<'a'>;
+} & ComponentPropsWithRef<'a'>;
 
 /**
  * Union of {@link AnchorLikeProps} and {@link InheritedProps}
  */
 export type InheritedExplicitAnchorLikeProps<TAsProp extends AnchorLike> = {
   as?: TAsProp;
-} & Omit<PartialRequired<ComponentPropsWithoutRef<TAsProp>, 'href'>, 'as'>;
+} & Omit<PartialRequired<ComponentPropsWithRef<TAsProp>, 'href'>, 'as'>;
 
 /**
  * Extends the default component props (or intrinsic attributes)
@@ -58,7 +58,7 @@ export type InheritedComponentProps<
   TComponentProps,
 > = {
   as?: PolymorphicAs;
-} & Omit<ComponentPropsWithoutRef<TAsProp>, keyof TComponentProps | 'as'>;
+} & Omit<ComponentPropsWithRef<TAsProp>, keyof TComponentProps | 'as'>;
 
 /**
  *
@@ -104,7 +104,7 @@ export interface InferredPolymorphicRenderFunction<
   TDefaultAs extends PolymorphicAs = PolymorphicAs,
 > {
   <TAsProp extends PolymorphicAs = TDefaultAs>(
-    props: InferredPolymorphicProps<TAsProp, TComponentProps>,
+    props: InferredPolymorphicPropsWithRef<TAsProp, TComponentProps>,
     ref: PolymorphicRef<TAsProp>,
   ): ReactElement | null;
   displayName?: string;

--- a/packages/polymorphic/src/Polymorphic/Polymorphic.types.ts
+++ b/packages/polymorphic/src/Polymorphic/Polymorphic.types.ts
@@ -36,7 +36,8 @@ export interface AsProp<T extends PolymorphicAs> {
  * The type of the Ref element based on the `as` prop type
  */
 export type PolymorphicRef<T extends PolymorphicAs> =
-  ComponentPropsWithRef<T>['ref'];
+  | ComponentPropsWithRef<T>['ref']
+  | null;
 
 /**
  * Union of prop types potentially re-defined in React.ComponentProps


### PR DESCRIPTION
## ✍️ Proposed changes

- `PolymorphicRef` extends `null`
- `PolymorphicProps` extends `ComponentPropsWithRef`
- Adds type specs for refs and event handlers
