### PR TITLE
LG-4724: Export prop types which are already wrapped in the polymorphic types

### DIFF
--- a/.changeset/grumpy-moose-exercise.md
+++ b/.changeset/grumpy-moose-exercise.md
@@ -1,0 +1,9 @@
+---
+'@leafygreen-ui/input-option': patch
+'@leafygreen-ui/search-input': patch
+'@leafygreen-ui/split-button': patch
+'@leafygreen-ui/card': patch
+'@leafygreen-ui/menu': patch
+---
+
+Export prop types for components already wrapped in polymorphic types

--- a/packages/card/src/Card/Card.tsx
+++ b/packages/card/src/Card/Card.tsx
@@ -10,12 +10,12 @@ import {
 } from '@leafygreen-ui/polymorphic';
 
 import { colorSet, containerStyle } from './styles';
-import { CardProps, ContentStyle } from './types';
+import { ContentStyle, InternalCardProps } from './types';
 
 /**
  * Cards are used to organize information into consumable chunks.
  */
-export const Card = InferredPolymorphic<CardProps, 'div'>(
+export const Card = InferredPolymorphic<InternalCardProps, 'div'>(
   (
     {
       as = 'div' as PolymorphicAs,

--- a/packages/card/src/Card/types.ts
+++ b/packages/card/src/Card/types.ts
@@ -1,4 +1,8 @@
 import { DarkModeProps } from '@leafygreen-ui/lib';
+import {
+  InferredPolymorphicProps,
+  PolymorphicAs,
+} from '@leafygreen-ui/polymorphic';
 
 export const ContentStyle = {
   None: 'none',
@@ -7,7 +11,7 @@ export const ContentStyle = {
 
 export type ContentStyle = (typeof ContentStyle)[keyof typeof ContentStyle];
 
-export interface CardProps extends DarkModeProps {
+export interface InternalCardProps extends DarkModeProps {
   /**
    * Determines whether the Card should be styled as clickable.
    *
@@ -23,3 +27,7 @@ export interface CardProps extends DarkModeProps {
    */
   title?: string;
 }
+
+// External only
+export type CardProps<TAsProp extends PolymorphicAs = 'div'> =
+  InferredPolymorphicProps<TAsProp, InternalCardProps>;

--- a/packages/input-option/src/InputOption/InputOption.tsx
+++ b/packages/input-option/src/InputOption/InputOption.tsx
@@ -15,9 +15,9 @@ import {
   getInputOptionWedge,
   inputOptionClassName,
 } from './InputOption.style';
-import { InputOptionProps } from './InputOption.types';
+import { InternalInputOptionProps } from './InputOption.types';
 
-export const InputOption = Polymorphic<InputOptionProps>(
+export const InputOption = Polymorphic<InternalInputOptionProps>(
   (
     {
       as = 'li' as PolymorphicAs,

--- a/packages/input-option/src/InputOption/InputOption.types.ts
+++ b/packages/input-option/src/InputOption/InputOption.types.ts
@@ -1,5 +1,6 @@
 import { AriaLabelPropsWithChildren } from '@leafygreen-ui/a11y';
 import { DarkModeProps } from '@leafygreen-ui/lib';
+import { PolymorphicAs, PolymorphicProps } from '@leafygreen-ui/polymorphic';
 
 /**
  * TERMINOLOGY
@@ -55,6 +56,10 @@ export interface BaseInputOptionProps {
   isInteractive?: boolean;
 }
 
-export type InputOptionProps = DarkModeProps &
+export type InternalInputOptionProps = DarkModeProps &
   AriaLabelPropsWithChildren &
   BaseInputOptionProps;
+
+// External only
+export type InputOptionProps<TAsProp extends PolymorphicAs = 'li'> =
+  PolymorphicProps<TAsProp, InternalInputOptionProps>;

--- a/packages/menu/src/MenuItem/InternalMenuItemContent.tsx
+++ b/packages/menu/src/MenuItem/InternalMenuItemContent.tsx
@@ -20,11 +20,11 @@ import {
   getMenuItemStyles,
   getNestedMenuItemStyles,
 } from './MenuItem.styles';
-import { MenuItemProps, Variant } from './MenuItem.types';
+import { InternalMenuItemProps, Variant } from './MenuItem.types';
 
 export type InternalMenuItemContentProps = InferredPolymorphicProps<
   PolymorphicAs,
-  MenuItemProps
+  InternalMenuItemProps
 > & {
   index: number;
 };

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -10,9 +10,9 @@ import { MenuDescendantsContext } from '../MenuContext';
 
 import { InternalMenuItemContent } from './InternalMenuItemContent';
 import { menuItemClassName, menuItemContainerStyles } from './MenuItem.styles';
-import { MenuItemProps } from './MenuItem.types';
+import { InternalMenuItemProps } from './MenuItem.types';
 
-export const MenuItem = InferredPolymorphic<MenuItemProps, 'button'>(
+export const MenuItem = InferredPolymorphic<InternalMenuItemProps, 'button'>(
   (
     { as, disabled = false, active = false, onClick, ...rest },
     fwdRef: React.Ref<any>,

--- a/packages/menu/src/MenuItem/MenuItem.types.ts
+++ b/packages/menu/src/MenuItem/MenuItem.types.ts
@@ -1,5 +1,10 @@
 import { ReactElement, ReactNode } from 'react';
 
+import {
+  InferredPolymorphicProps,
+  PolymorphicAs,
+} from '@leafygreen-ui/polymorphic';
+
 const Variant = {
   Default: 'default',
   Destructive: 'destructive',
@@ -9,7 +14,7 @@ type Variant = (typeof Variant)[keyof typeof Variant];
 
 export { Variant };
 
-export interface MenuItemProps {
+export interface InternalMenuItemProps {
   /**
    * Determines whether or not the MenuItem is disabled.
    */
@@ -54,3 +59,7 @@ export interface MenuItemProps {
   // TODO: codemod to remove `size` props from existing implementations
   size?: 'default' | 'large';
 }
+
+// External only
+export type MenuItemProps<TAsProp extends PolymorphicAs = 'button'> =
+  InferredPolymorphicProps<TAsProp, InternalMenuItemProps>;

--- a/packages/menu/src/SubMenu/SubMenu.tsx
+++ b/packages/menu/src/SubMenu/SubMenu.tsx
@@ -98,7 +98,9 @@ export const SubMenu = InferredPolymorphic<InternalSubMenuProps, 'button'>(
     const submenuTriggerRef = useRef<HTMLButtonElement>(null);
     const subMenuHeight = useChildrenHeight(submenuRef, [open]);
 
-    const handleClick: MouseEventHandler = e => {
+    const handleClick: MouseEventHandler<
+      HTMLAnchorElement & HTMLButtonElement
+    > = e => {
       if (onClick || rest.href) {
         if (!disabled) {
           onClick?.(e);

--- a/packages/menu/src/SubMenu/SubMenu.types.ts
+++ b/packages/menu/src/SubMenu/SubMenu.types.ts
@@ -51,7 +51,5 @@ export interface InternalSubMenuProps
 }
 
 // External only
-export type SubMenuProps = InferredPolymorphicProps<
-  PolymorphicAs,
-  InternalSubMenuProps
->;
+export type SubMenuProps<TAsProp extends PolymorphicAs = 'button'> =
+  InferredPolymorphicProps<TAsProp, InternalSubMenuProps>;

--- a/packages/search-input/src/SearchResult/SearchResult.tsx
+++ b/packages/search-input/src/SearchResult/SearchResult.tsx
@@ -4,9 +4,12 @@ import { InputOption, InputOptionContent } from '@leafygreen-ui/input-option';
 import { getNodeTextContent } from '@leafygreen-ui/lib';
 import { InferredPolymorphic, PolymorphicAs } from '@leafygreen-ui/polymorphic';
 
-import { SearchResultProps } from './SearchResult.types';
+import { InternalSearchResultProps } from './SearchResult.types';
 
-export const SearchResult = InferredPolymorphic<SearchResultProps, 'li'>(
+export const SearchResult = InferredPolymorphic<
+  InternalSearchResultProps,
+  'li'
+>(
   (
     {
       as = 'li' as PolymorphicAs,

--- a/packages/search-input/src/SearchResult/SearchResult.types.ts
+++ b/packages/search-input/src/SearchResult/SearchResult.types.ts
@@ -2,8 +2,12 @@ import React from 'react';
 
 import { BaseInputOptionProps } from '@leafygreen-ui/input-option';
 import { DarkModeProps } from '@leafygreen-ui/lib';
+import {
+  InferredPolymorphicProps,
+  PolymorphicAs,
+} from '@leafygreen-ui/polymorphic';
 
-export type SearchResultProps = DarkModeProps &
+export type InternalSearchResultProps = DarkModeProps &
   Omit<BaseInputOptionProps, 'showWedge' | 'active' | 'isInteractive'> & {
     /**
      * The value of the result
@@ -20,3 +24,7 @@ export type SearchResultProps = DarkModeProps &
      */
     onClick?: React.MouseEventHandler;
   };
+
+// External only
+export type SearchResultProps<TAsProp extends PolymorphicAs = 'li'> =
+  InferredPolymorphicProps<TAsProp, InternalSearchResultProps>;

--- a/packages/split-button/src/Menu/Menu.tsx
+++ b/packages/split-button/src/Menu/Menu.tsx
@@ -79,7 +79,10 @@ export const Menu = ({
   useBackdropClick(handleClose, [buttonRef, menuRef], open);
 
   const renderMenuItems = useMemo(() => {
-    const onMenuItemClick = (e: MouseEvent, menuItem: MenuItemType) => {
+    const onMenuItemClick = (
+      e: MouseEvent<HTMLAnchorElement & HTMLButtonElement>,
+      menuItem: MenuItemType,
+    ) => {
       handleClose();
       menuItem.props.onClick?.(e);
       onChange?.(e);
@@ -90,7 +93,8 @@ export const Menu = ({
         return React.cloneElement(menuItem, {
           active: false,
           key: `menuItem-${menuItem.key}`,
-          onClick: (e: MouseEvent) => onMenuItemClick(e, menuItem),
+          onClick: (e: MouseEvent<HTMLAnchorElement & HTMLButtonElement>) =>
+            onMenuItemClick(e, menuItem),
         });
       } else {
         console.warn(

--- a/packages/split-button/src/SplitButton/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.tsx
@@ -21,9 +21,17 @@ import {
   buttonContainerStyles,
   buttonThemeStyles,
 } from './SplitButton.styles';
-import { Align, Justify, SplitButtonProps, Variant } from './SplitButton.types';
+import {
+  Align,
+  InternalSplitButtonProps,
+  Justify,
+  Variant,
+} from './SplitButton.types';
 
-export const SplitButton = InferredPolymorphic<SplitButtonProps, 'button'>(
+export const SplitButton = InferredPolymorphic<
+  InternalSplitButtonProps,
+  'button'
+>(
   (
     {
       darkMode: darkModeProp,

--- a/packages/split-button/src/SplitButton/SplitButton.types.ts
+++ b/packages/split-button/src/SplitButton/SplitButton.types.ts
@@ -115,7 +115,7 @@ export interface MenuProps extends SelectedMenuProps {
   onChange?: MouseEventHandler;
 }
 
-export interface SplitButtonProps
+export interface InternalSplitButtonProps
   extends DarkModeProps,
     ButtonProps,
     MenuProps {
@@ -131,3 +131,7 @@ export interface SplitButtonProps
    */
   label: string;
 }
+
+// External only
+export type SplitButtonProps<TAsProp extends PolymorphicAs = 'button'> =
+  InferredPolymorphicProps<TAsProp, InternalSplitButtonProps>;


### PR DESCRIPTION
## ✍️ Proposed changes

I went through the codebase to find uses of the "polymorphic" types and replicated the pattern already established for the `SubMenu` component:
- Prepended the `*Props` type name with "Internal".
- Updated the internal use of ☝️ to match the new name.
- Added a new type in-place of the type which was previously exported, wrapping the internal type in either `PolymorphicProps` or `InferredPolymorphicProps` (depending on which was used by the implementation of the component).

I'm marking this as a patch, since it's extending the existing prop types and therefore shouldn't cause downstream breakage. If a consumer is wrapping these types already this should be a no-op.

🎟 _Jira ticket:_ [LG-4724](https://jira.mongodb.org/browse/LG-4724)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
