### PR TITLE
LG-4531: Wrap toast transition functions in useCallback

### DIFF
--- a/.changeset/slimy-cameras-move.md
+++ b/.changeset/slimy-cameras-move.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/toast': patch
+---
+
+Avoids unnecessary re-renders in ToastProvider

--- a/packages/toast/src/ToastContainer/ToastContainer.tsx
+++ b/packages/toast/src/ToastContainer/ToastContainer.tsx
@@ -146,7 +146,7 @@ export const ToastContainer = ({
     handleTransitionEnter,
   } = useToastTransitions({
     getShouldExpand,
-    enterCallback: () => {
+    enterCallback: useCallback(() => {
       if (toastContainerRef.current) {
         toastContainerRef.current.scrollTop = totalStackHeight;
       }
@@ -155,8 +155,8 @@ export const ToastContainer = ({
       if (getShouldExpand()) {
         updateToastHeights();
       }
-    },
-    exitCallback: () => {
+    }, [getShouldExpand, updateToastHeights]),
+    exitCallback: useCallback(() => {
       if (scrollContainerRef.current) {
         // check whether the toast container is still hovered
         const _isHovered = scrollContainerRef.current.matches(':hover');
@@ -167,7 +167,7 @@ export const ToastContainer = ({
       if (getShouldExpand()) {
         updateToastHeights();
       }
-    },
+    }, [getShouldExpand, updateToastHeights]),
   });
 
   /**


### PR DESCRIPTION
## ✍️ Proposed changes

Inside `useToastTransitions`, as of [LG-4335](https://jira.mongodb.org/browse/LG-4335) (#2458) we're cancelling 
debounced transitions on subsequent renders when something changes or the provider unmounts. However, we included functions in that `useEffect` that aren't wrapped in a `useCallback`, which means those transitions will be cancelled on every render, rather than just on unmount or when something actually changes. This adds those `useCallback` wrappers.

🎟 _Jira ticket:_ [LG-4531](https://jira.mongodb.org/browse/LG-4531)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

TODO