### PR TITLE
Menu exports

### DIFF
--- a/.changeset/angry-donkeys-cross.md
+++ b/.changeset/angry-donkeys-cross.md
@@ -4,10 +4,12 @@
 
 Adds additional exports:
 - `MenuDescendantsContext`
+  - Used to register and consume Menu descendants
   - This context value allows you to register and track custom menu items
 - Context hooks `useMenuContext`, `useMenuGroupContext`, & `useSubMenuContext`, along with types types `MenuContextData`, `MenuGroupContextData`, & `SubMenuContextData`,
   - use these to read context data from custom menu item components
-- `menuColor`: Custom "active state" colors used within the menu
+- `menuColor`: Custom color tokens used within `Menu` and related components
+- `MenuInteractionState`: Enumerates interaction states on a menu item
 - `LGIDs`: Unique ids for menu elements
 - `menuItemClassName`: The unique class name for menu item components
 - `subMenuContainerClassName` & `subMenuToggleClassName`

--- a/.changeset/angry-donkeys-cross.md
+++ b/.changeset/angry-donkeys-cross.md
@@ -1,0 +1,14 @@
+---
+'@leafygreen-ui/menu': minor
+---
+
+Adds additional exports:
+- `MenuDescendantsContext`
+  - This context value allows you to register and track custom menu items
+- Context hooks `useMenuContext`, `useMenuGroupContext`, & `useSubMenuContext`, along with types types `MenuContextData`, `MenuGroupContextData`, & `SubMenuContextData`,
+  - use these to read context data from custom menu item components
+- `menuColor`: Custom "active state" colors used within the menu
+- `LGIDs`: Unique ids for menu elements
+- `menuItemClassName`: The unique class name for menu item components
+- `subMenuContainerClassName` & `subMenuToggleClassName`
+  - Unique classnames for submenu elements

--- a/.changeset/itchy-bikes-hear.md
+++ b/.changeset/itchy-bikes-hear.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/descendants': patch
+---
+
+Adds missing `useHighlightContext` export

--- a/packages/descendants/src/Highlight/index.ts
+++ b/packages/descendants/src/Highlight/index.ts
@@ -8,3 +8,4 @@ export type {
 export { createHighlightContext } from './HighlightContext';
 export { HighlightProvider } from './HighlightProvider';
 export { useHighlight } from './useHighlight';
+export { useHighlightContext } from './useHighlightContext';

--- a/packages/descendants/src/index.ts
+++ b/packages/descendants/src/index.ts
@@ -22,4 +22,5 @@ export {
   HighlightProvider,
   type Index,
   useHighlight,
+  useHighlightContext,
 } from './Highlight';

--- a/packages/menu/src/HighlightReducer/HighlightReducer.ts
+++ b/packages/menu/src/HighlightReducer/HighlightReducer.ts
@@ -49,7 +49,21 @@ const makeHighlightReducerFunction =
 
 /**
  * Custom hook that handles setting the highlighted descendant index,
- * and fires any `onChange` side effects
+ * and fires any `onChange` side effects.
+ *
+ * @returns {HighlightReducerReturnType}.
+ *
+ * Usage:
+ * ```ts
+ * const { getDescendants } = useDescendantsContext(MyDescendantsContext);
+ * const { highlight, moveHighlight } = useHighlightReducer(getDescendants);
+ *
+ * const handleKeyboardEvent = (e) => {
+ *  if (e.key === 'ArrowDown') moveHighlight('next');
+ *  // ...
+ * }
+ *
+ * ```
  */
 export const useHighlightReducer = (
   /** An accessor for the updated descendants list */
@@ -77,6 +91,8 @@ export const useHighlightReducer = (
     });
 
     onChange?.(updatedHighlight);
+    // TODO: Extend this arg to accept numbers
+    // e.g. moveHighlight(2); moveHighlight(-3)
     dispatch({ direction });
   };
 

--- a/packages/menu/src/HighlightReducer/highlight.types.ts
+++ b/packages/menu/src/HighlightReducer/highlight.types.ts
@@ -38,7 +38,12 @@ export type HighlightReducerFunction = Reducer<
 >;
 
 export interface HighlightReducerReturnType {
+  /** The currently highlighted {@link Descendant} object */
   highlight: Descendant | undefined;
+
+  /** Moves the current highlight in some {@link Direction} */
   moveHighlight: (direction: Direction) => void;
+
+  /** Sets the current highlight by index or id */
   setHighlight: (indexOrId: number | string) => void;
 }

--- a/packages/menu/src/HighlightReducer/index.ts
+++ b/packages/menu/src/HighlightReducer/index.ts
@@ -1,2 +1,9 @@
-export type { Direction, Index } from './highlight.types';
+export type {
+  Descendant,
+  HighlightChangeHandler,
+  HighlightReducerFunction,
+  HighlightReducerReturnType,
+  Index,
+  UpdateHighlightAction,
+} from './highlight.types';
 export { useHighlightReducer } from './HighlightReducer';

--- a/packages/menu/src/HighlightReducer/index.ts
+++ b/packages/menu/src/HighlightReducer/index.ts
@@ -1,5 +1,4 @@
 export type {
-  Descendant,
   HighlightChangeHandler,
   HighlightReducerFunction,
   HighlightReducerReturnType,

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -176,6 +176,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
           darkMode,
           highlight,
           setHighlight,
+          moveHighlight,
           renderDarkMenu,
         }}
       >

--- a/packages/menu/src/MenuContext/GroupContext.tsx
+++ b/packages/menu/src/MenuContext/GroupContext.tsx
@@ -1,7 +1,12 @@
 import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 export interface MenuGroupContextData {
+  /** The depth of the current group */
   depth: number;
+  /**
+   * Whether the current group has an icon.
+   * Along with `depth`, this affects the indentation of child items
+   */
   hasIcon: boolean;
 }
 
@@ -20,4 +25,7 @@ export const MenuGroupProvider = ({
   </MenuGroupContext.Provider>
 );
 
+/**
+ * Returns the {@link MenuGroupContextData} for a given menu group context
+ */
 export const useMenuGroupContext = () => useContext(MenuGroupContext);

--- a/packages/menu/src/MenuContext/MenuContext.tsx
+++ b/packages/menu/src/MenuContext/MenuContext.tsx
@@ -20,6 +20,9 @@ export interface MenuContextData {
   renderDarkMenu?: boolean;
 }
 
+/**
+ * Used to register and consume Menu descendants
+ */
 export const MenuDescendantsContext = createDescendantsContext(
   'MenuDescendantsContext',
 );
@@ -30,4 +33,7 @@ export const MenuContext = createContext<MenuContextData>({
   highlight: undefined,
 });
 
+/**
+ * Returns the {@link MenuContextData} for a given menu context
+ */
 export const useMenuContext = () => useContext(MenuContext);

--- a/packages/menu/src/MenuContext/MenuContext.tsx
+++ b/packages/menu/src/MenuContext/MenuContext.tsx
@@ -1,20 +1,14 @@
 import { createContext, useContext } from 'react';
+import noop from 'lodash/noop';
 
 import { createDescendantsContext } from '@leafygreen-ui/descendants';
-import { Descendant } from '@leafygreen-ui/descendants';
 import { Theme } from '@leafygreen-ui/lib';
 
 import { HighlightReducerReturnType } from '../HighlightReducer/highlight.types';
 
-export interface MenuContextData {
+export interface MenuContextData extends HighlightReducerReturnType {
   theme: Theme;
   darkMode: boolean;
-
-  /** The index of the currently highlighted (focused) item */
-  highlight?: Descendant;
-
-  /** Sets the current highlight by index or id */
-  setHighlight?: HighlightReducerReturnType['setHighlight'];
 
   /** Whether to render a dark menu in light mode */
   renderDarkMenu?: boolean;
@@ -31,6 +25,8 @@ export const MenuContext = createContext<MenuContextData>({
   theme: 'light',
   darkMode: false,
   highlight: undefined,
+  moveHighlight: noop,
+  setHighlight: noop,
 });
 
 /**

--- a/packages/menu/src/MenuContext/SubMenuContext.tsx
+++ b/packages/menu/src/MenuContext/SubMenuContext.tsx
@@ -1,7 +1,12 @@
 import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 export interface SubMenuContextData {
+  /** The depth of the current submenu */
   depth: number;
+  /**
+   * Whether the current submenu has an icon.
+   * Along with `depth`, this affects the indentation of submenu items
+   */
   hasIcon: boolean;
 }
 
@@ -20,4 +25,7 @@ export const SubMenuProvider = ({
   </SubMenuContext.Provider>
 );
 
+/**
+ * Returns the {@link SubMenuContextData} for a given submenu context
+ */
 export const useSubMenuContext = () => useContext(SubMenuContext);

--- a/packages/menu/src/MenuContext/index.ts
+++ b/packages/menu/src/MenuContext/index.ts
@@ -1,6 +1,6 @@
 export {
-  type MenuGroupContext,
-  MenuGroupContextData,
+  MenuGroupContext,
+  type MenuGroupContextData,
   MenuGroupProvider,
   useMenuGroupContext,
 } from './GroupContext';

--- a/packages/menu/src/MenuItem/MenuItem.stories.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.stories.tsx
@@ -7,7 +7,6 @@ import Icon, { glyphs } from '@leafygreen-ui/icon';
 
 import { MenuProps } from '../Menu';
 import { withMenuContext } from '../testUtils/withMenuContextDecorator.testutils';
-import { Size } from '../types';
 
 import { MenuItem, Variant } from '.';
 
@@ -51,10 +50,6 @@ export const LiveExample = {
       options: [undefined, ...Object.keys(glyphs)],
     },
     highlighted: { control: 'boolean' },
-    size: {
-      control: 'select',
-      options: Object.values(Size),
-    },
     renderDarkMenu: { control: 'boolean' },
   },
   render: ({ children, glyph, ...args }) => (
@@ -145,7 +140,6 @@ export const DarkInLightMode = {
         darkMode: false,
         description: 'This is a description',
         glyph: <Icon glyph="Cloud" />,
-        size: Size.Default,
         renderDarkMenu: true,
       },
       combineArgs: {

--- a/packages/menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/menu/src/MenuItem/MenuItem.types.ts
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from 'react';
 
-import { Size } from '../types';
-
 const Variant = {
   Default: 'default',
   Destructive: 'destructive',
@@ -54,5 +52,5 @@ export interface MenuItemProps {
    * @deprecated - Size no longer has any effect
    */
   // TODO: codemod to remove `size` props from existing implementations
-  size?: Size;
+  size?: 'default' | 'large';
 }

--- a/packages/menu/src/SubMenu/index.ts
+++ b/packages/menu/src/SubMenu/index.ts
@@ -1,2 +1,6 @@
 export { SubMenu } from './SubMenu';
+export {
+  subMenuContainerClassName,
+  subMenuToggleClassName,
+} from './SubMenu.styles';
 export { InternalSubMenuProps, SubMenuProps } from './SubMenu.types';

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,7 +1,6 @@
 export { LGIDs } from './constants';
 export { FocusableMenuItem } from './FocusableMenuItem';
 export type {
-  Descendant,
   HighlightChangeHandler,
   HighlightReducerFunction,
   HighlightReducerReturnType,

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,5 +1,14 @@
 export { LGIDs } from './constants';
 export { FocusableMenuItem } from './FocusableMenuItem';
+export type {
+  Descendant,
+  HighlightChangeHandler,
+  HighlightReducerFunction,
+  HighlightReducerReturnType,
+  Index,
+  UpdateHighlightAction,
+} from './HighlightReducer';
+export { useHighlightReducer } from './HighlightReducer';
 export { Menu, type MenuProps } from './Menu';
 export {
   type MenuContextData,

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,13 +1,5 @@
 export { LGIDs } from './constants';
 export { FocusableMenuItem } from './FocusableMenuItem';
-export type {
-  HighlightChangeHandler,
-  HighlightReducerFunction,
-  HighlightReducerReturnType,
-  Index,
-  UpdateHighlightAction,
-} from './HighlightReducer';
-export { useHighlightReducer } from './HighlightReducer';
 export { Menu, type MenuProps } from './Menu';
 export {
   type MenuContextData,

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -1,6 +1,27 @@
+export { LGIDs } from './constants';
 export { FocusableMenuItem } from './FocusableMenuItem';
 export { Menu, type MenuProps } from './Menu';
+export {
+  type MenuContextData,
+  MenuDescendantsContext,
+  type MenuGroupContextData,
+  type SubMenuContextData,
+  useMenuContext,
+  useMenuGroupContext,
+  useSubMenuContext,
+} from './MenuContext';
 export { MenuGroup } from './MenuGroup';
-export { MenuItem, type MenuItemProps, Variant } from './MenuItem';
+export {
+  MenuItem,
+  menuItemClassName,
+  type MenuItemProps,
+  Variant,
+} from './MenuItem';
 export { MenuSeparator } from './MenuSeparator';
-export { SubMenu, type SubMenuProps } from './SubMenu';
+export { menuColor, MenuInteractionState } from './styles';
+export {
+  SubMenu,
+  subMenuContainerClassName,
+  type SubMenuProps,
+  subMenuToggleClassName,
+} from './SubMenu';

--- a/packages/menu/src/styles.ts
+++ b/packages/menu/src/styles.ts
@@ -6,14 +6,18 @@ import { RecursiveRecord, Theme } from '@leafygreen-ui/lib';
 import { palette } from '@leafygreen-ui/palette';
 import { color, InteractionState, Property } from '@leafygreen-ui/tokens';
 
+/** Enumerates interaction states on a menu item */
 const MenuInteractionState = {
   ...InteractionState,
   Active: 'active',
 } as const;
+/** Enumerates interaction states on a menu item */
 export type MenuInteractionState =
   (typeof MenuInteractionState)[keyof typeof MenuInteractionState];
 
-// Menu dark/light mode colors intentionally do not line up with tokens
+/**
+ * Custom color tokens used within `Menu` and related components
+ */
 export const menuColor = {
   [Theme.Light]: {
     [Property.Background]: {

--- a/packages/menu/src/styles.ts
+++ b/packages/menu/src/styles.ts
@@ -7,7 +7,7 @@ import { palette } from '@leafygreen-ui/palette';
 import { color, InteractionState, Property } from '@leafygreen-ui/tokens';
 
 /** Enumerates interaction states on a menu item */
-const MenuInteractionState = {
+export const MenuInteractionState = {
   ...InteractionState,
   Active: 'active',
 } as const;

--- a/packages/menu/src/testUtils/withMenuContextDecorator.testutils.tsx
+++ b/packages/menu/src/testUtils/withMenuContextDecorator.testutils.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-key, react/display-name, react-hooks/rules-of-hooks */
 import React from 'react';
 import { InstanceDecorator } from '@lg-tools/storybook-utils';
+import noop from 'lodash/noop';
 
 import { css } from '@leafygreen-ui/emotion';
 import { Theme } from '@leafygreen-ui/lib';
@@ -15,11 +16,20 @@ import { MenuItem } from '../MenuItem';
 export const withMenuContext =
   (): InstanceDecorator<typeof MenuItem & typeof Menu> => (Instance, ctx) => {
     const {
-      args: { darkMode: darkModeProp, renderDarkMenu },
+      args: {
+        darkMode: darkModeProp,
+        renderDarkMenu,
+        highlight,
+        moveHighlight,
+        setHighlight,
+      },
     } = ctx ?? {
       args: {
         darkMode: false,
         renderDarkMenu: false,
+        highlight: undefined,
+        moveHighlight: noop,
+        setHighlight: noop,
       },
     };
 
@@ -37,6 +47,9 @@ export const withMenuContext =
             darkMode,
             theme,
             renderDarkMenu,
+            highlight,
+            moveHighlight,
+            setHighlight,
           }}
         >
           <Instance />

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -1,6 +1,0 @@
-export const Size = {
-  Default: 'default',
-  Large: 'large',
-} as const;
-
-export type Size = (typeof Size)[keyof typeof Size];

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -4,7 +4,3 @@ export const Size = {
 } as const;
 
 export type Size = (typeof Size)[keyof typeof Size];
-
-export type ElementOf<
-  T extends React.ComponentType<React.PropsWithChildren<unknown>>,
-> = React.ReactComponentElement<T, React.ComponentPropsWithRef<T>>;


### PR DESCRIPTION
## ✍️ Proposed changes

Exports the following from `Menu`:
- `MenuDescendantsContext`
  - Used to register and consume Menu descendants
  - This context value allows you to register and track custom menu items
- Context hooks `useMenuContext`, `useMenuGroupContext`, & `useSubMenuContext`, along with types types `MenuContextData`, `MenuGroupContextData`, & `SubMenuContextData`,
  - use these to read context data from custom menu item components
- `menuColor`: Custom color tokens used within `Menu` and related components
- `MenuInteractionState`: Enumerates interaction states on a menu item
- `LGIDs`: Unique ids for menu elements
- `menuItemClassName`: The unique class name for menu item components
- `subMenuContainerClassName` & `subMenuToggleClassName`
  - Unique classnames for submenu elements

Also, adds missing `useHighlightContext` export from `Descendants`