### PR TITLE
LG-4796: Fix expanding when passing `state` to `useLeafyGreenTable`

### DIFF
--- a/.changeset/big-tables-carry.md
+++ b/.changeset/big-tables-carry.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/table': patch
+---
+
+Fix expanding when passing `state` to `useLeafyGreenTable`

--- a/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.spec.tsx
+++ b/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { renderHook } from '@leafygreen-ui/testing-lib';
+import { act, renderHook } from '@leafygreen-ui/testing-lib';
 
 import { Person } from '../utils/makeData.testutils';
 import {
@@ -65,6 +65,32 @@ describe('packages/table/useLeafyGreenTable', () => {
 
     // Subrows are only included if they are expanded
     expect(result.current.getRowModel().rows.length).toEqual(data.length);
+  });
+
+  test('returns the correct number of rows when a row is expanded and an empty state is passed', () => {
+    const data = getDefaultTestData({
+      renderExpandedContent: (_: LeafyGreenTableRow<Person>) => {
+        return <>Expandable content test</>;
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useLeafyGreenTable({
+        data,
+        columns: getDefaultTestColumns({}),
+        // This empty state should not affect the default behavior
+        state: {},
+      }),
+    );
+
+    const [firstRow] = result.current.getExpandedRowModel().rows;
+    expect(result.current.getRowCount()).toEqual(data.length);
+
+    // Expand the first row and expect a new row to appear
+    act(() => {
+      firstRow.toggleExpanded();
+    });
+    expect(result.current.getRowCount()).toEqual(data.length + 1);
   });
 
   // eslint-disable-next-line jest/no-disabled-tests

--- a/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.tsx
+++ b/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.tsx
@@ -95,10 +95,6 @@ function useLeafyGreenTable<T extends LGRowData, V extends unknown = unknown>({
   }
 
   const table = useReactTable<LGTableDataType<T>>({
-    state: {
-      expanded,
-      ...rest.state,
-    },
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -113,6 +109,10 @@ function useLeafyGreenTable<T extends LGRowData, V extends unknown = unknown>({
     onExpandedChange: setExpanded,
     getExpandedRowModel: getLGExpandedRowModel(),
     ...rest,
+    state: {
+      expanded,
+      ...rest.state,
+    },
   });
 
   return {


### PR DESCRIPTION
## ✍️ Proposed changes

Merging this PR will:
1. Add a failing test to demonstrate the issue and prevent future regressions.
2. Move the `state` value below the `...rest` spread in `useLeafyGreenTable` when passing values to the `useReactTable`.

🎟 _Jira ticket:_ [LG-4796](https://jira.mongodb.org/browse/LG-4796)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

I've added a test:

```bash
pnpm test packages/table/src/useLeafyGreenTable
```