### PR TITLE
Refactored `SplitButton` (breaking)

### DIFF
--- a/.changeset/chilled-hounds-laugh.md
+++ b/.changeset/chilled-hounds-laugh.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/split-button': major
+---
+
+Update types to reflect what is actually being passed through to the underlying `Menu`

--- a/packages/split-button/src/SplitButton/SplitButton.types.ts
+++ b/packages/split-button/src/SplitButton/SplitButton.types.ts
@@ -53,18 +53,22 @@ type ButtonProps = Omit<
   'rightGlyph' | 'href' | 'as' | 'variant'
 >;
 
-export type SelectedMenuProps = Omit<
+export type SelectedMenuProps = Pick<
   ImportedMenuProps,
-  | 'children'
-  | 'trigger'
-  | 'shouldClose'
   | 'darkMode'
-  | 'onClick'
+  | 'maxHeight'
+  | 'adjustOnMutation'
+  | 'popoverZIndex'
+  | 'renderMode'
+  | 'portalClassName'
+  | 'portalContainer'
+  | 'portalRef'
+  | 'scrollContainer'
   | 'align'
   | 'justify'
-  | 'className'
-  | 'refEl'
-  | 'spacing'
+  | 'id'
+  | 'open'
+  | 'setOpen'
 >;
 
 export interface MenuProps extends SelectedMenuProps {


### PR DESCRIPTION
## ✍️ Proposed changes

As per my suggestion in https://github.com/mongodb/leafygreen-ui/pull/2601, future regressions could be avoided if the types derived from `MenuProps` intended for pass-through is allow-listed via a `Pick` instead of deny-listed via `Omit`.

This change is breaking, since it's removing a lot of props from the `SplitButton` which were never actually passed through to the `Menu`.

~This also optimize the internals by passing `darkMode` directly to child components instead of wrapping them in a new `LeafyGreenProvider` - this is not breaking, just a "drive-by" optimization.~

NOTE: If https://github.com/mongodb/leafygreen-ui/pull/2601 merge before this PR, it needs to be updated to add `renderDarkMenu` in the allow-list.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

- Add the `@leafygreen-ui/split-button` to a project
- Observe how the `onEnter` or `renderDarkMenu` props are available on the `SplitButton`.
- Apply this patch.
- Observe how the `onEnter` or `renderDarkMenu` props are no longer available on the `SplitButton`.
