### PR TITLE
Refactored SplitButton (breaking - more)

### DIFF
--- a/.changeset/chilled-hounds-laugh.md
+++ b/.changeset/chilled-hounds-laugh.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/split-button': major
+---
+
+Update types to reflect what is actually being passed through to the underlying `Menu`

--- a/packages/split-button/src/Menu/Menu.types.ts
+++ b/packages/split-button/src/Menu/Menu.types.ts
@@ -4,9 +4,23 @@ import {
 } from '../SplitButton/SplitButton.types';
 
 export type MenuProps = Required<
-  Pick<SplitButtonProps, 'variant' | 'size' | 'disabled'>
+  Pick<SplitButtonProps, 'variant' | 'size' | 'disabled' | 'onItemClick'>
 > &
   Pick<SplitButtonProps, 'baseFontSize'> &
   SBMenuProps & {
     containerRef: React.RefObject<HTMLElement>;
   };
+
+export type ItemClickHandlerOptions = {
+  /**
+   * Closes the menu.
+   */
+  close(): void;
+
+  /**
+   * The element being clicked.
+   */
+  element: React.ReactElement<unknown>;
+};
+
+export type ItemClickHandler = (event: React.MouseEvent<unknown>, options: ItemClickHandlerOptions) => void;

--- a/packages/split-button/src/Menu/index.ts
+++ b/packages/split-button/src/Menu/index.ts
@@ -1,1 +1,1 @@
-export { Menu } from './Menu';
+export { Menu, defaultItemClick } from './Menu';

--- a/packages/split-button/src/SplitButton.stories.tsx
+++ b/packages/split-button/src/SplitButton.stories.tsx
@@ -30,12 +30,12 @@ const meta: StoryMetaType<typeof SplitButton> = {
         ...storybookExcludedControlParams,
         'as',
         'children',
-        'menuItems',
         'href',
         'type',
         'maxHeight',
         'open',
         'onTriggerClick',
+        'onItemClick',
         'triggerAriaLabel',
       ],
     },
@@ -74,7 +74,7 @@ const meta: StoryMetaType<typeof SplitButton> = {
     variant: Variant.Default,
     align: Align.Bottom,
     justify: Justify.End,
-    menuItems: [
+    children: [
       <MenuItem key="0" onClick={(event: MouseEvent) => console.log(event)}>
         Menu Item
       </MenuItem>,

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -33,7 +33,7 @@ const getMenuItems = (): MenuItemsType => {
 
 const defaultProps = {
   label: 'Button Label',
-  menuItems: getMenuItems(),
+  children: getMenuItems(),
 };
 
 function renderSplitButton(props = {}) {
@@ -216,16 +216,16 @@ describe('packages/split-button', () => {
   });
 
   describe('MenuItem', () => {
-    test('click triggers onChange callback', () => {
-      const onChange = jest.fn();
-      const { menuTrigger, getByTestId } = renderSplitButton({ onChange });
+    test('click triggers onItemClick callback', () => {
+      const onItemClick = jest.fn();
+      const { menuTrigger, getByTestId } = renderSplitButton({ onItemClick });
 
       userEvent.click(menuTrigger as HTMLElement);
 
       const menu = getByTestId(menuTestId);
       const options = globalGetAllByRole(menu, 'menuitem');
       userEvent.click(options[0]);
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onItemClick).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -298,7 +298,7 @@ describe('packages/split-button', () => {
 
       test('Fires the click handler of the highlighted item', async () => {
         const { openMenu } = renderSplitButton({
-          menuItems,
+          children: menuItems,
         });
         const { menuItemElements } = await openMenu({
           withKeyboard: true,
@@ -315,7 +315,7 @@ describe('packages/split-button', () => {
         // https://github.com/testing-library/react-testing-library/issues/269#issuecomment-1453666401 - this needs v13 of testing-library
         // TODO: This is not triggered so the test fails
         const { openMenu, menuTrigger } = renderSplitButton({
-          menuItems,
+          children: menuItems,
         });
         const { menuEl, menuItemElements } = await openMenu();
         userEvent.type(menuItemElements?.[0]!, `{${key}}`);
@@ -335,7 +335,7 @@ describe('packages/split-button', () => {
 
       describe('Down arrow', () => {
         test('highlights the next option in the menu', async () => {
-          const { openMenu } = renderSplitButton({ menuItems });
+          const { openMenu } = renderSplitButton({ children: menuItems });
           const { menuEl, menuItemElements } = await openMenu({
             withKeyboard: true,
           });
@@ -346,7 +346,7 @@ describe('packages/split-button', () => {
         });
 
         test('cycles highlight to the top', async () => {
-          const { openMenu } = renderSplitButton({ menuItems });
+          const { openMenu } = renderSplitButton({ children: menuItems });
           const { menuEl, menuItemElements } = await openMenu({
             withKeyboard: true,
           });
@@ -362,7 +362,7 @@ describe('packages/split-button', () => {
 
       describe('Up arrow', () => {
         test('highlights the previous option in the menu', async () => {
-          const { openMenu } = renderSplitButton({ menuItems });
+          const { openMenu } = renderSplitButton({ children: menuItems });
           const { menuEl, menuItemElements } = await openMenu({
             withKeyboard: true,
           });
@@ -376,7 +376,7 @@ describe('packages/split-button', () => {
         });
 
         test('cycles highlight to the bottom', async () => {
-          const { openMenu } = renderSplitButton({ menuItems });
+          const { openMenu } = renderSplitButton({ children: menuItems });
           const { menuEl, menuItemElements } = await openMenu({
             withKeyboard: true,
           });
@@ -394,22 +394,19 @@ describe('packages/split-button', () => {
   describe('Types behave as expected', () => {
     test.skip('Accepts base props', () => {
       <>
-        <SplitButton label="label" menuItems={getMenuItems()} />
+        <SplitButton label="label" children={getMenuItems()} />
+        <SplitButton label="label">
+          <MenuItem key="0">Menu Item</MenuItem>
+          <MenuItem key="1" disabled>
+            Disabled Menu Item
+          </MenuItem>
+          <MenuItem key="2" description="I am also a description">
+            Menu Item With Description
+          </MenuItem>
+        </SplitButton>
         <SplitButton
           label="label"
-          menuItems={[
-            <MenuItem key="0">Menu Item</MenuItem>,
-            <MenuItem key="1" disabled>
-              Disabled Menu Item
-            </MenuItem>,
-            <MenuItem key="2" description="I am also a description">
-              , Menu Item With Description
-            </MenuItem>,
-          ]}
-        />
-        <SplitButton
-          label="label"
-          menuItems={getMenuItems()}
+          children={getMenuItems()}
           onClick={() => {}}
           disabled={true}
           size="default"
@@ -426,17 +423,15 @@ describe('packages/split-button', () => {
           open={false}
           triggerAriaLabel="im the trigger silly"
         />
-        {/* @ts-expect-error - expects label and menuItems*/}
-        <SplitButton />
-        {/* @ts-expect-error - expects menuItems */}
-        <SplitButton label="label" />
         {/* @ts-expect-error - expects label */}
-        <SplitButton menuItems={getMenuItems()} />
+        <SplitButton />
+        {/* @ts-expect-error - expects label */}
+        <SplitButton children={getMenuItems()} />
       </>;
     });
 
     test.skip('Accepts string as `as` prop', () => {
-      <SplitButton as="p" label="label" menuItems={getMenuItems()} />;
+      <SplitButton as="p" label="label" children={getMenuItems()} />;
     });
 
     test.skip('Accepts component as `as` prop', () => {
@@ -448,7 +443,7 @@ describe('packages/split-button', () => {
           data-testid="split-button"
           as={As}
           label="label"
-          menuItems={getMenuItems()}
+          children={getMenuItems()}
         />,
       );
     });
@@ -459,25 +454,25 @@ describe('packages/split-button', () => {
       };
 
       <>
-        <SplitButton href="allowed" label="label" menuItems={getMenuItems()} />
+        <SplitButton href="allowed" label="label" children={getMenuItems()} />
         <SplitButton
           as="a"
           href="allowed"
           label="label"
-          menuItems={getMenuItems()}
+          children={getMenuItems()}
         />
         <SplitButton
           as="div"
           // @ts-expect-error - href not allowed when as is div
           href="string"
           label="label"
-          menuItems={getMenuItems()}
+          children={getMenuItems()}
         />
         <SplitButton
           as={AnchorLikeWrapper}
           href="string"
           label="label"
-          menuItems={getMenuItems()}
+          children={getMenuItems()}
         />
       </>;
     });

--- a/packages/split-button/src/SplitButton/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.tsx
@@ -14,7 +14,7 @@ import {
 import { RenderMode } from '@leafygreen-ui/popover';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
 
-import { Menu } from '../Menu';
+import { Menu, defaultItemClick } from '../Menu';
 
 import {
   buttonBaseStyles,
@@ -26,6 +26,7 @@ import { Align, Justify, SplitButtonProps, Variant } from './SplitButton.types';
 export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
   (
     {
+      children,
       darkMode: darkModeProp,
       variant = Variant.Default,
       type = 'button',
@@ -33,7 +34,6 @@ export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
       justify = Justify.End,
       size = Size.Default,
       disabled = false,
-      menuItems = [],
       as,
       baseFontSize,
       label,
@@ -49,8 +49,8 @@ export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
       open,
       setOpen,
       onTriggerClick,
+      onItemClick = defaultItemClick,
       triggerAriaLabel,
-      onChange,
       ...rest
     },
     ref: React.Ref<any>,
@@ -101,15 +101,16 @@ export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
             align={align}
             justify={justify}
             containerRef={containerRef}
-            menuItems={menuItems}
             id={menuId}
             disabled={disabled}
             open={open}
             setOpen={setOpen}
             onTriggerClick={onTriggerClick}
+            onItemClick={onItemClick}
             triggerAriaLabel={triggerAriaLabel}
-            onChange={onChange}
-          />
+          >
+            {children}
+          </Menu>
         </LeafyGreenProvider>
       </div>
     );
@@ -126,7 +127,6 @@ SplitButton.propTypes = {
   justify: PropTypes.oneOf(Object.values(Justify)),
   variant: PropTypes.oneOf(Object.values(Variant)),
   label: PropTypes.string.isRequired,
-  menuItems: PropTypes.arrayOf(PropTypes.element).isRequired,
   baseFontSize: PropTypes.oneOf(Object.values(BaseFontSize)),
   disabled: PropTypes.bool,
   leftGlyph: PropTypes.element,

--- a/packages/split-button/src/SplitButton/SplitButton.types.ts
+++ b/packages/split-button/src/SplitButton/SplitButton.types.ts
@@ -53,18 +53,22 @@ type ButtonProps = Omit<
   'rightGlyph' | 'href' | 'as' | 'variant'
 >;
 
-export type SelectedMenuProps = Omit<
+export type SelectedMenuProps = Pick<
   ImportedMenuProps,
-  | 'children'
-  | 'trigger'
-  | 'shouldClose'
   | 'darkMode'
-  | 'onClick'
+  | 'maxHeight'
+  | 'adjustOnMutation'
+  | 'popoverZIndex'
+  | 'renderMode'
+  | 'portalClassName'
+  | 'portalContainer'
+  | 'portalRef'
+  | 'scrollContainer'
   | 'align'
   | 'justify'
-  | 'className'
-  | 'refEl'
-  | 'spacing'
+  | 'id'
+  | 'open'
+  | 'setOpen'
 >;
 
 export interface MenuProps extends SelectedMenuProps {

--- a/packages/split-button/src/SplitButton/SplitButton.types.ts
+++ b/packages/split-button/src/SplitButton/SplitButton.types.ts
@@ -17,6 +17,7 @@ import {
   Align as ImportedAlign,
   Justify as ImportedJustify,
 } from '@leafygreen-ui/popover';
+import type { ItemClickHandler } from '../Menu/Menu.types';
 
 export type MenuItemType = ReactElement<
   InferredPolymorphicProps<PolymorphicAs, MenuItemProps>
@@ -50,11 +51,12 @@ export type Justify = (typeof Justify)[keyof typeof Justify];
 // https://jira.mongodb.org/browse/LG-3260
 type ButtonProps = Omit<
   ImportedButtonProps,
-  'rightGlyph' | 'href' | 'as' | 'variant'
+  'children' | 'rightGlyph' | 'href' | 'as' | 'variant'
 >;
 
 export type SelectedMenuProps = Pick<
   ImportedMenuProps,
+  | 'children'
   | 'darkMode'
   | 'maxHeight'
   | 'adjustOnMutation'
@@ -87,42 +89,27 @@ export interface MenuProps extends SelectedMenuProps {
   justify?: Justify;
 
   /**
-   * The menu items to appear in the menu dropdown. Must be an array of `<MenuItem />`.
-   *
-   * ```js
-   * [
-   *   <MenuItem key='0' onClick={()=>{}}> Menu Item</MenuItem>,
-   *   <MenuItem key='1' description="I am a description" disabled>Disabled Menu Item</MenuItem>,
-   *   <MenuItem key='2' description="I am also a description">,
-   *     Menu Item With Description
-   *   </MenuItem>
-   * ]
-   * ```
-   *
-   * @type Array<MenuItem>
-   */
-  menuItems: MenuItemsType;
-
-  /**
    * Callback fired when the trigger is clicked.
    */
   onTriggerClick?: MouseEventHandler;
 
   /**
+   * Callback called when an item is clicked, with the click event and an options object.
+   * Provide an implementation to avoid the default behavior of the menu closing when an item is clicked.
+   */
+  onItemClick?: ItemClickHandler;
+
+  /**
    * aria-label for the menu trigger button.
    */
   triggerAriaLabel?: string;
-
-  /**
-   * Callback fired when a menuItem is clicked.
-   */
-  onChange?: MouseEventHandler;
 }
 
 export interface SplitButtonProps
   extends DarkModeProps,
     ButtonProps,
     MenuProps {
+
   /**
    * Sets the variant for both Buttons.
    *


### PR DESCRIPTION
I'm working on a feature in Compass where I'd like to pass arbitrary elements to be rendered in the `SplitButton` menu, ex:
- `MenuSeparator` elements.
- `MenuItem` elements with controls that shouldn't cause the menu to close when clicked.

## ✍️ Proposed changes

1. The types of the `SplitButton` currently declare taking `children` (from the `ButtonProps`) but these are never used internally. I suggest that these are instead passed into the `Menu`. This will make the `menuItems` prop obsolete.
2. To make the behavior of clicking a `MenuItem` configurable, I suggest adding an `onItemClick` prop taking a callback which will be called (just like `onChange` is called now) but also passed a second options object with a reference to the React `element` being clicked (to allow inspection of props) as well as a `close` function, which can be called to close the menu.
3. To avoid breaking the existing behavior of the menu closing when an item is clicked, I suggest a "default" implementation of the `onItemClick` used when no function is explicitly passed. Since the signature and semantics of this new `onItemClick` prop is so similar to `onChange`, I suggest removing the latter. The main caveat with this is that someone renaming their `onChange` callback to `onItemClick` now also has to explicitly call the `close` function in the callback.

NOTE: This builds upon https://github.com/mongodb/leafygreen-ui/pull/2602 and needs to be rebased once that gets merged. Once rebased, I'll update the changeset description, including examples of how to migrate to the two new props (`menuItems` → `children` and `onChange` → `onItemClick`).

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
