### PR TITLE
LG-4743: Fix resize bug in charts

### DIFF
--- a/.changeset/sour-bottles-sip.md
+++ b/.changeset/sour-bottles-sip.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Fixes bug that prevented chart resizing after initial render

--- a/charts/core/src/Echart/useEchart.ts
+++ b/charts/core/src/Echart/useEchart.ts
@@ -263,7 +263,7 @@ export function useEchart({
   useEffect(() => {
     setError(null);
 
-    let resizeCallback: (e: UIEvent) => void;
+    let resizeCallback: () => void;
 
     initializeEcharts()
       .then(echartsCore => {


### PR DESCRIPTION
## ✍️ Proposed changes
### Before
Resizing didn't trigger a resize of the chart because the echart instance was null from the callback.

### After
Creates the callback inside of the initialization hook to make sure it is accessible from the callback.

🎟 _Jira ticket:_ [LG-4743](https://jira.mongodb.org/browse/LG-4743)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- Test in storybook by resizing the browser and confirming that the chart resizes correctly and that there are no errors in the console.