### PR TITLE
Validate test file dev deps

### DIFF
--- a/.changeset/quick-insects-smash.md
+++ b/.changeset/quick-insects-smash.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/validate': minor
+---
+
+Updates `devFilePatterns`, and will exclude all files in `test/` `testing/` or `test-utilities/` directories from explicit dep. checks. i.e. Files in these directories will only need to have their imports listed s `devDependencies` in the `package.json`

--- a/tools/validate/src/dependencies/config.ts
+++ b/tools/validate/src/dependencies/config.ts
@@ -18,7 +18,9 @@ export interface DependencyIssues {
   isMissingPeers: boolean;
 }
 
-/** We treat dependencies imported by files matching these patterns as devDependencies */
+/**
+ * Treat packages imported by these files as `devDependencies`
+ */
 export const devFilePatterns: Array<RegExp> = [
   /.*scripts\/.*/,
   /.*.stories.js/,
@@ -26,7 +28,8 @@ export const devFilePatterns: Array<RegExp> = [
   /.*.?stor(y|ies).(t|j)sx?/,
   /.*.stories.tsx?/,
   /.*.example.tsx?/,
-  /.*.testutils((.tsx?)|(\/.*))/,
+  /.*.test(-?[uU])til(itie)?s((.tsx?)|(\/.*))/,
+  /.*\/test(ing|-?[uU]til(itie)?s)?\//g,
   /.*\/dist\/.*/,
 ];
 


### PR DESCRIPTION
## ✍️ Proposed changes

Updates `@lg-tools/validate` with the following change:

Updates `devFilePatterns`, and will exclude all files in `test/` `testing/` or `test-utilities/` directories from explicit dep. checks. i.e. Files in these directories will only need to have their imports listed s `devDependencies` in the `package.json`
