### PR TITLE
Revert absolute dimensions on charts

### DIFF
--- a/charts/core/src/Echart/useEchart.ts
+++ b/charts/core/src/Echart/useEchart.ts
@@ -276,8 +276,6 @@ export function useEchart({
           const newChart = echartsCoreRef.current.init(container, null, {
             devicePixelRatio: window.devicePixelRatio || 1,
             renderer: 'canvas',
-            width: container.clientWidth,
-            height: container.clientHeight,
           });
           // Set the initial options on the instance
           newChart.setOption(options);


### PR DESCRIPTION
## ✍️ Proposed changes
Absolute dimensions were added to charts in hopes of ensuring render quality. This didn't make a noticeable difference. Unfortunately it also broke resizing. This reverts that.

## 🧪 How to test changes
- Confirm chart resizes in storybook as expected