### PR TITLE
LG-4698: Allow choosing of axis for zoom selection 

### DIFF
--- a/.changeset/six-berries-dance.md
+++ b/.changeset/six-berries-dance.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': minor
+---
+
+Adds ability to enable zoom selection per axis individually.

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -86,10 +86,10 @@ Chart container component.
 
 | Name                        | Description                                                                   | Type                                   | Default                          |
 | --------------------------- | ----------------------------------------------------------------------------- | -------------------------------------- | -------------------------------- |
-| `onChartReady`              | Callback to be called when chart is finished rendering.                       | `() => void`                           |                                  |
-| `zoomSelect` _(optional)_   | Enable zoom select (click and drag area selection) for either axis.           | `{ xAxis?: boolean; yAxis?: boolean }` | `{ xAxis: false, yAxis: false }` |
-| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if enabled.               | `(e: ZoomSelectionEvent) => void`      |                                  |
 | `groupId` _(optional)_      | Charts with the same `groupId` will have their tooltips synced across charts. | `string`                               |                                  |
+| `onChartReady`              | Callback to be called when chart is finished rendering.                       | `() => void`                           |                                  |
+| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if enabled.               | `(e: ZoomSelectionEvent) => void`      |                                  |
+| `zoomSelect` _(optional)_   | Enable zoom select (click and drag area selection) for either axis.           | `{ xAxis?: boolean; yAxis?: boolean }` | `{ xAxis: false, yAxis: false }` |
 
 **Note**: Callback passed to `onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:
 

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -84,12 +84,12 @@ Chart container component.
 
 #### Props
 
-| Name                        | Description                                                                   | Type                                   | Default                          |
-| --------------------------- | ----------------------------------------------------------------------------- | -------------------------------------- | -------------------------------- |
-| `groupId` _(optional)_      | Charts with the same `groupId` will have their tooltips synced across charts. | `string`                               |                                  |
-| `onChartReady`              | Callback to be called when chart is finished rendering.                       | `() => void`                           |                                  |
-| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if enabled.               | `(e: ZoomSelectionEvent) => void`      |                                  |
-| `zoomSelect` _(optional)_   | Enable zoom select (click and drag area selection) for either axis.           | `{ xAxis?: boolean; yAxis?: boolean }` | `{ xAxis: false, yAxis: false }` |
+| Name                        | Description                                                                     | Type                                   | Default                          |
+| --------------------------- | ------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------- |
+| `groupId` _(optional)_      | Charts with the same `groupId` will have their tooltips synced across charts.   | `string`                               |                                  |
+| `onChartReady`              | Callback to be called when chart is finished rendering.                         | `() => void`                           |                                  |
+| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if `ZoomSelect` is enabled. | `(e: ZoomSelectionEvent) => void`      |                                  |
+| `zoomSelect` _(optional)_   | Enable zoom select (click and drag area selection) for either axis.             | `{ xAxis?: boolean; yAxis?: boolean }` | `{ xAxis: false, yAxis: false }` |
 
 **Note**: Callback passed to `onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:
 

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -84,15 +84,19 @@ Chart container component.
 
 #### Props
 
-| Name                        | Description                                                                                                                                   | Type                           | Default |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ------- |
-| `onChartReady`              | Callback to be called when chart is finished rendering.                                                                                       | `() => void`                   |         |
-| `onZoomSelect` _(optional)_ | Callback to be called when a user clicks and drags on a chart to zoom. Click and drag action will only be enabled if this handler is present. | `(ZoomSelectionEvent) => void` |         |
+| Name                      | Description                                             | Type                                                                                                                                                   | Default |
+| ------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `onChartReady`            | Callback to be called when chart is finished rendering. | `() => void`                                                                                                                                           |         |
+| `zoomSelect` _(optional)_ | Configuration for click and drag zoom selection.        | <pre><code>{</code><br><code> xAxis?: boolean</code><br><code> xAxis?: boolean</code><br><code> onZoomSelect?: function</code><br><code>}</code></pre> |         |
+
+**Note**: Callback passed to `zoomSelect.onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:
 
 ```ts
 ZoomSelectionEvent = {
-  xAxis: { startValue: number; endValue: number };
-  yAxis: { startValue: number; endValue: number };
+  // present if xAxis is enabled
+  xAxis?: { startValue: number; endValue: number };
+  // present if yAxis is enabled
+  yAxis?: { startValue: number; endValue: number };
 }
 ```
 

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -84,10 +84,11 @@ Chart container component.
 
 #### Props
 
-| Name                      | Description                                             | Type                                                                                                                                                   | Default |
-| ------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `onChartReady`            | Callback to be called when chart is finished rendering. | `() => void`                                                                                                                                           |         |
-| `zoomSelect` _(optional)_ | Configuration for click and drag zoom selection.        | <pre><code>{</code><br><code> xAxis?: boolean</code><br><code> xAxis?: boolean</code><br><code> onZoomSelect?: function</code><br><code>}</code></pre> |         |
+| Name                        | Description                                                         | Type                                   | Default                          |
+| --------------------------- | ------------------------------------------------------------------- | -------------------------------------- | -------------------------------- |
+| `onChartReady`              | Callback to be called when chart is finished rendering.             | `() => void`                           |                                  |
+| `zoomSelect` _(optional)_   | Enable zoom select (click and drag area selection) for either axis. | `{ xAxis?: boolean; yAxis?: boolean }` | `{ xAxis: false, yAxis: false }` |
+| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if enabled.     | `(e: ZoomSelectionEvent) => void`      |                                  |
 
 **Note**: Callback passed to `onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:
 

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -89,7 +89,7 @@ Chart container component.
 | `onChartReady`            | Callback to be called when chart is finished rendering. | `() => void`                                                                                                                                           |         |
 | `zoomSelect` _(optional)_ | Configuration for click and drag zoom selection.        | <pre><code>{</code><br><code> xAxis?: boolean</code><br><code> xAxis?: boolean</code><br><code> onZoomSelect?: function</code><br><code>}</code></pre> |         |
 
-**Note**: Callback passed to `zoomSelect.onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:
+**Note**: Callback passed to `onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:
 
 ```ts
 ZoomSelectionEvent = {

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -88,7 +88,7 @@ Chart container component.
 | --------------------------- | ------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------- |
 | `groupId` _(optional)_      | Charts with the same `groupId` will have their tooltips synced across charts.   | `string`                               |                                  |
 | `onChartReady`              | Callback to be called when chart is finished rendering.                         | `() => void`                           |                                  |
-| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if `ZoomSelect` is enabled. | `(e: ZoomSelectionEvent) => void`      |                                  |
+| `onZoomSelect` _(optional)_ | Callback to be called when a zoom selection is made if `zoomSelect` is enabled. | `(e: ZoomSelectionEvent) => void`      |                                  |
 | `zoomSelect` _(optional)_   | Enable zoom select (click and drag area selection) for either axis.             | `{ xAxis?: boolean; yAxis?: boolean }` | `{ xAxis: false, yAxis: false }` |
 
 **Note**: Callback passed to `onZoomSelect` callback receives the following `ZoomSelectionEvent` as an argument:

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -364,3 +364,80 @@ export const WithHeaderContent: StoryObj<StorybookProps> = {
     );
   },
 };
+
+export const WithZoom: StoryObj<StorybookProps> = {
+  render: ({
+    data,
+    verticalGridLines,
+    horizontalGridLines,
+    renderGrid,
+    renderXAxis,
+    renderYAxis,
+    xAxisType,
+    xAxisFormatter,
+    yAxisType,
+    yAxisFormatter,
+    xAxisLabel,
+    yAxisLabel,
+    renderTooltip,
+    tooltipSortDirection,
+    tooltipSortKey,
+    tooltipValueFormatter,
+    renderHeader,
+    headerTitle,
+    headerShowDivider,
+  }) => {
+    return (
+      <Chart
+        zoomSelect={{
+          // xAxis: true,
+          yAxis: true,
+        }}
+      >
+        {renderHeader && (
+          <Header
+            title={headerTitle}
+            showDivider={headerShowDivider}
+            headerContent={
+              <div style={{ display: 'flex', justifyContent: 'right' }}>
+                <IconButton aria-label="FullScreen">
+                  <Icon glyph="FullScreenEnter" />
+                </IconButton>
+                <IconButton aria-label="Close">
+                  <Icon glyph="X" />
+                </IconButton>
+              </div>
+            }
+          />
+        )}
+        {renderGrid && (
+          <Grid vertical={verticalGridLines} horizontal={horizontalGridLines} />
+        )}
+        {renderTooltip && (
+          <Tooltip
+            sortDirection={tooltipSortDirection}
+            sortKey={tooltipSortKey}
+            valueFormatter={tooltipValueFormatter}
+          />
+        )}
+        {renderXAxis && (
+          <XAxis
+            type={xAxisType}
+            formatter={xAxisFormatter}
+            label={xAxisLabel}
+          />
+        )}
+        {renderYAxis && (
+          <YAxis
+            type={yAxisType}
+            formatter={yAxisFormatter}
+            label={yAxisLabel}
+          />
+        )}
+        {data.map(({ name, data }) => (
+          <Line name={name} data={data} key={name} />
+        ))}
+      </Chart>
+    );
+  },
+};

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storybookArgTypes } from '@lg-tools/storybook-utils';
+import { action } from '@storybook/addon-actions';
 import type { StoryObj } from '@storybook/react';
 
 import Icon from '@leafygreen-ui/icon';
@@ -39,6 +40,9 @@ export default {
     renderHeader: true,
     headerTitle: 'LeafyGreen Chart Header',
     headerShowDivider: true,
+    zoomSelectXAxis: true,
+    zoomSelectYAxis: true,
+    zoomSelectCallback: action('onZoomSelect'),
   },
   argTypes: {
     darkMode: storybookArgTypes.darkMode,
@@ -201,12 +205,25 @@ export default {
         category: 'Header',
       },
     },
-    onZoomSelect: {
-      description: 'Zoom handler',
-      name: 'onZoomSelect',
+    zoomSelect: {
       table: {
-        category: 'Chart',
         disable: true,
+      },
+    },
+    zoomSelectXAxis: {
+      control: 'boolean',
+      description: 'Enable zoom selection on x-axis',
+      name: 'XAxis',
+      table: {
+        category: 'ZoomSelect',
+      },
+    },
+    zoomSelectYAxis: {
+      control: 'boolean',
+      description: 'Enable zoom selection on y-axis',
+      name: 'YAxis',
+      table: {
+        category: 'ZoomSelect',
       },
     },
   },
@@ -232,6 +249,9 @@ interface StorybookProps {
   renderHeader: boolean;
   headerTitle: HeaderProps['title'];
   headerShowDivider: HeaderProps['showDivider'];
+  zoomSelectXAxis: boolean;
+  zoomSelectYAxis: boolean;
+  zoomSelectCallback;
 }
 
 export const Basic: StoryObj<StorybookProps> = {
@@ -255,9 +275,18 @@ export const Basic: StoryObj<StorybookProps> = {
     renderHeader,
     headerTitle,
     headerShowDivider,
+    zoomSelectXAxis,
+    zoomSelectYAxis,
+    zoomSelectCallback,
   }) => {
     return (
-      <Chart>
+      <Chart
+        zoomSelect={{
+          xAxis: zoomSelectXAxis,
+          yAxis: zoomSelectYAxis,
+          onZoomSelect: zoomSelectCallback,
+        }}
+      >
         {renderHeader && (
           <Header title={headerTitle} showDivider={headerShowDivider} />
         )}
@@ -314,84 +343,16 @@ export const WithHeaderContent: StoryObj<StorybookProps> = {
     renderHeader,
     headerTitle,
     headerShowDivider,
-  }) => {
-    return (
-      <Chart>
-        {renderHeader && (
-          <Header
-            title={headerTitle}
-            showDivider={headerShowDivider}
-            headerContent={
-              <div style={{ display: 'flex', justifyContent: 'right' }}>
-                <IconButton aria-label="FullScreen">
-                  <Icon glyph="FullScreenEnter" />
-                </IconButton>
-                <IconButton aria-label="Close">
-                  <Icon glyph="X" />
-                </IconButton>
-              </div>
-            }
-          />
-        )}
-        {renderGrid && (
-          <Grid vertical={verticalGridLines} horizontal={horizontalGridLines} />
-        )}
-        {renderTooltip && (
-          <Tooltip
-            sortDirection={tooltipSortDirection}
-            sortKey={tooltipSortKey}
-            valueFormatter={tooltipValueFormatter}
-          />
-        )}
-        {renderXAxis && (
-          <XAxis
-            type={xAxisType}
-            formatter={xAxisFormatter}
-            label={xAxisLabel}
-          />
-        )}
-        {renderYAxis && (
-          <YAxis
-            type={yAxisType}
-            formatter={yAxisFormatter}
-            label={yAxisLabel}
-          />
-        )}
-        {data.map(({ name, data }) => (
-          <Line name={name} data={data} key={name} />
-        ))}
-      </Chart>
-    );
-  },
-};
-
-export const WithZoom: StoryObj<StorybookProps> = {
-  render: ({
-    data,
-    verticalGridLines,
-    horizontalGridLines,
-    renderGrid,
-    renderXAxis,
-    renderYAxis,
-    xAxisType,
-    xAxisFormatter,
-    yAxisType,
-    yAxisFormatter,
-    xAxisLabel,
-    yAxisLabel,
-    renderTooltip,
-    tooltipSortDirection,
-    tooltipSortKey,
-    tooltipValueFormatter,
-    renderHeader,
-    headerTitle,
-    headerShowDivider,
+    zoomSelectXAxis,
+    zoomSelectYAxis,
+    zoomSelectCallback,
   }) => {
     return (
       <Chart
         zoomSelect={{
-          // xAxis: true,
-          yAxis: true,
+          xAxis: zoomSelectXAxis,
+          yAxis: zoomSelectYAxis,
+          onZoomSelect: zoomSelectCallback,
         }}
       >
         {renderHeader && (

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -226,6 +226,16 @@ export default {
         category: 'ZoomSelect',
       },
     },
+    onZoomSelect: {
+      table: {
+        disable: true,
+      },
+    },
+    zoomSelectCallback: {
+      table: {
+        disable: true,
+      },
+    },
   },
 };
 
@@ -284,8 +294,8 @@ export const Basic: StoryObj<StorybookProps> = {
         zoomSelect={{
           xAxis: zoomSelectXAxis,
           yAxis: zoomSelectYAxis,
-          onZoomSelect: zoomSelectCallback,
         }}
+        onZoomSelect={zoomSelectCallback}
       >
         {renderHeader && (
           <Header title={headerTitle} showDivider={headerShowDivider} />
@@ -352,8 +362,8 @@ export const WithHeaderContent: StoryObj<StorybookProps> = {
         zoomSelect={{
           xAxis: zoomSelectXAxis,
           yAxis: zoomSelectYAxis,
-          onZoomSelect: zoomSelectCallback,
         }}
+        onZoomSelect={zoomSelectCallback}
       >
         {renderHeader && (
           <Header

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -23,6 +23,7 @@ export function Chart({
   darkMode: darkModeProp,
   onChartReady,
   zoomSelect,
+  onZoomSelect,
   className,
   ...rest
 }: ChartProps) {
@@ -37,6 +38,7 @@ export function Chart({
     theme,
     onChartReady,
     zoomSelect,
+    onZoomSelect,
   });
 
   return (

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -22,7 +22,7 @@ export function Chart({
   children,
   darkMode: darkModeProp,
   onChartReady,
-  onZoomSelect,
+  zoomSelect,
   className,
   ...rest
 }: ChartProps) {
@@ -36,7 +36,7 @@ export function Chart({
   } = useChart({
     theme,
     onChartReady,
-    onZoomSelect,
+    zoomSelect,
   });
 
   return (

--- a/charts/core/src/Chart/Chart.types.ts
+++ b/charts/core/src/Chart/Chart.types.ts
@@ -13,7 +13,7 @@ import type { ComposeOption } from 'echarts/core';
 
 import { DarkModeProps, type HTMLElementProps } from '@leafygreen-ui/lib';
 
-import { ZoomSelectionEvent } from './hooks/useChart.types';
+import { zoomSelect } from './hooks/useChart.types';
 
 type RequiredSeriesProps = 'type' | 'name' | 'data';
 export type SeriesOption = Pick<LineSeriesOption, RequiredSeriesProps> &
@@ -45,10 +45,9 @@ export type ChartProps = HTMLElementProps<'div'> &
     onChartReady?: () => void;
 
     /**
-     * Callback to be called when a user clicks and drags on a chart to zoom.
-     * Click and drag action will only be enabled if this handler is present.
+     * Zoom selection configuration.
      */
-    onZoomSelect?: (e: ZoomSelectionEvent) => void;
+    zoomSelect?: zoomSelect;
   }>;
 
 export const ChartActionType = {

--- a/charts/core/src/Chart/Chart.types.ts
+++ b/charts/core/src/Chart/Chart.types.ts
@@ -13,7 +13,7 @@ import type { ComposeOption } from 'echarts/core';
 
 import { DarkModeProps, type HTMLElementProps } from '@leafygreen-ui/lib';
 
-import { zoomSelect } from './hooks/useChart.types';
+import { ZoomSelect, ZoomSelectionEvent } from './hooks/useChart.types';
 
 type RequiredSeriesProps = 'type' | 'name' | 'data';
 export type SeriesOption = Pick<LineSeriesOption, RequiredSeriesProps> &
@@ -47,7 +47,12 @@ export type ChartProps = HTMLElementProps<'div'> &
     /**
      * Zoom selection configuration.
      */
-    zoomSelect?: zoomSelect;
+    zoomSelect?: ZoomSelect;
+
+    /**
+     * Zoom selection enablement configuration.
+     */
+    onZoomSelect?: (e: ZoomSelectionEvent) => void;
   }>;
 
 export const ChartActionType = {

--- a/charts/core/src/Chart/hooks/useChart.ts
+++ b/charts/core/src/Chart/hooks/useChart.ts
@@ -83,6 +83,10 @@ export function useChart({
           };
           onZoomSelect(zoomEventResponse);
         }
+      } else {
+        console.error(
+          'zoomSelect configuration provided without any axes props. Either xAxis or yAxis must be set.',
+        );
       }
     }
 

--- a/charts/core/src/Chart/hooks/useChart.ts
+++ b/charts/core/src/Chart/hooks/useChart.ts
@@ -41,7 +41,12 @@ echarts.use([
  * Creates a generic Apache ECharts options object with default values for those not set
  * that are in line with the designs and needs of the design system.
  */
-export function useChart({ theme, onChartReady, zoomSelect }: ChartHookProps) {
+export function useChart({
+  theme,
+  onChartReady,
+  zoomSelect,
+  onZoomSelect,
+}: ChartHookProps) {
   const chartRef = useRef(null);
   const chartInstanceRef = useRef<echarts.EChartsType | undefined>();
   const [chartOptions, setChartOptions] = useState(
@@ -49,12 +54,12 @@ export function useChart({ theme, onChartReady, zoomSelect }: ChartHookProps) {
   );
 
   function handleDataZoom(params: any) {
-    if (zoomSelect?.onZoomSelect) {
+    if (onZoomSelect) {
       if (zoomSelect?.xAxis && zoomSelect?.yAxis) {
         if (params.batch) {
           const { startValue: xStart, endValue: xEnd } = params.batch[0];
           const { startValue: yStart, endValue: yEnd } = params.batch[1];
-          zoomSelect.onZoomSelect({
+          onZoomSelect({
             xAxis: { startValue: xStart, endValue: xEnd },
             yAxis: { startValue: yStart, endValue: yEnd },
           });
@@ -68,14 +73,14 @@ export function useChart({ theme, onChartReady, zoomSelect }: ChartHookProps) {
             startValue: params.startValue,
             endValue: params.endValue,
           };
-          zoomSelect.onZoomSelect(zoomEventResponse);
+          onZoomSelect(zoomEventResponse);
         } else if (params.batch) {
           const { startValue, endValue } = params.batch[0];
           zoomEventResponse[axis] = {
             startValue,
             endValue,
           };
-          zoomSelect.onZoomSelect(zoomEventResponse);
+          onZoomSelect(zoomEventResponse);
         }
       }
     }

--- a/charts/core/src/Chart/hooks/useChart.types.ts
+++ b/charts/core/src/Chart/hooks/useChart.types.ts
@@ -5,21 +5,24 @@ export interface ZoomSelectionEvent {
   yAxis?: { startValue: number; endValue: number };
 }
 
-export interface ZoomSelect {
-  /**
-   * Should zoom selection be enabled on the x-axis.
-   */
-  xAxis?: boolean;
-
-  /**
-   * Should zoom selection be enabled on the y-axis.
-   */
-  yAxis?: boolean;
-}
+export type ZoomSelect =
+  | {
+      xAxis: boolean;
+      yAxis?: boolean;
+    }
+  | {
+      xAxis?: boolean;
+      yAxis: boolean;
+    }
+  | undefined;
 
 export interface ChartHookProps {
-  groupId?: string;
   theme: Theme;
+
+  /**
+   * Charts with the same `groupId` will have their tooltips synced across charts.
+   */
+  groupId?: string;
 
   /**
    * Callback to be called when chart is finished rendering.

--- a/charts/core/src/Chart/hooks/useChart.types.ts
+++ b/charts/core/src/Chart/hooks/useChart.types.ts
@@ -5,7 +5,7 @@ export interface ZoomSelectionEvent {
   yAxis?: { startValue: number; endValue: number };
 }
 
-export interface zoomSelect {
+export interface ZoomSelect {
   /**
    * Should zoom selection be enabled on the x-axis.
    */
@@ -15,15 +15,23 @@ export interface zoomSelect {
    * Should zoom selection be enabled on the y-axis.
    */
   yAxis?: boolean;
+}
+
+export interface ChartHookProps {
+  theme: Theme;
+
+  /**
+   * Callback to be called when chart is finished rendering.
+   */
+  onChartReady?: () => void;
+
+  /**
+   * Zoom selection enablement configuration.
+   */
+  zoomSelect?: ZoomSelect;
 
   /**
    * Callback to be called when a zoom selection is made.
    */
   onZoomSelect?: (e: ZoomSelectionEvent) => void;
-}
-
-export interface ChartHookProps {
-  onChartReady?: () => void;
-  zoomSelect?: zoomSelect;
-  theme: Theme;
 }

--- a/charts/core/src/Chart/hooks/useChart.types.ts
+++ b/charts/core/src/Chart/hooks/useChart.types.ts
@@ -1,12 +1,29 @@
 import { Theme } from '@leafygreen-ui/lib';
 
 export interface ZoomSelectionEvent {
-  xAxis: { startValue: number; endValue: number };
-  yAxis: { startValue: number; endValue: number };
+  xAxis?: { startValue: number; endValue: number };
+  yAxis?: { startValue: number; endValue: number };
+}
+
+export interface zoomSelect {
+  /**
+   * Should zoom selection be enabled on the x-axis.
+   */
+  xAxis?: boolean;
+
+  /**
+   * Should zoom selection be enabled on the y-axis.
+   */
+  yAxis?: boolean;
+
+  /**
+   * Callback to be called when a zoom selection is made.
+   */
+  onZoomSelect?: (e: ZoomSelectionEvent) => void;
 }
 
 export interface ChartHookProps {
   onChartReady?: () => void;
-  onZoomSelect?: (e: ZoomSelectionEvent) => void;
+  zoomSelect?: zoomSelect;
   theme: Theme;
 }


### PR DESCRIPTION
## ✍️ Proposed changes

It was an ask from consumers that they be able to optionally turn zoom selection on and off for axis. This change primarily adds that.

Note, this also updates the component's props. Previously we decided to just allow the handler to turn off and on the select-ability. Since now there is an option to enable it by axis, it made sense to just create a `zoomSelect` prop, that configures zoom selection. I like this approach better as a) the name `zoomSelect` clearer communicates that we're not actually zooming on data, and b) it removes the implied enablement of the previous design that none of us were crazy about.

🎟 _Jira ticket:_ [LG-4698](https://jira.mongodb.org/browse/LG-4698)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
Added to storybook so it can now be tested there.