### PR TITLE
LG-4634: Ensure canvas is sized to container with correct pixel ratio

### DIFF
--- a/.changeset/sour-tables-wonder.md
+++ b/.changeset/sour-tables-wonder.md
@@ -1,5 +1,5 @@
 ---
-'@lg-charts/core': major
+'@lg-charts/core': patch
 ---
 
 Ensure canvas is sized to container with correct pixel ratio

--- a/.changeset/sour-tables-wonder.md
+++ b/.changeset/sour-tables-wonder.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': major
+---
+
+Ensure canvas is sized to container with correct pixel ratio

--- a/charts/core/src/Echart/useEchart.ts
+++ b/charts/core/src/Echart/useEchart.ts
@@ -272,7 +272,12 @@ export function useEchart({
 
         if (container) {
           // Init an echart instance
-          const newChart = echartsCoreRef.current.init(container);
+          const newChart = echartsCoreRef.current.init(container, null, {
+            devicePixelRatio: window.devicePixelRatio || 1,
+            renderer: 'canvas',
+            width: container.clientWidth,
+            height: container.clientHeight,
+          });
           // Set the initial options on the instance
           newChart.setOption(options);
           // Resize chart when window resizes because echarts don't be default


### PR DESCRIPTION
## ✍️ Proposed changes
### This Doesn't
Actually fix blurriness, at least on the large monitor I'm viewing it on. It appears there's an ongoing issue about [charts appearing blurry on canvas in echarts](https://github.com/apache/echarts/issues/13504). I also see that in the [echarts examples](https://echarts.apache.org/examples/en/editor.html?c=data-transform-filter), if I set the `lineStyle` of a series to a width of 1, I see the same level of "not perfectly smooth" as I see in our chart. 

### This Does
Ensures that the the canvas is being sized correctly to the container and the correct pixel ratio is being used. There was a report of line blurriness occurring intermittently when users would return to their chart. I have yet to see this or be able to reproduce this. By making this change we're hopefully doing everything we can to ensure optimal rendering.

🎟 _Jira ticket:_ [LG-4634](https://jira.mongodb.org/browse/LG-4634)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.