### PR TITLE
LG-4703: Fix large `Tooltip` being cutoff by `ChartCard`

### DIFF
--- a/.changeset/perfect-cups-film.md
+++ b/.changeset/perfect-cups-film.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Prevents large tooltips from being cutoff my `ChartCard`

--- a/charts/core/src/ChartCard/ChartCard.stories.tsx
+++ b/charts/core/src/ChartCard/ChartCard.stories.tsx
@@ -90,7 +90,26 @@ export const ContainingChart: StoryObj<ChartCardProps> = {
           <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
           <XAxis type="time" />
           <YAxis type="value" />
-          {makeLineData(50).map(({ name, data }) => (
+          {makeLineData(10).map(({ name, data }) => (
+            <Line name={name} data={data} key={name} />
+          ))}
+        </Chart>
+      </ChartCard>
+    );
+  },
+};
+
+export const ContainingChartWithOverflowingTooltip: StoryObj<ChartCardProps> = {
+  render: ({ chartCardTitle }) => {
+    return (
+      <ChartCard title={chartCardTitle}>
+        <Chart>
+          <Header title="Chart 1" showDivider />
+          <Grid vertical={false} />
+          <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
+          <XAxis type="time" />
+          <YAxis type="value" />
+          {makeLineData(20).map(({ name, data }) => (
             <Line name={name} data={data} key={name} />
           ))}
         </Chart>

--- a/charts/core/src/ChartCard/ChartCard.stories.tsx
+++ b/charts/core/src/ChartCard/ChartCard.stories.tsx
@@ -90,7 +90,7 @@ export const ContainingChart: StoryObj<ChartCardProps> = {
           <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
           <XAxis type="time" />
           <YAxis type="value" />
-          {makeLineData(10).map(({ name, data }) => (
+          {makeLineData(50).map(({ name, data }) => (
             <Line name={name} data={data} key={name} />
           ))}
         </Chart>

--- a/charts/core/src/ChartCard/ChartCard.stories.tsx
+++ b/charts/core/src/ChartCard/ChartCard.stories.tsx
@@ -90,25 +90,6 @@ export const ContainingChart: StoryObj<ChartCardProps> = {
           <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
           <XAxis type="time" />
           <YAxis type="value" />
-          {makeLineData(10).map(({ name, data }) => (
-            <Line name={name} data={data} key={name} />
-          ))}
-        </Chart>
-      </ChartCard>
-    );
-  },
-};
-
-export const ContainingChartWithOverflowingTooltip: StoryObj<ChartCardProps> = {
-  render: ({ chartCardTitle }) => {
-    return (
-      <ChartCard title={chartCardTitle}>
-        <Chart>
-          <Header title="Chart 1" showDivider />
-          <Grid vertical={false} />
-          <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
-          <XAxis type="time" />
-          <YAxis type="value" />
           {makeLineData(20).map(({ name, data }) => (
             <Line name={name} data={data} key={name} />
           ))}
@@ -128,7 +109,7 @@ export const ContainingMultiCharts: StoryObj<ChartCardProps> = {
           <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
           <XAxis type="time" />
           <YAxis type="value" />
-          {makeLineData(10).map(({ name, data }) => (
+          {makeLineData(20).map(({ name, data }) => (
             <Line name={name} data={data} key={name} />
           ))}
         </Chart>
@@ -138,7 +119,7 @@ export const ContainingMultiCharts: StoryObj<ChartCardProps> = {
           <Tooltip sortDirection={SortDirection.Desc} sortKey={SortKey.Value} />
           <XAxis type="time" />
           <YAxis type="value" />
-          {makeLineData(10).map(({ name, data }) => (
+          {makeLineData(20).map(({ name, data }) => (
             <Line name={name} data={data} key={name} />
           ))}
         </Chart>

--- a/charts/core/src/Tooltip/Tooltip.tsx
+++ b/charts/core/src/Tooltip/Tooltip.tsx
@@ -35,6 +35,7 @@ export function Tooltip({
         borderRadius: borderRadius[200],
         borderWidth: 0,
         confine: true,
+        appendTo: 'body',
         enterable: false,
         hideDelay: 0,
         valueFormatter: valueFormatter


### PR DESCRIPTION
## ✍️ Proposed changes
Appends the `Tooltip` to `body` in order to prevent the cutoff, as proposed in solution here: https://github.com/apache/echarts/issues/5955

🎟 _Jira ticket:_ [LG-4703](https://jira.mongodb.org/browse/LG-4703)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
I have added more lines to all `ChartCard` stories to show that it's working

## Screenshots
### Before
<img width="1063" alt="Screenshot 2024-12-06 at 9 57 09 AM" src="https://github.com/user-attachments/assets/c4b9399c-35d7-4856-93c3-4b73dea234c8">

### After
<img width="1050" alt="Screenshot 2024-12-06 at 9 56 51 AM" src="https://github.com/user-attachments/assets/6910c70d-74fc-4873-afa7-40c9d7fe32f4">

