### PR TITLE
LG-4659: Replace axes `unit` prop with `formatter`

### DIFF
--- a/.changeset/silly-jars-cheat.md
+++ b/.changeset/silly-jars-cheat.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': minor
+---
+
+Replaces `unit` prop of `XAxis` and `YAxis` with `formatter` prop

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -92,11 +92,11 @@ Renders an x-axis.
 
 #### Props
 
-| Name                     | Description                                                                                                                                                                                                         | Type                                                                              | Default |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------- |
-| `type`                   | Type of axis.                                                                                                                                                                                                       | 'category' \| 'value' \| 'time' \| 'log'                                          |         |
-| `label` _(optional)_     | Label name to be rendered on the axis.                                                                                                                                                                              | string                                                                            |         |
-| `formatter` _(optional)_ | Formatter of axis label, which supports string template and callback function. (See [ECharts xAxis.axisLabel.formatter docs](https://echarts.apache.org/en/option.html#xAxis.axisLabel.formatter) for more details) | string \| ((value: string, index: number) => string) \| { [key: string]: string } |         |
+| Name                     | Description                                   | Type                                     | Default |
+| ------------------------ | --------------------------------------------- | ---------------------------------------- | ------- |
+| `type`                   | Type of axis.                                 | 'category' \| 'value' \| 'time' \| 'log' |         |
+| `label` _(optional)_     | Label name to be rendered on the axis.        | string                                   |         |
+| `formatter` _(optional)_ | Callback function for formatting tick values. | (value: string, index: number) => string |         |
 
 ### `YAxis`
 
@@ -104,8 +104,8 @@ Renders a y-axis.
 
 #### Props
 
-| Name                     | Description                                                                                                                                                                                                         | Type                                                                              | Default |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------- |
-| `type`                   | Type of axis.                                                                                                                                                                                                       | 'category' \| 'value' \| 'time' \| 'log'                                          |         |
-| `label` _(optional)_     | Label name to be rendered on the axis.                                                                                                                                                                              | string                                                                            |         |
-| `formatter` _(optional)_ | Formatter of axis label, which supports string template and callback function. (See [ECharts yAxis.axisLabel.formatter docs](https://echarts.apache.org/en/option.html#yAxis.axisLabel.formatter) for more details) | string \| ((value: string, index: number) => string) \| { [key: string]: string } |         |
+| Name                     | Description                                   | Type                                     | Default |
+| ------------------------ | --------------------------------------------- | ---------------------------------------- | ------- |
+| `type`                   | Type of axis.                                 | 'category' \| 'value' \| 'time' \| 'log' |         |
+| `label` _(optional)_     | Label name to be rendered on the axis.        | string                                   |         |
+| `formatter` _(optional)_ | Callback function for formatting tick values. | (value: string, index: number) => string |         |

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -26,7 +26,7 @@ import { Chart, Line, Grid, XAxis, YAxis } from '@lg-charts/core';
 <Chart>
   <Grid vertical={false}>
   <XAxis type="time" />
-  <YAxis type="value" unit="GB" />
+  <YAxis type="value" formatter="{value}GB" />
   <Line
     name="Series 1"
     data={[
@@ -92,11 +92,11 @@ Renders an x-axis.
 
 #### Props
 
-| Name                 | Description                                                                                                                                                                                                                                                                           | Type                                     | Default |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------- |
-| `type`               | Type of axis.                                                                                                                                                                                                                                                                         | 'category' \| 'value' \| 'time' \| 'log' |         |
-| `label` _(optional)_ | Label name to be rendered on the axis.                                                                                                                                                                                                                                                | string                                   |         |
-| `unit` _(optional)_  | String that will be appended to the values of the axis. Only applies if `type` of `value`. _Note: this unit will not impact the data. E.g. if data is given in MB and the units are set to "GB", the component won’t convert these values. Conversion of data is up to the consumer._ | string                                   |         |
+| Name                     | Description                                                                                                                                                                                                         | Type                                                                              | Default |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------- |
+| `type`                   | Type of axis.                                                                                                                                                                                                       | 'category' \| 'value' \| 'time' \| 'log'                                          |         |
+| `label` _(optional)_     | Label name to be rendered on the axis.                                                                                                                                                                              | string                                                                            |         |
+| `formatter` _(optional)_ | Formatter of axis label, which supports string template and callback function. (See [ECharts xAxis.axisLabel.formatter docs](https://echarts.apache.org/en/option.html#xAxis.axisLabel.formatter) for more details) | string \| ((value: string, index: number) => string) \| { [key: string]: string } |         |
 
 ### `YAxis`
 
@@ -104,8 +104,8 @@ Renders a y-axis.
 
 #### Props
 
-| Name                 | Description                                                                                                                                                                                                                                                                           | Type                                     | Default |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------- |
-| `type`               | Type of axis.                                                                                                                                                                                                                                                                         | 'category' \| 'value' \| 'time' \| 'log' |         |
-| `label` _(optional)_ | Label name to be rendered on the axis.                                                                                                                                                                                                                                                | string                                   |         |
-| `unit` _(optional)_  | String that will be appended to the values of the axis. Only applies if `type` of `value`. _Note: this unit will not impact the data. E.g. if data is given in MB and the units are set to "GB", the component won’t convert these values. Conversion of data is up to the consumer._ | string                                   |         |
+| Name                     | Description                                                                                                                                                                                                         | Type                                                                              | Default |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------- |
+| `type`                   | Type of axis.                                                                                                                                                                                                       | 'category' \| 'value' \| 'time' \| 'log'                                          |         |
+| `label` _(optional)_     | Label name to be rendered on the axis.                                                                                                                                                                              | string                                                                            |         |
+| `formatter` _(optional)_ | Formatter of axis label, which supports string template and callback function. (See [ECharts yAxis.axisLabel.formatter docs](https://echarts.apache.org/en/option.html#yAxis.axisLabel.formatter) for more details) | string \| ((value: string, index: number) => string) \| { [key: string]: string } |         |

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -26,7 +26,7 @@ import { Chart, Line, Grid, XAxis, YAxis } from '@lg-charts/core';
 <Chart>
   <Grid vertical={false}>
   <XAxis type="time" />
-  <YAxis type="value" formatter="{value}GB" />
+  <YAxis type="value" formatter={(value) => `${value}GB`} />
   <Line
     name="Series 1"
     data={[

--- a/charts/core/src/XAxis/XAxis.tsx
+++ b/charts/core/src/XAxis/XAxis.tsx
@@ -14,13 +14,13 @@ import {
 import { ChartOptions } from '../Chart/Chart.types';
 import { useChartContext } from '../ChartContext';
 
-import { XAxisProps, XAxisType } from './XAxis.types';
+import { XAxisProps } from './XAxis.types';
 
 const getOptions = ({
   theme,
   type,
   label,
-  unit,
+  formatter,
 }: XAxisProps & { theme: Theme }): Partial<ChartOptions> => {
   const options: Partial<ChartOptions> = {
     xAxis: {
@@ -42,10 +42,7 @@ const getOptions = ({
         color: color[theme].text[Variant.Secondary][InteractionState.Default],
         align: 'center',
         margin: spacing[400],
-        formatter:
-          unit && type === XAxisType.Value
-            ? (value: string) => `${value}${unit}`
-            : undefined,
+        formatter,
       },
       axisTick: {
         show: false,
@@ -87,17 +84,17 @@ const getOptions = ({
  *   <XAxis
  *     type="time",
  *     label="My X-Axis Data",
- *     unit="GB"
+ *     formatter="{value}GB"
  *   />
  * </Chart>
  */
-export function XAxis({ type, label, unit }: XAxisProps) {
+export function XAxis({ type, label, formatter }: XAxisProps) {
   const { updateChartOptions } = useChartContext();
   const { theme } = useDarkMode();
 
   useEffect(() => {
-    updateChartOptions(getOptions({ type, label, unit, theme }));
-  }, [type, label, unit, theme, updateChartOptions]);
+    updateChartOptions(getOptions({ type, label, formatter, theme }));
+  }, [type, label, formatter, theme, updateChartOptions]);
 
   return null;
 }

--- a/charts/core/src/XAxis/XAxis.types.ts
+++ b/charts/core/src/XAxis/XAxis.types.ts
@@ -22,17 +22,8 @@ export interface XAxisProps {
    * Formatter of axis label, which supports string template and callback function.
    *
    * ```ts
-   * // Use string template; template variable is the default label of axis {value}
-   * formatter: '{value} kg'
-   *
-   * // Use callback.
-   * formatter: function (value, index) {
-   *   return value + 'kg';
-   *}
+   * formatter: (value, index) => `${value}GB`
    * ```
    */
-  formatter?:
-    | string
-    | ((value: string, index: number) => string)
-    | { [key: string]: string };
+  formatter?: (value: string, index: number) => string;
 }

--- a/charts/core/src/XAxis/XAxis.types.ts
+++ b/charts/core/src/XAxis/XAxis.types.ts
@@ -18,7 +18,18 @@ export interface XAxisProps {
   label?: string;
 
   /**
-   * Unit of the axis to be rendered with value.
+   *
+   * Formatter of axis label, which supports string template and callback function.
+   *
+   * ```ts
+   * // Use string template; template variable is the default label of axis {value}
+   * formatter: '{value} kg'
+   *
+   * // Use callback.
+   * formatter: function (value, index) {
+   *   return value + 'kg';
+   *}
+   * ```
    */
-  unit?: string;
+  formatter?: string | ((value: string, index: number) => string);
 }

--- a/charts/core/src/XAxis/XAxis.types.ts
+++ b/charts/core/src/XAxis/XAxis.types.ts
@@ -31,5 +31,8 @@ export interface XAxisProps {
    *}
    * ```
    */
-  formatter?: string | ((value: string, index: number) => string);
+  formatter?:
+    | string
+    | ((value: string, index: number) => string)
+    | { [key: string]: string };
 }

--- a/charts/core/src/YAxis/YAxis.tsx
+++ b/charts/core/src/YAxis/YAxis.tsx
@@ -14,13 +14,13 @@ import {
 import { ChartOptions } from '../Chart/Chart.types';
 import { useChartContext } from '../ChartContext';
 
-import { YAxisProps, YAxisType } from './YAxis.types';
+import { YAxisProps } from './YAxis.types';
 
 const getOptions = ({
   theme,
   type,
   label,
-  unit,
+  formatter,
 }: YAxisProps & { theme: Theme }): Partial<ChartOptions> => {
   const options: Partial<ChartOptions> = {
     yAxis: {
@@ -42,10 +42,7 @@ const getOptions = ({
         color: color[theme].text[Variant.Secondary][InteractionState.Default],
         align: 'right',
         margin: spacing[200],
-        formatter:
-          unit && type === YAxisType.Value
-            ? (value: string) => `${value}${unit}`
-            : undefined,
+        formatter,
       },
       axisTick: {
         show: false,
@@ -86,17 +83,17 @@ const getOptions = ({
  *   <YAxis
  *     type="value",
  *     label="My Y-Axis Data",
- *     unit="GB"
+ *     formatter="{value}GB"
  *   />
  * </Chart>
  */
-export function YAxis({ type, label, unit }: YAxisProps) {
+export function YAxis({ type, label, formatter }: YAxisProps) {
   const { updateChartOptions } = useChartContext();
   const { theme } = useDarkMode();
 
   useEffect(() => {
-    updateChartOptions(getOptions({ type, label, unit, theme }));
-  }, [type, label, unit, theme, updateChartOptions]);
+    updateChartOptions(getOptions({ type, label, formatter, theme }));
+  }, [type, label, formatter, theme, updateChartOptions]);
 
   return null;
 }

--- a/charts/core/src/YAxis/YAxis.types.ts
+++ b/charts/core/src/YAxis/YAxis.types.ts
@@ -32,5 +32,8 @@ export interface YAxisProps {
    *}
    * ```
    */
-  formatter?: string | ((value: string, index: number) => string);
+  formatter?:
+    | string
+    | ((value: string, index: number) => string)
+    | { [key: string]: string };
 }

--- a/charts/core/src/YAxis/YAxis.types.ts
+++ b/charts/core/src/YAxis/YAxis.types.ts
@@ -19,7 +19,18 @@ export interface YAxisProps {
   label?: string;
 
   /**
-   * Unit of the axis to be rendered with value. Only applies if `type` of `value`.
+   *
+   * Formatter of axis label, which supports string template and callback function.
+   *
+   * ```ts
+   * // Use string template; template variable is the default label of axis {value}
+   * formatter: '{value} kg'
+   *
+   * // Use callback.
+   * formatter: function (value, index) {
+   *   return value + 'kg';
+   *}
+   * ```
    */
-  unit?: string;
+  formatter?: string | ((value: string, index: number) => string);
 }

--- a/charts/core/src/YAxis/YAxis.types.ts
+++ b/charts/core/src/YAxis/YAxis.types.ts
@@ -23,17 +23,11 @@ export interface YAxisProps {
    * Formatter of axis label, which supports string template and callback function.
    *
    * ```ts
-   * // Use string template; template variable is the default label of axis {value}
-   * formatter: '{value} kg'
-   *
    * // Use callback.
    * formatter: function (value, index) {
    *   return value + 'kg';
    *}
    * ```
    */
-  formatter?:
-    | string
-    | ((value: string, index: number) => string)
-    | { [key: string]: string };
+  formatter?: (value: string, index: number) => string;
 }

--- a/charts/core/src/core.stories.tsx
+++ b/charts/core/src/core.stories.tsx
@@ -43,10 +43,10 @@ export default {
         category: 'XAxis',
       },
     },
-    xAxisUnit: {
+    xAxisFormatter: {
       control: 'text',
-      description: 'X-axis units',
-      name: 'Unit',
+      description: 'X-axis formatter',
+      name: 'Formatter',
       table: {
         category: 'XAxis',
       },
@@ -68,10 +68,10 @@ export default {
         category: 'YAxis',
       },
     },
-    yAxisUnit: {
+    yAxisFormatter: {
       control: 'text',
-      description: 'Y-axis units',
-      name: 'Unit',
+      description: 'Y-axis formatter',
+      name: 'Formatter',
       table: {
         category: 'YAxis',
       },
@@ -103,8 +103,8 @@ interface StoryChartProps {
   horizontalGridLines: boolean;
   xAxisType: XAxisProps['type'];
   yAxisType: YAxisProps['type'];
-  xAxisUnit: string;
-  yAxisUnit: string;
+  xAxisFormatter: string;
+  yAxisFormatter: string;
   xAxisLabel: string;
   yAxisLabel: string;
 }
@@ -115,9 +115,9 @@ const Template: React.FC<StoryChartProps> = props => {
     verticalGridLines,
     horizontalGridLines,
     xAxisType,
-    xAxisUnit,
+    xAxisFormatter,
     yAxisType,
-    yAxisUnit,
+    yAxisFormatter,
     xAxisLabel,
     yAxisLabel,
   } = props;
@@ -125,8 +125,8 @@ const Template: React.FC<StoryChartProps> = props => {
   return (
     <Chart {...props}>
       <Grid vertical={verticalGridLines} horizontal={horizontalGridLines} />
-      <XAxis type={xAxisType} unit={xAxisUnit} label={xAxisLabel} />
-      <YAxis type={yAxisType} unit={yAxisUnit} label={yAxisLabel} />
+      <XAxis type={xAxisType} formatter={xAxisFormatter} label={xAxisLabel} />
+      <YAxis type={yAxisType} formatter={yAxisFormatter} label={yAxisLabel} />
       {data.map(({ name, data }) => (
         <Line name={name} data={data} key={name} />
       ))}
@@ -141,6 +141,5 @@ LiveExample.args = {
   verticalGridLines: false,
   xAxisType: 'time',
   yAxisType: 'value',
-  xAxisUnit: '',
-  yAxisUnit: 'GB',
+  yAxisFormatter: '{value}GB',
 };

--- a/charts/core/src/core.stories.tsx
+++ b/charts/core/src/core.stories.tsx
@@ -44,11 +44,10 @@ export default {
       },
     },
     xAxisFormatter: {
-      control: 'text',
       description: 'X-axis formatter',
       name: 'Formatter',
       table: {
-        category: 'XAxis',
+        disable: true,
       },
     },
     xAxisLabel: {
@@ -69,11 +68,10 @@ export default {
       },
     },
     yAxisFormatter: {
-      control: 'text',
       description: 'Y-axis formatter',
       name: 'Formatter',
       table: {
-        category: 'YAxis',
+        disable: true,
       },
     },
     yAxisLabel: {
@@ -103,10 +101,10 @@ interface StoryChartProps {
   horizontalGridLines: boolean;
   xAxisType: XAxisProps['type'];
   yAxisType: YAxisProps['type'];
-  xAxisFormatter: string;
-  yAxisFormatter: string;
-  xAxisLabel: string;
-  yAxisLabel: string;
+  xAxisFormatter: XAxisProps['formatter'];
+  yAxisFormatter: XAxisProps['formatter'];
+  xAxisLabel: XAxisProps['label'];
+  yAxisLabel: YAxisProps['label'];
 }
 
 const Template: React.FC<StoryChartProps> = props => {
@@ -141,6 +139,5 @@ LiveExample.args = {
   verticalGridLines: false,
   xAxisType: 'time',
   yAxisType: 'value',
-  xAxisFormatter: '{hh}:{mm}',
-  yAxisFormatter: '{value}GB',
+  yAxisFormatter: value => `${value}GB`,
 };

--- a/charts/core/src/core.stories.tsx
+++ b/charts/core/src/core.stories.tsx
@@ -141,5 +141,6 @@ LiveExample.args = {
   verticalGridLines: false,
   xAxisType: 'time',
   yAxisType: 'value',
+  xAxisFormatter: '{hh}:{mm}',
   yAxisFormatter: '{value}GB',
 };


### PR DESCRIPTION
## ✍️ Proposed changes
- Replace `unit` prop of `XAxis` and `YAxis` with `formatter` prop.

🎟 _Jira ticket:_ [LG-4659](https://jira.mongodb.org/browse/LG-4659)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- Use it in Storybook