### PR TITLE
LG-4335: Clean up running tasks in `Toast`

### DIFF
--- a/.changeset/tough-trees-trade.md
+++ b/.changeset/tough-trees-trade.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/toast': patch
+---
+
+Cleans up running tasks in `Toast` on unmount

--- a/packages/toast/src/ToastContainer/utils/useToastHeights.ts
+++ b/packages/toast/src/ToastContainer/utils/useToastHeights.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import debounce from 'lodash/debounce';
 
 import { spacing } from '@leafygreen-ui/tokens';
@@ -126,6 +126,13 @@ export function useToastHeights({
     () => debounce(_updateToastHeights, 100),
     [_updateToastHeights],
   );
+
+  useEffect(() => {
+    // Cleanup debounced functions on unmount
+    return () => {
+      updateToastHeights.cancel();
+    };
+  }, [updateToastHeights]);
 
   return {
     toastHeights,

--- a/packages/toast/src/ToastContainer/utils/useToastHeights.ts
+++ b/packages/toast/src/ToastContainer/utils/useToastHeights.ts
@@ -128,7 +128,6 @@ export function useToastHeights({
   );
 
   useEffect(() => {
-    // Cleanup debounced functions on unmount
     return () => {
       updateToastHeights.cancel();
     };

--- a/packages/toast/src/ToastContainer/utils/useToastTransitions.ts
+++ b/packages/toast/src/ToastContainer/utils/useToastTransitions.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import debounce from 'lodash/debounce';
 
 const transitionDebounceTime = 100;
@@ -59,6 +59,14 @@ export function useToastTransitions({
       }),
     [exitCallback, getShouldExpand],
   );
+
+  useEffect(() => {
+    // Cleanup debounced functions on unmount
+    return () => {
+      handleTransitionEnter.cancel();
+      handleTransitionExit.cancel();
+    };
+  }, [handleTransitionEnter, handleTransitionExit]);
 
   return {
     isExpanded,

--- a/packages/toast/src/ToastContainer/utils/useToastTransitions.ts
+++ b/packages/toast/src/ToastContainer/utils/useToastTransitions.ts
@@ -61,7 +61,6 @@ export function useToastTransitions({
   );
 
   useEffect(() => {
-    // Cleanup debounced functions on unmount
     return () => {
       handleTransitionEnter.cancel();
       handleTransitionExit.cancel();


### PR DESCRIPTION
## ✍️ Proposed changes

There are a number of `debounce` functions that are not currently cancelled on unmount. This PR cancel those.

🎟 _Jira ticket:_ [LG-4335](https://jira.mongodb.org/browse/LG-4335)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- [x] Previous unit tests passing
- [x] No regression in `Toast` component


