### PR TITLE
LG-4680:  `Tabs` removes `setSelectedd` prop

### DIFF
--- a/.changeset/red-goats-doubt.md
+++ b/.changeset/red-goats-doubt.md
@@ -1,5 +1,5 @@
 ---
-'@leafygreen-ui/tabs': major
+'@leafygreen-ui/tabs': patch
 ---
 
-Remove incorrect `setSelectedd` prop
+Removes incorrect `setSelectedd` prop. `setSelected` is the correct prop.

--- a/.changeset/red-goats-doubt.md
+++ b/.changeset/red-goats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tabs': major
+---
+
+Remove incorrect `setSelectedd` prop

--- a/packages/tabs/src/Tabs/Tabs.types.ts
+++ b/packages/tabs/src/Tabs/Tabs.types.ts
@@ -72,7 +72,6 @@ export interface TabsProps<SelectedType extends number | string>
    * Callback to be executed when Tab is selected. Receives index or name of activated Tab as the first argument.
    */
   setSelected?: React.Dispatch<React.SetStateAction<SelectedType>>;
-  setSelectedd?: React.Dispatch<SelectedType>;
 
   /**
    * The size of the title. `size='small'` overrides `baseFontSize` to be `BaseFontSize.Body1`


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [LG-4680](https://jira.mongodb.org/browse/[LG-4680])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
