### PR TITLE
LG-4361 : Avoid most infinite render loops in ControlledToast

### DIFF
--- a/.changeset/proud-avocados-burn.md
+++ b/.changeset/proud-avocados-burn.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/toast': patch
+---
+
+Fixed the controlled Toast component to avoid most infinite render loops

--- a/packages/toast/src/ControlledToast/ControlledToast.spec.tsx
+++ b/packages/toast/src/ControlledToast/ControlledToast.spec.tsx
@@ -69,6 +69,22 @@ describe('packages/toast/controlled', () => {
       expect(toast).toBeInTheDocument();
     });
 
+    test('handles rerender when `open` is true without hanging', async () => {
+      const { findByTestId, rerender } = render(
+        <Toast open title="Test Rerender" data-testid="test-toast-rerender" />,
+        {
+          wrapper: ({ children }) => <ToastProvider>{children}</ToastProvider>,
+        },
+      );
+
+      rerender(
+        <Toast open title="Test Rerender" data-testid="test-toast-rerender" />,
+      );
+
+      const toast = await findByTestId('test-toast-rerender');
+      expect(toast).toBeInTheDocument();
+    });
+
     test('does not render when `open` is true and component is unmounted', async () => {
       const { queryByTestId } = render(
         <ToastProvider>

--- a/packages/toast/src/ControlledToast/useStableControlledToastProps.tsx
+++ b/packages/toast/src/ControlledToast/useStableControlledToastProps.tsx
@@ -1,0 +1,34 @@
+import { useCallback, useRef } from 'react';
+import isEqual from 'lodash/isEqual';
+
+import { ControlledToastProps } from './ControlledToast.types';
+
+export default function useStableControlledToastProps(
+  props: Omit<ControlledToastProps, 'open'>,
+) {
+  // onClose is the only function prop, so handle it separately here
+  // NOTE: Any functions inside props in the toast's title or description can still theoretically cause a render loop
+  // unless they use useCallback
+  const onCloseRef = useRef(props.onClose);
+  onCloseRef.current = props.onClose;
+
+  // A function that maintains a consistent identity and always calls the most recent version of the prop
+  const stableOnClose = useCallback<
+    NonNullable<ControlledToastProps['onClose']>
+  >((...args) => onCloseRef.current?.(...args), []);
+
+  const propsWithStableOnClose = {
+    ...props,
+    onClose: stableOnClose,
+  };
+
+  const lastPropsRef = useRef<Omit<ControlledToastProps, 'open'> | null>(null);
+  const lastProps = lastPropsRef.current;
+  const stableProps =
+    lastProps != null && isEqual(propsWithStableOnClose, lastProps)
+      ? lastProps
+      : propsWithStableOnClose;
+  lastPropsRef.current = stableProps;
+
+  return stableProps;
+}


### PR DESCRIPTION
## ✍️ Proposed changes

The `ControlledToast` component was using a `props` object that was newly-created on every render, and then including it in a dependencies array for a `useEffect`. The `useEffect`'s cleanup callback was calling `popToast`, which triggers a re-render, so any time a component with an open controlled toast had a second render it would trigger an infinite render loop. This change is one possible way to avoid this, using `updateToast` instead of pop and push, storing some objects in refs (with deep `isEqual` comparisons to detect updates) to avoid triggering unnecessary re-renders, and separating the "unmount" effect from the "update" one.

🎟 _Jira ticket:_ [LG-4361](https://jira.mongodb.org/browse/LG-4361)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

## 🧪 How to test changes

I added a simple unit test that would hang forever with the existing code, that should be enough to see the difference.