### PR TITLE
Terrence/fix undefined window

### DIFF
--- a/.changeset/short-eels-deliver.md
+++ b/.changeset/short-eels-deliver.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/hooks': patch
+---
+
+When server side rendering is used, `window` is not defined. This is causing build issues on the server where we access `window` in `useViewportSize`. To fix this, this change adds a hook, `useIsSsr`, that checks the rendering environment and can be used before attempting to access `window`. It adds a check of this to `useViewportSize` to fix the current build issue.

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -16,3 +16,4 @@ export { default as usePrevious } from './usePrevious';
 export { useStateRef } from './useStateRef';
 export { default as useValidation } from './useValidation';
 export { default as useViewportSize } from './useViewportSize';
+export { default as useIsSsr } from './useIsSsr';

--- a/packages/hooks/src/useIsSsr.ts
+++ b/packages/hooks/src/useIsSsr.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export default function useIsSsr() {
+  const [isSsr, setIsSsr] = useState(typeof window === 'undefined');
+
+  useEffect(() => {
+    // When rendered on server, this won't run until we're on the client. Therefore,
+    // isSsr should be true when server rendered, and only be set to false on subsequent client render.
+    // When rendered directly on the client, isSsr should already be false, so
+    // this update shouldn't trigger a re-render.
+    setIsSsr(false);
+  }, []);
+
+  return isSsr;
+}

--- a/packages/hooks/src/useViewportSize.ts
+++ b/packages/hooks/src/useViewportSize.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import debounce from 'lodash/debounce';
+import useIsSsr from './useIsSsr';
 
 interface ViewportSize {
   width: number;
@@ -14,10 +15,10 @@ function getViewportSize(): ViewportSize {
 }
 
 export default function useViewportSize(): ViewportSize | null {
-  const isRenderingServerSide = typeof window === 'undefined';
+  const isSsr = useIsSsr();
 
   const [viewportSize, setViewportUpdateVal] = useState<ViewportSize | null>(
-    isRenderingServerSide ? null : getViewportSize(), // window undefined on server
+    isSsr ? null : getViewportSize(), // window undefined on server
   );
 
   useEffect(() => {

--- a/packages/hooks/src/useViewportSize.ts
+++ b/packages/hooks/src/useViewportSize.ts
@@ -13,9 +13,11 @@ function getViewportSize(): ViewportSize {
   };
 }
 
-export default function useViewportSize(): ViewportSize {
-  const [viewportSize, setViewportUpdateVal] = useState<ViewportSize>(
-    getViewportSize(),
+export default function useViewportSize(): ViewportSize | null {
+  const isRenderingServerSide = typeof window === 'undefined';
+
+  const [viewportSize, setViewportUpdateVal] = useState<ViewportSize | null>(
+    isRenderingServerSide ? null : getViewportSize(), // window undefined on server
   );
 
   useEffect(() => {
@@ -24,8 +26,8 @@ export default function useViewportSize(): ViewportSize {
       100,
     );
 
+    // useEffect callback only runs on client, so safe to assume window is defined here
     window.addEventListener('resize', calcResize);
-
     return () => window.removeEventListener('resize', calcResize);
   }, []);
 


### PR DESCRIPTION
## ✍️ Proposed changes

When server side rendering is used, `window` is not defined. This is causing build issues on the server where we access `window` in `useViewportSize`. To fix this, this PR adds a hook to check if we're on the server or client. Placing this logic in a hook allows for the `useEffect` callback to be re-run on the client and properly updated when server rendered.

Note to reviewer: Would love a 2nd opinion on rendering here. I don't believe there should be an issue, since this is just essentially reverting to a previous state where we do an initial set to `null`, but adds logic to update that IF rendered on the client. However, I want to make sure I'm not missing something that will cause a disruption on render.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ x ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
