### PR TITLE
LG-4721: Fix `SplitButton`'s menu is rendered in dark-mode regardless of value passed through `renderDarkMenu`

### DIFF
--- a/.changeset/afraid-years-listen.md
+++ b/.changeset/afraid-years-listen.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/split-button': patch
+---
+
+Fix passing `renderDarkMenu` to the underlying `Menu`

--- a/packages/menu/src/Menu.stories.tsx
+++ b/packages/menu/src/Menu.stories.tsx
@@ -111,6 +111,8 @@ export default {
     },
     darkMode: storybookArgTypes.darkMode,
     renderDarkMenu: {
+      description:
+        'Whether the menu should always render dark, regardless of the theme context',
       control: 'boolean',
     },
   },

--- a/packages/split-button/src/SplitButton.stories.tsx
+++ b/packages/split-button/src/SplitButton.stories.tsx
@@ -89,6 +89,11 @@ const meta: StoryMetaType<typeof SplitButton> = {
   },
   argTypes: {
     darkMode: storybookArgTypes.darkMode,
+    renderDarkMenu: {
+      description:
+        'Whether the menu should always render dark, regardless of the theme context',
+      control: 'boolean',
+    },
     disabled: {
       control: 'boolean',
     },

--- a/packages/split-button/src/SplitButton/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.tsx
@@ -51,6 +51,7 @@ export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
       onTriggerClick,
       triggerAriaLabel,
       onChange,
+      renderDarkMenu,
       ...rest
     },
     ref: React.Ref<any>,
@@ -109,6 +110,7 @@ export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
             onTriggerClick={onTriggerClick}
             triggerAriaLabel={triggerAriaLabel}
             onChange={onChange}
+            renderDarkMenu={renderDarkMenu}
           />
         </LeafyGreenProvider>
       </div>


### PR DESCRIPTION
## ✍️ Proposed changes

The component's types declares that it takes a  `renderDarkMenu` prop, which isn't passed to the underlying `Menu` component. This makes it impossible for the consumer to force rendering a light menu in light-mode.

This PR suggests:
- Passing the prop to the `Menu`.
- Updating the storybook to reflect this.

🎟 _Jira ticket:_ [LG-4721](https://jira.mongodb.org/browse/LG-4721)

### NOTE: Avoiding future regressions

To avoid future regressions like this, I suggest using a `Pick` instead of an `Omit` (i.e. allowlist instead of denylist) in the declaration of the `SelectedMenuProps` type:

https://github.com/mongodb/leafygreen-ui/blob/3e821156e82f2ee6a486bb96174208501d3df767/packages/split-button/src/SplitButton/SplitButton.types.ts#L56-L68

I've provided a PR for that with #2602 and I didn't include it here since it's a breaking change in the API of the `SplitButton`.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

- Open the storybook UI and navigate to the `SplitButton` page.
- Toggle off the `darkMode` prop.
- Toggle off the `renderDarkMenu` prop.
- Click the right glyph on the button to have the menu drop down.
- See how the menu is rendered in light mode as expected.
