### PR TITLE
LG-4714: Fix using `SplitButton` as a managed component

### DIFF
--- a/.changeset/tame-panthers-knock.md
+++ b/.changeset/tame-panthers-knock.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/split-button': patch
+---
+
+Fix using `SplitButton` as a managed component by calling the `setOpen` function passed as prop when clicking the trigger.

--- a/packages/split-button/src/Menu/Menu.tsx
+++ b/packages/split-button/src/Menu/Menu.tsx
@@ -58,9 +58,7 @@ export const Menu = ({
 
   const handleTriggerClick: MouseEventHandler = e => {
     onTriggerClick?.(e);
-    if (typeof controlledOpen !== 'boolean') {
-      setOpen(o => !o);
-    }
+    setOpen(o => !o);
   };
 
   const handleClose = useCallback(() => {

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -209,7 +209,7 @@ describe('packages/split-button', () => {
       document.body.appendChild(portalContainer);
       const portalRef = createRef<HTMLElement>();
       renderSplitButton({
-        open,
+        open: true,
         portalContainer,
         portalRef,
         renderMode: RenderMode.Portal,
@@ -255,9 +255,9 @@ describe('packages/split-button', () => {
         await waitForElementToBeRemoved(menuEl);
         expect(menuEl).not.toBeInTheDocument();
       });
-      test('Returns focus to trigger {usePortal: true}', async () => {
+      test('Returns focus to trigger {renderMode: "portal"}', async () => {
         const { openMenu, menuTrigger } = renderSplitButton({
-          usePortal: true,
+          renderMode: "portal"
         });
         const { menuEl } = await openMenu();
 
@@ -266,9 +266,9 @@ describe('packages/split-button', () => {
         expect(menuTrigger).toHaveFocus();
       });
 
-      test('Returns focus to trigger {usePortal: false}', async () => {
+      test('Returns focus to trigger {renderMode: "inline"}', async () => {
         const { openMenu, menuTrigger } = renderSplitButton({
-          usePortal: false,
+          renderMode: "inline"
         });
         const { menuEl } = await openMenu();
 

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -10,10 +10,12 @@ import {
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
+import { InferredPolymorphicPropsWithRef } from '@leafygreen-ui/polymorphic';
+import { Optional } from '@leafygreen-ui/lib';
 import { MenuItem } from '@leafygreen-ui/menu';
 import { RenderMode } from '@leafygreen-ui/popover';
 
-import { MenuItemsType } from './SplitButton.types';
+import { MenuItemsType, SplitButtonProps } from './SplitButton.types';
 import { SplitButton } from '.';
 
 const menuTestId = 'lg-split-button-menu';
@@ -36,7 +38,9 @@ const defaultProps = {
   menuItems: getMenuItems(),
 };
 
-function renderSplitButton(props = {}) {
+type RenderSplitButtonProps = Optional<InferredPolymorphicPropsWithRef<'button', SplitButtonProps>, keyof typeof defaultProps>;
+
+function renderSplitButton(props: RenderSplitButtonProps = {}) {
   const renderResult = render(
     <SplitButton data-testid="split-button" {...defaultProps} {...props} />,
   );

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -178,7 +178,7 @@ describe('packages/split-button', () => {
     test('trigger opens the menu when clicked', () => {
       const { menuTrigger, getByTestId } = renderSplitButton({});
 
-      fireEvent.click(menuTrigger as HTMLElement);
+      fireEvent.click(menuTrigger);
 
       const menu = getByTestId(menuTestId);
       expect(menu).toBeInTheDocument();
@@ -189,7 +189,7 @@ describe('packages/split-button', () => {
         disabled: true,
       });
 
-      fireEvent.click(menuTrigger as HTMLElement);
+      fireEvent.click(menuTrigger);
 
       const menu = queryByTestId(menuTestId);
       expect(menu).not.toBeInTheDocument();
@@ -198,7 +198,7 @@ describe('packages/split-button', () => {
     test('has correct menu items', () => {
       const { menuTrigger, getByTestId } = renderSplitButton({});
 
-      fireEvent.click(menuTrigger as HTMLElement);
+      fireEvent.click(menuTrigger);
 
       const menu = getByTestId(menuTestId);
       expect(menu.childElementCount).toEqual(4);
@@ -224,7 +224,7 @@ describe('packages/split-button', () => {
       const onChange = jest.fn();
       const { menuTrigger, getByTestId } = renderSplitButton({ onChange });
 
-      userEvent.click(menuTrigger as HTMLElement);
+      userEvent.click(menuTrigger);
 
       const menu = getByTestId(menuTestId);
       const options = globalGetAllByRole(menu, 'menuitem');

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -10,9 +10,9 @@ import {
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
-import { InferredPolymorphicPropsWithRef } from '@leafygreen-ui/polymorphic';
 import { Optional } from '@leafygreen-ui/lib';
 import { MenuItem } from '@leafygreen-ui/menu';
+import { InferredPolymorphicPropsWithRef } from '@leafygreen-ui/polymorphic';
 import { RenderMode } from '@leafygreen-ui/popover';
 
 import { MenuItemsType, SplitButtonProps } from './SplitButton.types';
@@ -38,7 +38,10 @@ const defaultProps = {
   menuItems: getMenuItems(),
 };
 
-type RenderSplitButtonProps = Optional<InferredPolymorphicPropsWithRef<'button', SplitButtonProps>, keyof typeof defaultProps>;
+type RenderSplitButtonProps = Optional<
+  InferredPolymorphicPropsWithRef<'button', SplitButtonProps>,
+  keyof typeof defaultProps
+>;
 
 function renderSplitButton(props: RenderSplitButtonProps = {}) {
   const renderResult = render(
@@ -267,7 +270,7 @@ describe('packages/split-button', () => {
       });
       test('Returns focus to trigger {renderMode: "portal"}', async () => {
         const { openMenu, menuTrigger } = renderSplitButton({
-          renderMode: "portal"
+          renderMode: 'portal',
         });
         const { menuEl } = await openMenu();
 
@@ -278,7 +281,7 @@ describe('packages/split-button', () => {
 
       test('Returns focus to trigger {renderMode: "inline"}', async () => {
         const { openMenu, menuTrigger } = renderSplitButton({
-          renderMode: "inline"
+          renderMode: 'inline',
         });
         const { menuEl } = await openMenu();
 

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -217,6 +217,16 @@ describe('packages/split-button', () => {
       expect(portalRef.current).toBeDefined();
       expect(portalRef.current).toBe(portalContainer);
     });
+
+    describe('managed', () => {
+      test('calls setOpen when triggered', () => {
+        const setOpen = jest.fn();
+        const { menuTrigger } = renderSplitButton({ open: false, setOpen });
+
+        userEvent.click(menuTrigger);
+        expect(setOpen).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('MenuItem', () => {


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

I propose removing a check for the `open` prop (`controlledOpen` internally) of the `SplitButton`'s internal `Menu` component to unconditionally call any `setOpen` function passed via props.

I've also included a few (hopefully not too controversial) improvements to the tests, now I was there. Let me know if I should split those into a separate PR 👍

🎟 _Jira ticket:_ [LG-4714](https://jira.mongodb.org/browse/LG-4714)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

## 🧪 How to test changes

I've added a failing test which pass after applying the fix.
