### PR TITLE
LG-4604: extend TableSkeleton component columnLabels prop type

### DIFF
--- a/.changeset/dull-pianos-rest.md
+++ b/.changeset/dull-pianos-rest.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/skeleton-loader': patch
+---
+
+[LG-4604](https://jira.mongodb.org/browse/LG-4604): Extends `TableSkeleton` component's `columnLabels` prop type from `Array<string | undefined>` to `Array<React.ReactNode>`

--- a/packages/skeleton-loader/README.md
+++ b/packages/skeleton-loader/README.md
@@ -46,13 +46,13 @@ npm install @leafygreen-ui/skeleton-loader
 
 #### Table Skeleton
 
-| Name             | Type            | Default | Description                                                                           |
-| ---------------- | --------------- | ------- | ------------------------------------------------------------------------------------- |
-| `columnLabels`   | `Array<string>` |         | Column labels. Empty strings will be treated as unknown and render a simple skeleton. |
-| `numRows`        | `number`        | `5`     | Number of rows                                                                        |
-| `numCols`        | `number`        | `4`     | Number of columns                                                                     |
-| `baseFontSize`   | `13 \| 16`      | `13`    | Base font size                                                                        |
-| HTML `div` props |                 |         | Additional HTML div properties                                                        |
+| Name             | Type                     | Default | Description                                                                           |
+| ---------------- | ------------------------ | ------- | ------------------------------------------------------------------------------------- |
+| `columnLabels`   | `Array<React.ReactNode>` |         | Column labels. Empty strings will be treated as unknown and render a simple skeleton. |
+| `numRows`        | `number`                 | `5`     | Number of rows                                                                        |
+| `numCols`        | `number`                 | `4`     | Number of columns                                                                     |
+| `baseFontSize`   | `13 \| 16`               | `13`    | Base font size                                                                        |
+| HTML `div` props |                          |         | Additional HTML div properties                                                        |
 
 #### Form Skeleton
 

--- a/packages/skeleton-loader/src/TableSkeleton/TableSkeleton.types.ts
+++ b/packages/skeleton-loader/src/TableSkeleton/TableSkeleton.types.ts
@@ -21,7 +21,7 @@ export interface TableSkeletonProps
   /**
    * Column labels. Empty strings or undefined values will be treated as unknown and render a simple skeleton.
    */
-  columnLabels?: Array<string | undefined>;
+  columnLabels?: Array<React.ReactNode>;
 
   /**
    * Number of rows


### PR DESCRIPTION
## ✍️ Proposed changes

- Extends `TableSkeleton` component's `columnLabels` prop type from `Array<string | undefined>` to `Array<React.ReactNode>`

🎟 _Jira ticket:_ [LG-4604](https://jira.mongodb.org/browse/LG-4604)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
