### PR TITLE
Add `data-testid` attribute to `SplitButton`'s menu trigger element

### DIFF
--- a/.changeset/big-drinks-thank.md
+++ b/.changeset/big-drinks-thank.md
@@ -1,5 +1,5 @@
 ---
-'@leafygreen-ui/split-button': minor
+'@leafygreen-ui/split-button': major
 ---
 
-Add data-testid attribute on SplitButton's menu trigger element
+Update `data-testid` and `data-lgid` attributes on SplitButton's button, trigger and menu elements.

--- a/.changeset/big-drinks-thank.md
+++ b/.changeset/big-drinks-thank.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/split-button': minor
+---
+
+Add data-testid attribute on SplitButton's menu trigger element

--- a/packages/split-button/src/Menu/Menu.tsx
+++ b/packages/split-button/src/Menu/Menu.tsx
@@ -138,6 +138,7 @@ export const Menu = ({
           className={cx(triggerBaseStyles, triggerSizeStyles[size], {
             [triggerThemeStyles(theme, variant)]: !disabled,
           })}
+          data-testid="lg-split-button-trigger"
           aria-label={triggerAriaLabel || 'More options'}
           aria-controls={open ? id : ''}
           onClick={handleTriggerClick}

--- a/packages/split-button/src/Menu/Menu.tsx
+++ b/packages/split-button/src/Menu/Menu.tsx
@@ -15,6 +15,7 @@ import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 import { isComponentType, keyMap } from '@leafygreen-ui/lib';
 import { Menu as LGMenu } from '@leafygreen-ui/menu';
 
+import { LGIDs } from '../constants';
 import { MenuItemType } from '../SplitButton';
 
 import {
@@ -119,13 +120,14 @@ export const Menu = ({
 
   return (
     <LGMenu
-      data-testid="lg-split-button-menu"
       align={align}
       justify={justify}
       id={id}
       open={open}
       ref={menuRef}
       portalRef={portalRef}
+      data-testid={LGIDs.menu}
+      data-lgid={LGIDs.menu}
       {...rest}
       trigger={
         <Button
@@ -138,13 +140,14 @@ export const Menu = ({
           className={cx(triggerBaseStyles, triggerSizeStyles[size], {
             [triggerThemeStyles(theme, variant)]: !disabled,
           })}
-          data-testid="lg-split-button-trigger"
           aria-label={triggerAriaLabel || 'More options'}
           aria-controls={open ? id : ''}
           onClick={handleTriggerClick}
           ref={buttonRef}
           aria-expanded={open}
           aria-haspopup={true}
+          data-testid={LGIDs.trigger}
+          data-lgid={LGIDs.trigger}
         />
       }
     >

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -49,7 +49,7 @@ function renderSplitButton(props: RenderSplitButtonProps = {}) {
   );
   const wrapper = renderResult.container.firstChild as HTMLElement;
   const primaryButton = renderResult.getByTestId('split-button');
-  const menuTrigger = primaryButton.nextSibling as HTMLElement;
+  const menuTrigger = renderResult.getByTestId('lg-split-button-trigger');
 
   /**
    * Since menu elements won't exist until component is interacted with,

--- a/packages/split-button/src/SplitButton/SplitButton.spec.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.spec.tsx
@@ -18,7 +18,7 @@ import { RenderMode } from '@leafygreen-ui/popover';
 import { MenuItemsType, SplitButtonProps } from './SplitButton.types';
 import { SplitButton } from '.';
 
-const menuTestId = 'lg-split-button-menu';
+const menuTestId = 'lg-split_button-menu';
 
 const getMenuItems = (): MenuItemsType => {
   return [
@@ -47,9 +47,9 @@ function renderSplitButton(props: RenderSplitButtonProps = {}) {
   const renderResult = render(
     <SplitButton data-testid="split-button" {...defaultProps} {...props} />,
   );
-  const wrapper = renderResult.container.firstChild as HTMLElement;
-  const primaryButton = renderResult.getByTestId('split-button');
-  const menuTrigger = renderResult.getByTestId('lg-split-button-trigger');
+  const wrapper = renderResult.getByTestId('split-button');
+  const primaryButton = renderResult.getByTestId('lg-split_button-button');
+  const menuTrigger = renderResult.getByTestId('lg-split_button-trigger');
 
   /**
    * Since menu elements won't exist until component is interacted with,

--- a/packages/split-button/src/SplitButton/SplitButton.tsx
+++ b/packages/split-button/src/SplitButton/SplitButton.tsx
@@ -12,6 +12,7 @@ import {
 } from '@leafygreen-ui/polymorphic';
 import { RenderMode } from '@leafygreen-ui/popover';
 
+import { LGIDs } from '../constants';
 import { Menu } from '../Menu';
 
 import {
@@ -58,6 +59,7 @@ export const SplitButton = InferredPolymorphic<
       triggerAriaLabel,
       onChange,
       renderDarkMenu,
+      'data-testid': testId = LGIDs.root,
       ...rest
     },
     ref: React.Ref<any>,
@@ -82,7 +84,12 @@ export const SplitButton = InferredPolymorphic<
     } as const;
 
     return (
-      <div className={cx(buttonContainerStyles, className)} ref={containerRef}>
+      <div
+        className={cx(buttonContainerStyles, className)}
+        ref={containerRef}
+        data-testid={testId}
+        data-lgid={LGIDs.root}
+      >
         <LeafyGreenProvider darkMode={darkMode}>
           <Button
             as={Component}
@@ -91,6 +98,8 @@ export const SplitButton = InferredPolymorphic<
             className={cx(buttonBaseStyles, {
               [buttonThemeStyles(theme, variant)]: !disabled,
             })}
+            data-testid={LGIDs.button}
+            data-lgid={LGIDs.button}
             {...rest}
           >
             {label}

--- a/packages/split-button/src/SplitButton/SplitButton.types.ts
+++ b/packages/split-button/src/SplitButton/SplitButton.types.ts
@@ -135,6 +135,11 @@ export interface InternalSplitButtonProps
    * The text that will appear inside of the primary button.
    */
   label: string;
+
+  /**
+   * A test id put onto the root element.
+   */
+  'data-testid'?: string;
 }
 
 // External only

--- a/packages/split-button/src/constants.ts
+++ b/packages/split-button/src/constants.ts
@@ -1,0 +1,6 @@
+export const LGIDs = {
+  root: 'lg-split_button',
+  button: 'lg-split_button-button',
+  menu: 'lg-split_button-menu',
+  trigger: 'lg-split_button-trigger',
+} as const;

--- a/packages/split-button/src/index.ts
+++ b/packages/split-button/src/index.ts
@@ -1,3 +1,4 @@
+export { LGIDs } from './constants';
 export {
   Align,
   Justify,


### PR DESCRIPTION
## ✍️ Proposed changes

In an effort to make out tests more robust to future changes, I suggest adding a `data-testid` attribute so the `SplitButton` trigger button can be targeted directly.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
