### PR TITLE
LG-3553: Make `prefix` argument optional for `useDynamicRefs`

### DIFF
--- a/.changeset/twenty-pans-promise.md
+++ b/.changeset/twenty-pans-promise.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/hooks': patch
+---
+
+Makes prefix argument optional for useDynamicRefs

--- a/.changeset/twenty-pans-promise.md
+++ b/.changeset/twenty-pans-promise.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/hooks': patch
 ---
 
-Makes prefix argument optional for useDynamicRefs
+Makes prefix argument optional for `useDynamicRefs`

--- a/packages/hooks/src/useDynamicRefs/index.ts
+++ b/packages/hooks/src/useDynamicRefs/index.ts
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { consoleOnce } from '@leafygreen-ui/lib';
 
 export interface UseDynamicRefsArgs {
-  prefix: string;
+  prefix?: string;
 }
 
 /** The Map type for a given ref object  */
@@ -53,12 +53,15 @@ export function useDynamicRefs<T>(
 ): DynamicRefGetter<T> {
   const prefix = args?.prefix;
 
-  const getRef = React.useMemo(() => {
-    const refMap: RefMap<T> = new Map<string, React.RefObject<T>>();
-    const getter = getGetRef<T>(refMap);
-    return getter;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prefix]);
+  const getRef = React.useMemo(
+    () => {
+      const refMap: RefMap<T> = new Map<string, React.RefObject<T>>();
+      const getter = getGetRef<T>(refMap);
+      return getter;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    prefix ? [prefix] : [],
+  );
 
   return getRef;
 }


### PR DESCRIPTION
## ✍️ Proposed changes

Makes `prefix` argument optional for `useDynamicRefs`.

🎟 _Jira ticket:_ [LG-3553](https://jira.mongodb.org/browse/[LG-3553])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.