### PR TITLE
Descendants DX

### DIFF
--- a/.changeset/mean-pandas-learn.md
+++ b/.changeset/mean-pandas-learn.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/menu': patch
+---
+
+Update Menu to use latest Descendants API

--- a/.changeset/sour-kangaroos-sit.md
+++ b/.changeset/sour-kangaroos-sit.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tabs': patch
+---
+
+Updates Tabs to use latest Descendants API

--- a/.changeset/swift-points-sip.md
+++ b/.changeset/swift-points-sip.md
@@ -1,0 +1,37 @@
+---
+'@leafygreen-ui/descendants': major
+---
+
+Updates `useInitDescendants` signature to require a Context value, and return a `Provider` component.
+
+Eliminates the need to destructure `descendants` and `dispatch` from the hook's return value just to pass into the provider. Instead, the hook will construct a pre-populated provider unique to the Context value given.
+
+Note: `descendants`, `dispatch` and `getDescendants` are still returned by the hook for use in the parent component if necessary.
+
+Before:
+```tsx
+const MyDescendantContext = createDescendantsContext();
+const { descendants, dispatch } = useInitDescendants();
+
+return (
+  <DescendantsProvider
+    context={MyDescendantContext}
+    descendants={descendants}
+    dispatch={dispatch}
+  >
+    <MyDescendantItem />
+  </DescendantsProvider>
+)
+```
+
+After:
+```tsx
+const MyDescendantContext = createDescendantsContext();
+const { Provider } = useInitDescendants(MyDescendantContext);
+
+return (
+  <Provider>
+    <MyDescendantItem />
+  </Provider>
+)
+```

--- a/packages/descendants/README.md
+++ b/packages/descendants/README.md
@@ -48,17 +48,16 @@ There are 4 steps required to set up a pair of components as Parent/Descendent.
  * shouldn't track fly-out menu items as its own descendants)
  *
  */
-const MyDescendantsContext = createDescendantsContext('MyDescendantsContext');
+const MyDescendantsContext = createDescendantsContext<HTMLDivElement>(
+  'MyDescendantsContext',
+);
 
 export const MyParent = ({ children, ...rest }: ComponentProps<'div'>) => {
   /**
-   * 2. Initialize an empty descendants list and setter
-   *
-   * We call this _outside_ the Provider
-   * so we can access the `descendants` object
-   * from the Parent level.
+   * 2. Initialize an empty descendants list and provider
    */
-  const { descendants, dispatch } = useInitDescendants<HTMLDivElement>();
+  const { getDescendants, Provider: MyDescendantsProvider } =
+    useInitDescendants(MyDescendantsContext);
 
   /**
    * 3. Pass the context, descendants list and setter into the provider
@@ -69,13 +68,9 @@ export const MyParent = ({ children, ...rest }: ComponentProps<'div'>) => {
    * (see fly-out menu example in step 1.)
    */
   return (
-    <DescendantsProvider
-      context={MyDescendantsContext}
-      descendants={descendants}
-      dispatch={dispatch}
-    >
+    <MyDescendantsProvider>
       <div {...rest}>{children}</div>
-    </DescendantsProvider>
+    </MyDescendantsProvider>
   );
 };
 
@@ -84,15 +79,11 @@ export const TestDescendant = ({
   ...rest
 }: ComponentProps<'div'>) => {
   /**
-   * 4. Establish a child component as a descendant
-   *
-   * Pass the context value into the hook
-   * in order to establish this element
+   * 4. Establish a child component as a descendant of our context
    */
   const { index, ref } = useDescendant(MyDescendantsContext);
 
-  // This component has access to its index within the Parent context
-
+  // This component has access to its relative index within the Parent context
   return (
     <div ref={ref} {...rest}>
       {children}

--- a/packages/descendants/src/Descendants/Descendants.spec.tsx
+++ b/packages/descendants/src/Descendants/Descendants.spec.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../test/components.testutils';
 import { renderDescendantsTestContext } from '../../test/renderDescendantsTestContext.testutils';
 
-import { DescendantsProvider, useInitDescendants } from '.';
+import { useInitDescendants } from '.';
 
 describe('packages/descendants', () => {
   describe('rendering', () => {
@@ -294,8 +294,9 @@ describe('packages/descendants', () => {
         open,
         ...rest
       }: ComponentProps<'div'> & { open: boolean }) => {
-        const { descendants, dispatch, getDescendants } =
-          useInitDescendants<HTMLDivElement>();
+        const { Provider, getDescendants } = useInitDescendants(
+          TestDescendantContext,
+        );
 
         const handleTransition = () => {
           logDescendants(getDescendants());
@@ -303,17 +304,13 @@ describe('packages/descendants', () => {
 
         return (
           <StrictMode>
-            <DescendantsProvider
-              context={TestDescendantContext}
-              descendants={descendants}
-              dispatch={dispatch}
-            >
+            <Provider>
               <Popover active={open} onEntered={handleTransition}>
                 <div {...rest} data-testid="parent">
                   {children}
                 </div>
               </Popover>
-            </DescendantsProvider>
+            </Provider>
           </StrictMode>
         );
       };

--- a/packages/descendants/src/Highlight/Highlight.stories.tsx
+++ b/packages/descendants/src/Highlight/Highlight.stories.tsx
@@ -5,11 +5,7 @@ import { StoryMetaType } from '@lg-tools/storybook-utils';
 import { StoryObj } from '@storybook/react';
 
 import { TestDescendantContext } from '../../test/components.testutils';
-import {
-  DescendantsProvider,
-  useDescendant,
-  useInitDescendants,
-} from '../Descendants';
+import { useDescendant, useInitDescendants } from '../Descendants';
 
 import { HighlightProvider } from './HighlightProvider';
 import { useHighlightContext } from './useHighlightContext';
@@ -66,7 +62,9 @@ const HighlightItem = ({ children }: PropsWithChildren<{}>) => {
 };
 
 export const Basic = () => {
-  const { getDescendants, dispatch } = useInitDescendants<HTMLDivElement>();
+  const { getDescendants, Provider: MyDescendantsProvider } =
+    useInitDescendants(TestDescendantContext);
+
   const { highlight, moveHighlight, setHighlight } = useHighlight(
     getDescendants,
     {
@@ -118,11 +116,7 @@ export const Basic = () => {
 
   return (
     <div>
-      <DescendantsProvider
-        context={TestDescendantContext}
-        descendants={getDescendants()}
-        dispatch={dispatch}
-      >
+      <MyDescendantsProvider>
         <HighlightProvider
           context={TestHighlightContext}
           highlight={highlight}
@@ -132,7 +126,7 @@ export const Basic = () => {
             <HighlightItem key={item}>{item}</HighlightItem>
           ))}
         </HighlightProvider>
-      </DescendantsProvider>
+      </MyDescendantsProvider>
     </div>
   );
 };
@@ -140,7 +134,8 @@ export const Basic = () => {
 export const Grid = {
   render: () => {
     const COLUMNS = 3;
-    const { getDescendants, dispatch } = useInitDescendants<HTMLDivElement>();
+    const { getDescendants, Provider: MyDescendantsProvider } =
+      useInitDescendants(TestDescendantContext);
     const { highlight, moveHighlight, setHighlight } = useHighlight(
       getDescendants,
       {
@@ -179,11 +174,7 @@ export const Grid = {
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div>
-        <DescendantsProvider
-          context={TestDescendantContext}
-          descendants={getDescendants()}
-          dispatch={dispatch}
-        >
+        <MyDescendantsProvider>
           <HighlightProvider
             context={TestHighlightContext}
             highlight={highlight}
@@ -200,7 +191,7 @@ export const Grid = {
               ))}
             </div>
           </HighlightProvider>
-        </DescendantsProvider>
+        </MyDescendantsProvider>
       </div>
     );
   },

--- a/packages/descendants/test/components.testutils.tsx
+++ b/packages/descendants/test/components.testutils.tsx
@@ -2,7 +2,6 @@ import React, { ComponentProps, forwardRef, useContext, useState } from 'react';
 
 import {
   createDescendantsContext,
-  DescendantsProvider,
   useDescendant,
   useInitDescendants,
 } from '..';
@@ -16,20 +15,16 @@ export const TestDescendantContext = createDescendantsContext<HTMLDivElement>(
 
 export const TestParent = ({ children, ...rest }: ComponentProps<'div'>) => {
   // 2. Initialize an empty descendants data structure
-  const { descendants, dispatch } = useInitDescendants<HTMLDivElement>();
+  const { Provider } = useInitDescendants(TestDescendantContext);
   const [selected, setSelected] = useState<number | undefined>(0);
 
   // 3. Pass the context & descendants data structure into the provider
   return (
-    <DescendantsProvider
-      context={TestDescendantContext}
-      descendants={descendants}
-      dispatch={dispatch}
-    >
+    <Provider>
       <TestSelectionContext.Provider value={{ selected, setSelected }}>
         <div {...rest}>{children}</div>
       </TestSelectionContext.Provider>
-    </DescendantsProvider>
+    </Provider>
   );
 };
 
@@ -75,17 +70,13 @@ const TestDescendantContext2 = createDescendantsContext<HTMLDivElement>(
 
 export const TestParent2 = ({ children, ...rest }: ComponentProps<'div'>) => {
   // 2. Initialize an empty descendants data structure
-  const { descendants, dispatch } = useInitDescendants<HTMLDivElement>();
+  const { Provider } = useInitDescendants(TestDescendantContext2);
 
   // 3. Pass the context & descendants data structure into the provider
   return (
-    <DescendantsProvider
-      context={TestDescendantContext2}
-      descendants={descendants}
-      dispatch={dispatch}
-    >
+    <Provider>
       <div {...rest}>{children}</div>
-    </DescendantsProvider>
+    </Provider>
   );
 };
 

--- a/packages/descendants/test/renderDescendantsTestContext.testutils.tsx
+++ b/packages/descendants/test/renderDescendantsTestContext.testutils.tsx
@@ -3,32 +3,20 @@ import { render } from '@testing-library/react';
 
 import { renderHook } from '@leafygreen-ui/testing-lib';
 
-import { DescendantsProvider, useInitDescendants } from '..';
+import { useInitDescendants } from '..';
 
 import { TestDescendantContext } from './components.testutils';
 
-export const renderDescendantsTestContext = (descendants: ReactNode) => {
-  const hook = renderHook(() => useInitDescendants<HTMLDivElement>());
+export const renderDescendantsTestContext = (children: ReactNode) => {
+  const hook = renderHook(() => useInitDescendants(TestDescendantContext));
 
   const renderResult = render(
-    <DescendantsProvider
-      context={TestDescendantContext}
-      descendants={hook.result.current.descendants}
-      dispatch={hook.result.current.dispatch}
-    >
-      {descendants}
-    </DescendantsProvider>,
+    <hook.result.current.Provider>{children}</hook.result.current.Provider>,
   );
 
-  const rerender = (descendants: ReactNode) => {
+  const rerender = (children: ReactNode) => {
     renderResult.rerender(
-      <DescendantsProvider
-        context={TestDescendantContext}
-        descendants={hook.result.current.descendants}
-        dispatch={hook.result.current.dispatch}
-      >
-        {descendants}
-      </DescendantsProvider>,
+      <hook.result.current.Provider>{children}</hook.result.current.Provider>,
     );
   };
 

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  DescendantsProvider,
   getDescendantById,
   useInitDescendants,
 } from '@leafygreen-ui/descendants';
@@ -97,7 +96,8 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
 
   useBackdropClick(handleClose, [popoverRef, triggerRef], open);
 
-  const { descendants, dispatch, getDescendants } = useInitDescendants();
+  const { getDescendants, Provider: MenuDescendantsProvider } =
+    useInitDescendants(MenuDescendantsContext);
 
   // Tracks the currently highlighted (focused) item index
   // Fires `.focus()` when the index is updated
@@ -169,11 +169,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
   };
 
   const popoverContent = (
-    <DescendantsProvider
-      context={MenuDescendantsContext}
-      descendants={descendants}
-      dispatch={dispatch}
-    >
+    <MenuDescendantsProvider>
       <MenuContext.Provider
         value={{
           theme,
@@ -226,7 +222,7 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(function Menu(
           </div>
         </Popover>
       </MenuContext.Provider>
-    </DescendantsProvider>
+    </MenuDescendantsProvider>
   );
 
   if (trigger) {

--- a/packages/tabs/src/Tabs/Tabs.tsx
+++ b/packages/tabs/src/Tabs/Tabs.tsx
@@ -2,10 +2,7 @@ import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { validateAriaLabelProps } from '@leafygreen-ui/a11y';
-import {
-  DescendantsProvider,
-  useInitDescendants,
-} from '@leafygreen-ui/descendants';
+import { useInitDescendants } from '@leafygreen-ui/descendants';
 import { cx } from '@leafygreen-ui/emotion';
 import { useIdAllocator } from '@leafygreen-ui/hooks';
 import LeafyGreenProvider, {
@@ -75,10 +72,11 @@ const Tabs = (props: AccessibleTabsProps) => {
   const { theme, darkMode } = useDarkMode(darkModeProp);
   const id = useIdAllocator({ prefix: rest.id || 'tabs' });
 
-  const { descendants: tabDescendants, dispatch: tabDispatch } =
-    useInitDescendants<HTMLDivElement>();
-  const { descendants: tabPanelDescendants, dispatch: tabPanelDispatch } =
-    useInitDescendants<HTMLDivElement>();
+  const { descendants: tabDescendants, Provider: TabDescendantsProvider } =
+    useInitDescendants(TabDescendantsContext);
+  const { Provider: TabPanelDescendantProvider } = useInitDescendants(
+    TabPanelDescendantsContext,
+  );
 
   const isControlled = typeof controlledSelected !== 'undefined';
   const [uncontrolledSelected, setUncontrolledSelected] = useState(0);
@@ -161,16 +159,8 @@ const Tabs = (props: AccessibleTabsProps) => {
 
   return (
     <LeafyGreenProvider baseFontSize={baseFontSize === 16 ? 16 : 14}>
-      <DescendantsProvider
-        context={TabDescendantsContext}
-        descendants={tabDescendants}
-        dispatch={tabDispatch}
-      >
-        <DescendantsProvider
-          context={TabPanelDescendantsContext}
-          descendants={tabPanelDescendants}
-          dispatch={tabPanelDispatch}
-        >
+      <TabDescendantsProvider>
+        <TabPanelDescendantProvider>
           <TabsContext.Provider
             value={{
               as,
@@ -207,8 +197,8 @@ const Tabs = (props: AccessibleTabsProps) => {
               </div>
             </div>
           </TabsContext.Provider>
-        </DescendantsProvider>
-      </DescendantsProvider>
+        </TabPanelDescendantProvider>
+      </TabDescendantsProvider>
     </LeafyGreenProvider>
   );
 };


### PR DESCRIPTION
## ✍️ Proposed changes


Updates `useInitDescendants` signature to require a Context value, and return a `Provider` component.

Eliminates the need to destructure `descendants` and `dispatch` from the hook's return value just to pass into the provider. Instead, the hook will construct a pre-populated provider unique to the Context value given.

Note: `descendants`, `dispatch` and `getDescendants` are still returned by the hook for use in the parent component if necessary.

Before:
```tsx
const MyDescendantContext = createDescendantsContext();
const { descendants, dispatch } = useInitDescendants();

return (
  <DescendantsProvider
    context={MyDescendantContext}
    descendants={descendants}
    dispatch={dispatch}
  >
    <MyDescendantItem />
  </DescendantsProvider>
)
```

After:
```tsx
const MyDescendantContext = createDescendantsContext();
const { Provider } = useInitDescendants(MyDescendantContext);

return (
  <Provider>
    <MyDescendantItem />
  </Provider>
)
```
