### PR TITLE
LG-4770: Fix duplicate tooltip in remounted chart groups

### DIFF
--- a/.changeset/fuzzy-moons-sneeze.md
+++ b/.changeset/fuzzy-moons-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Fixes duplicate tooltip bug in remounted chart groups

--- a/charts/core/src/Chart/hooks/useChart.spec.ts
+++ b/charts/core/src/Chart/hooks/useChart.spec.ts
@@ -13,6 +13,7 @@ jest.mock('../../Echart', () => ({
   useEchart: jest.fn(() => ({
     ready: false,
     addToGroup: jest.fn(),
+    removeFromGroup: jest.fn(),
     setupZoomSelect: jest.fn(),
     on: jest.fn(),
   })),
@@ -32,6 +33,7 @@ describe('@lg-echarts/core/hooks/useChart', () => {
     (useEchart as jest.Mock).mockReturnValue({
       ready: false,
       addToGroup: jest.fn(),
+      removeFromGroup: jest.fn(),
       setupZoomSelect: jest.fn(),
       on: jest.fn(),
     });
@@ -46,6 +48,7 @@ describe('@lg-echarts/core/hooks/useChart', () => {
     (useEchart as jest.Mock).mockReturnValue({
       ready: true,
       addToGroup: jest.fn(),
+      removeFromGroup: jest.fn(),
       setupZoomSelect: jest.fn(),
       on: jest.fn(),
     });
@@ -62,6 +65,7 @@ describe('@lg-echarts/core/hooks/useChart', () => {
     (useEchart as jest.Mock).mockReturnValue({
       ready: true,
       addToGroup: jest.fn(),
+      removeFromGroup: jest.fn(),
       setupZoomSelect,
       on: jest.fn(),
     });
@@ -87,6 +91,7 @@ describe('@lg-echarts/core/hooks/useChart', () => {
     (useEchart as jest.Mock).mockReturnValue({
       ready: true,
       addToGroup: jest.fn(),
+      removeFromGroup: jest.fn(),
       setupZoomSelect: jest.fn(),
       on,
     });
@@ -113,6 +118,7 @@ describe('@lg-echarts/core/hooks/useChart', () => {
     const mockEchartInstance = {
       ready: true,
       addToGroup: jest.fn(),
+      removeFromGroup: jest.fn(),
       setupZoomSelect: jest.fn(),
       on: jest.fn(),
     };
@@ -125,5 +131,45 @@ describe('@lg-echarts/core/hooks/useChart', () => {
       ...mockEchartInstance,
       ref: expect.any(Function),
     });
+  });
+
+  test('should call `addToGroup` when `groupId` is present', async () => {
+    const { useEchart } = require('../../Echart');
+    const addToGroup = jest.fn();
+
+    (useEchart as jest.Mock).mockReturnValue({
+      ready: true,
+      addToGroup,
+      removeFromGroup: jest.fn(),
+      setupZoomSelect: jest.fn(),
+      on: jest.fn(),
+    });
+
+    const groupId = 'test-group';
+
+    renderHook(() => useChart({ theme: 'dark', groupId }));
+
+    expect(addToGroup).toHaveBeenCalledWith(groupId);
+  });
+
+  test('should call `removeFromGroup` on unmount if `groupId` is present', async () => {
+    const { useEchart } = require('../../Echart');
+    const removeFromGroup = jest.fn();
+
+    (useEchart as jest.Mock).mockReturnValue({
+      ready: true,
+      addToGroup: jest.fn(),
+      removeFromGroup,
+      setupZoomSelect: jest.fn(),
+      on: jest.fn(),
+    });
+
+    const groupId = 'test-group';
+
+    const { unmount } = renderHook(() => useChart({ theme: 'dark', groupId }));
+
+    unmount();
+
+    expect(removeFromGroup).toHaveBeenCalled();
   });
 });

--- a/charts/core/src/Chart/hooks/useChart.ts
+++ b/charts/core/src/Chart/hooks/useChart.ts
@@ -42,6 +42,10 @@ export function useChart({
       if (groupId) {
         echart.addToGroup(groupId);
       }
+
+      return () => {
+        echart.removeFromGroup();
+      };
     }
   }, [echart.ready, groupId]);
 

--- a/charts/core/src/Echart/useEchart.ts
+++ b/charts/core/src/Echart/useEchart.ts
@@ -108,8 +108,10 @@ export function useEchart({
     withInstanceCheck((groupId: string) => {
       // echartsCoreRef.current should exist if instance does, but checking for extra safety
       if (echartsCoreRef.current) {
-        (echartsInstance as EChartsType).group = groupId;
-        echartsCoreRef.current.connect(groupId);
+        if ((echartsInstance as EChartsType).group !== groupId) {
+          (echartsInstance as EChartsType).group = groupId;
+          echartsCoreRef.current.connect(groupId);
+        }
       }
     }),
     [echartsCoreRef.current, echartsInstance],


### PR DESCRIPTION
## ✍️ Proposed changes
- Removes chart groups when chart unmounts
- Drive-by: Prevents unneeded group connecting if group already exists on instance

🎟 _Jira ticket:_ [LG-4770](https://jira.mongodb.org/browse/LG-4770)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `yarn changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- In storybook, run through reproduction steps in attached ticket and confirm duplicate tooltips aren't seen
