### PR TITLE
LG-3327: Prevent re-render in `useViewportSize`

### DIFF
--- a/.changeset/honest-drinks-change.md
+++ b/.changeset/honest-drinks-change.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/hooks': patch
+---
+
+Fixes re-render after initial render of useViewportSize hook

--- a/.changeset/honest-drinks-change.md
+++ b/.changeset/honest-drinks-change.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/hooks': patch
 ---
 
-Fixes re-render after initial render of useViewportSize hook
+Fixes re-render after initial render of `useViewportSize` hook

--- a/packages/hooks/src/hooks.spec.tsx
+++ b/packages/hooks/src/hooks.spec.tsx
@@ -95,33 +95,51 @@ describe('packages/hooks', () => {
   // Difficult to test a hook that measures changes to the DOM without having access to the DOM
   describe.skip('useMutationObserver', () => {}); //eslint-disable-line jest/no-disabled-tests
 
-  test('useViewportSize responds to updates in window size', async () => {
-    const { result, rerender } = renderHook(() => useViewportSize());
+  describe('useViewportSize', () => {
+    test('returns correct window dimensions on initial render', () => {
+      const mutableWindow: { -readonly [K in keyof Window]: Window[K] } =
+        window;
+      const initialHeight = 360;
+      const initialWidth = 480;
 
-    const mutableWindow: { -readonly [K in keyof Window]: Window[K] } = window;
-    const initialHeight = 360;
-    const initialWidth = 480;
+      mutableWindow.innerHeight = initialHeight;
+      mutableWindow.innerWidth = initialWidth;
 
-    mutableWindow.innerHeight = initialHeight;
-    mutableWindow.innerWidth = initialWidth;
+      const { result } = renderHook(() => useViewportSize());
 
-    window.dispatchEvent(new Event('resize'));
-    rerender();
-    await waitFor(() => {
       expect(result?.current?.height).toBe(initialHeight);
       expect(result?.current?.width).toBe(initialWidth);
     });
 
-    const updateHeight = 768;
-    const updateWidth = 1024;
+    test('responds to updates in window size', async () => {
+      const { result, rerender } = renderHook(() => useViewportSize());
 
-    mutableWindow.innerHeight = updateHeight;
-    mutableWindow.innerWidth = updateWidth;
+      const mutableWindow: { -readonly [K in keyof Window]: Window[K] } =
+        window;
+      const initialHeight = 360;
+      const initialWidth = 480;
 
-    window.dispatchEvent(new Event('resize'));
-    await waitFor(() => {
-      expect(result?.current?.height).toBe(updateHeight);
-      expect(result?.current?.width).toBe(updateWidth);
+      mutableWindow.innerHeight = initialHeight;
+      mutableWindow.innerWidth = initialWidth;
+
+      window.dispatchEvent(new Event('resize'));
+      rerender();
+      await waitFor(() => {
+        expect(result?.current?.height).toBe(initialHeight);
+        expect(result?.current?.width).toBe(initialWidth);
+      });
+
+      const updateHeight = 768;
+      const updateWidth = 1024;
+
+      mutableWindow.innerHeight = updateHeight;
+      mutableWindow.innerWidth = updateWidth;
+
+      window.dispatchEvent(new Event('resize'));
+      await waitFor(() => {
+        expect(result?.current?.height).toBe(updateHeight);
+        expect(result?.current?.width).toBe(updateWidth);
+      });
     });
   });
 

--- a/packages/hooks/src/hooks.spec.tsx
+++ b/packages/hooks/src/hooks.spec.tsx
@@ -116,18 +116,6 @@ describe('packages/hooks', () => {
 
       const mutableWindow: { -readonly [K in keyof Window]: Window[K] } =
         window;
-      const initialHeight = 360;
-      const initialWidth = 480;
-
-      mutableWindow.innerHeight = initialHeight;
-      mutableWindow.innerWidth = initialWidth;
-
-      window.dispatchEvent(new Event('resize'));
-      rerender();
-      await waitFor(() => {
-        expect(result?.current?.height).toBe(initialHeight);
-        expect(result?.current?.width).toBe(initialWidth);
-      });
 
       const updateHeight = 768;
       const updateWidth = 1024;

--- a/packages/hooks/src/useViewportSize.ts
+++ b/packages/hooks/src/useViewportSize.ts
@@ -14,12 +14,16 @@ function getViewportSize(): ViewportSize {
 }
 
 export default function useViewportSize(): ViewportSize | null {
-  const [viewportSize, setViewportUpdateVal] = useState<ViewportSize | null>(
-    null,
+  // const [viewportSize, setViewportUpdateVal] = useState<ViewportSize | null>(
+  //   null,
+  // );
+
+  const [viewportSize, setViewportUpdateVal] = useState<ViewportSize>(
+    getViewportSize(),
   );
 
   useEffect(() => {
-    setViewportUpdateVal(getViewportSize());
+    // setViewportUpdateVal(getViewportSize());
 
     const calcResize = debounce(
       () => setViewportUpdateVal(getViewportSize()),
@@ -31,5 +35,6 @@ export default function useViewportSize(): ViewportSize | null {
     return () => window.removeEventListener('resize', calcResize);
   }, []);
 
+  console.log('INNER');
   return viewportSize;
 }

--- a/packages/hooks/src/useViewportSize.ts
+++ b/packages/hooks/src/useViewportSize.ts
@@ -13,18 +13,12 @@ function getViewportSize(): ViewportSize {
   };
 }
 
-export default function useViewportSize(): ViewportSize | null {
-  // const [viewportSize, setViewportUpdateVal] = useState<ViewportSize | null>(
-  //   null,
-  // );
-
+export default function useViewportSize(): ViewportSize {
   const [viewportSize, setViewportUpdateVal] = useState<ViewportSize>(
     getViewportSize(),
   );
 
   useEffect(() => {
-    // setViewportUpdateVal(getViewportSize());
-
     const calcResize = debounce(
       () => setViewportUpdateVal(getViewportSize()),
       100,
@@ -35,6 +29,5 @@ export default function useViewportSize(): ViewportSize | null {
     return () => window.removeEventListener('resize', calcResize);
   }, []);
 
-  console.log('INNER');
   return viewportSize;
 }

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -402,11 +402,6 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
 
     const viewportSize = useViewportSize();
 
-    console.log('render', ++count);
-    console.log('innerWidth: ', window.innerWidth);
-    console.log('innerHeight: ', window.innerHeight);
-    console.log('viewportSize: ', viewportSize);
-
     const hasGlyphs = useMemo(() => {
       let hasGlyphs = false;
 

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -48,8 +48,6 @@ import {
 } from './Select.styles';
 import { DropdownWidthBasis, SelectProps, Size, State } from './Select.types';
 
-let count = 0;
-
 /**
  * Select inputs are typically used alongside other form elements like toggles, radio boxes, or text inputs when a user needs to make a selection from a list of items.
  *

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -48,6 +48,8 @@ import {
 } from './Select.styles';
 import { DropdownWidthBasis, SelectProps, Size, State } from './Select.types';
 
+let count = 0;
+
 /**
  * Select inputs are typically used alongside other form elements like toggles, radio boxes, or text inputs when a user needs to make a selection from a list of items.
  *
@@ -399,6 +401,11 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
      */
 
     const viewportSize = useViewportSize();
+
+    console.log('render', ++count);
+    console.log('innerWidth: ', window.innerWidth);
+    console.log('innerHeight: ', window.innerHeight);
+    console.log('viewportSize: ', viewportSize);
 
     const hasGlyphs = useMemo(() => {
       let hasGlyphs = false;


### PR DESCRIPTION
## ✍️ Proposed changes

- Initialize viewport size with value instead of setting it in `useEffect` callback to prevent additional re-render.

🎟 _Jira ticket:_ [LG-3327](https://jira.mongodb.org/browse/LG-3327)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [x] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- Checked all live examples using the `useViewportSize()` hook
- Checked all live examples using the `useAvailableSpace()` hook, which uses `useViewportSize()`
- All previous tests passing
