### PR TITLE
LG-4797: Fix charts not resizing when container dynamically changes

### DIFF
--- a/.changeset/happy-sheep-kick.md
+++ b/.changeset/happy-sheep-kick.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Fixes `Chart` not resizing when container dynamically changes

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -30,6 +30,7 @@ import {
 
 interface StorybookProps {
   data: Array<LineProps>;
+  chartState: ChartProps['chartState'];
   verticalGridLines: boolean;
   horizontalGridLines: boolean;
   renderGrid: boolean;

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -28,43 +28,92 @@ import {
   YAxisProps,
 } from '.';
 
+interface StorybookProps {
+  data: Array<LineProps>;
+  verticalGridLines: boolean;
+  horizontalGridLines: boolean;
+  renderGrid: boolean;
+  renderXAxis: boolean;
+  xAxisType: XAxisProps['type'];
+  xAxisFormatter: XAxisProps['formatter'];
+  xAxisLabel: XAxisProps['label'];
+  renderYAxis: boolean;
+  yAxisType: YAxisProps['type'];
+  yAxisFormatter: YAxisProps['formatter'];
+  yAxisLabel: YAxisProps['label'];
+  renderTooltip: boolean;
+  tooltipSortDirection: TooltipProps['sortDirection'];
+  tooltipSortKey: TooltipProps['sortKey'];
+  tooltipValueFormatter: TooltipProps['valueFormatter'];
+  renderHeader: boolean;
+  headerTitle: HeaderProps['title'];
+  headerShowDivider: HeaderProps['showDivider'];
+  zoomSelectXAxis: boolean;
+  zoomSelectYAxis: boolean;
+  zoomSelectCallback;
+  renderEventMarkerLine: boolean;
+  eventMarkerLineMessage: EventMarkerLineProps['message'];
+  eventMarkerLineLabel: EventMarkerLineProps['label'];
+  eventMarkerLineLevel: EventMarkerLineProps['level'];
+  eventMarkerLinePosition: EventMarkerLineProps['position'];
+  renderEventMarkerPoint: boolean;
+  eventMarkerPointMessage: EventMarkerPointProps['message'];
+  eventMarkerPointLabel: EventMarkerPointProps['label'];
+  eventMarkerPointLevel: EventMarkerPointProps['level'];
+  eventMarkerPointXPosition: EventMarkerPointProps['position'][0];
+  eventMarkerPointYPosition: EventMarkerPointProps['position'][1];
+  renderThresholdLine: true;
+  thresholdLineLabel: ThresholdLineProps['label'];
+  thresholdLineValue: ThresholdLineProps['value'];
+  thresholdLinePosition: ThresholdLineProps['position'];
+}
+
+const defaultArgs: Omit<
+  StorybookProps,
+  | 'xAxisFormatter'
+  | 'xAxisLabel'
+  | 'yAxisFormatter'
+  | 'yAxisLabel'
+  | 'tooltipValueFormatter'
+> = {
+  data: makeLineData(5),
+  horizontalGridLines: true,
+  verticalGridLines: false,
+  renderGrid: true,
+  renderXAxis: true,
+  xAxisType: 'time',
+  renderYAxis: true,
+  yAxisType: 'value',
+  renderTooltip: true,
+  tooltipSortDirection: SortDirection.Desc,
+  tooltipSortKey: SortKey.Value,
+  renderHeader: true,
+  headerTitle: 'LeafyGreen Chart Header',
+  headerShowDivider: true,
+  zoomSelectXAxis: true,
+  zoomSelectYAxis: true,
+  zoomSelectCallback: action('onZoomSelect'),
+  renderEventMarkerLine: true,
+  eventMarkerLineMessage: 'Event marker line message',
+  eventMarkerLineLabel: 'Event marker line label',
+  eventMarkerLineLevel: 'warning',
+  eventMarkerLinePosition: new Date('2024-01-01T00:20:00').getTime(),
+  renderEventMarkerPoint: true,
+  eventMarkerPointMessage: 'Event marker point message',
+  eventMarkerPointLabel: 'Event marker point label',
+  eventMarkerPointLevel: 'warning',
+  eventMarkerPointXPosition: new Date('2024-01-01T00:37:00').getTime(),
+  eventMarkerPointYPosition: 699,
+  renderThresholdLine: true,
+  thresholdLineLabel: 'Cluster Limit',
+  thresholdLineValue: '1400',
+  thresholdLinePosition: 1400,
+};
+
 export default {
   title: 'Charts/Chart',
   component: Chart,
-  args: {
-    data: makeLineData(5),
-    horizontalGridLines: true,
-    verticalGridLines: false,
-    renderGrid: true,
-    renderXAxis: true,
-    xAxisType: 'time',
-    renderYAxis: true,
-    yAxisType: 'value',
-    renderTooltip: true,
-    tooltipSortDirection: SortDirection.Desc,
-    tooltipSortKey: SortKey.Value,
-    renderHeader: true,
-    headerTitle: 'LeafyGreen Chart Header',
-    headerShowDivider: true,
-    zoomSelectXAxis: true,
-    zoomSelectYAxis: true,
-    zoomSelectCallback: action('onZoomSelect'),
-    renderEventMarkerLine: true,
-    eventMarkerLineMessage: 'Event marker line message',
-    eventMarkerLineLabel: 'Event marker line label',
-    eventMarkerLineLevel: 'warning',
-    eventMarkerLinePosition: new Date('2024-01-01T00:20:00'),
-    renderEventMarkerPoint: true,
-    eventMarkerPointMessage: 'Event marker point message',
-    eventMarkerPointLabel: 'Event marker point label',
-    eventMarkerPointLevel: 'warning',
-    eventMarkerPointXPosition: new Date('2024-01-01T00:37:00'),
-    eventMarkerPointYPosition: 699,
-    renderThresholdLine: true,
-    thresholdLineLabel: 'Cluster Limit',
-    thresholdLineValue: '1400',
-    thresholdLinePosition: 1400,
-  },
+  args: defaultArgs,
   argTypes: {
     darkMode: storybookArgTypes.darkMode,
     data: {
@@ -376,46 +425,6 @@ export default {
     },
   },
 };
-
-interface StorybookProps {
-  data: Array<LineProps>;
-  verticalGridLines: boolean;
-  horizontalGridLines: boolean;
-  renderGrid: boolean;
-  renderXAxis: boolean;
-  xAxisType: XAxisProps['type'];
-  xAxisFormatter: XAxisProps['formatter'];
-  xAxisLabel: XAxisProps['label'];
-  renderYAxis: boolean;
-  yAxisType: YAxisProps['type'];
-  yAxisFormatter: YAxisProps['formatter'];
-  yAxisLabel: YAxisProps['label'];
-  renderTooltip: boolean;
-  tooltipSortDirection: TooltipProps['sortDirection'];
-  tooltipSortKey: TooltipProps['sortKey'];
-  tooltipValueFormatter: TooltipProps['valueFormatter'];
-  renderHeader: boolean;
-  headerTitle: HeaderProps['title'];
-  headerShowDivider: HeaderProps['showDivider'];
-  zoomSelectXAxis: boolean;
-  zoomSelectYAxis: boolean;
-  zoomSelectCallback;
-  renderEventMarkerLine: boolean;
-  eventMarkerLineMessage: EventMarkerLineProps['message'];
-  eventMarkerLineLabel: EventMarkerLineProps['label'];
-  eventMarkerLineLevel: EventMarkerLineProps['level'];
-  eventMarkerLinePosition: EventMarkerLineProps['position'];
-  renderEventMarkerPoint: boolean;
-  eventMarkerPointMessage: EventMarkerPointProps['message'];
-  eventMarkerPointLabel: EventMarkerPointProps['label'];
-  eventMarkerPointLevel: EventMarkerPointProps['level'];
-  eventMarkerPointXPosition: EventMarkerPointProps['position'][0];
-  eventMarkerPointYPosition: EventMarkerPointProps['position'][1];
-  renderThresholdLine: true;
-  thresholdLineLabel: ThresholdLineProps['label'];
-  thresholdLineValue: ThresholdLineProps['value'];
-  thresholdLinePosition: ThresholdLineProps['position'];
-}
 
 export const LiveExample: StoryObj<StorybookProps> = {
   render: ({
@@ -789,6 +798,155 @@ export const WithSameGroupIds: StoryObj<StorybookProps> = {
               label={yAxisLabel}
             />
           )}
+          {data.map(({ name, data }) => (
+            <Line name={name} data={data} key={name} />
+          ))}
+          {renderEventMarkerPoint && (
+            <EventMarkerPoint
+              label={eventMarkerPointLabel}
+              message={eventMarkerPointMessage}
+              position={[eventMarkerPointXPosition, eventMarkerPointYPosition]}
+              level={eventMarkerPointLevel}
+            />
+          )}
+          {renderEventMarkerLine && (
+            <EventMarkerLine
+              position={eventMarkerLinePosition}
+              label={eventMarkerLineLabel}
+              message={eventMarkerLineMessage}
+              level={eventMarkerLineLevel}
+            />
+          )}
+          {renderThresholdLine && (
+            <ThresholdLine
+              position={thresholdLinePosition}
+              label={thresholdLineLabel}
+              value={thresholdLineValue}
+            />
+          )}
+        </Chart>
+      </div>
+    );
+  },
+};
+
+export const ResizingWithContainer: StoryObj<
+  StorybookProps & { containerWidth: number }
+> = {
+  args: {
+    containerWidth: 500,
+  },
+  argTypes: {
+    containerWidth: {
+      control: 'number',
+      description: 'Width of the container',
+      name: 'Width',
+      table: {
+        category: 'Container',
+      },
+    },
+    // Hide other controls
+    data: { table: { disable: true } },
+    horizontalGridLines: { table: { disable: true } },
+    verticalGridLines: { table: { disable: true } },
+    renderGrid: { table: { disable: true } },
+    renderXAxis: { table: { disable: true } },
+    xAxisType: { table: { disable: true } },
+    xAxisFormatter: { table: { disable: true } },
+    xAxisLabel: { table: { disable: true } },
+    renderYAxis: { table: { disable: true } },
+    yAxisType: { table: { disable: true } },
+    yAxisFormatter: { table: { disable: true } },
+    yAxisLabel: { table: { disable: true } },
+    renderTooltip: { table: { disable: true } },
+    tooltipSortDirection: { table: { disable: true } },
+    tooltipSortKey: { table: { disable: true } },
+    tooltipValueFormatter: { table: { disable: true } },
+    renderHeader: { table: { disable: true } },
+    headerTitle: { table: { disable: true } },
+    headerShowDivider: { table: { disable: true } },
+    zoomSelectXAxis: { table: { disable: true } },
+    zoomSelectYAxis: { table: { disable: true } },
+    zoomSelectCallback: { table: { disable: true } },
+    renderEventMarkerLine: { table: { disable: true } },
+    eventMarkerLineMessage: { table: { disable: true } },
+    eventMarkerLineLabel: { table: { disable: true } },
+    eventMarkerLineLevel: { table: { disable: true } },
+    eventMarkerLinePosition: { table: { disable: true } },
+    renderEventMarkerPoint: { table: { disable: true } },
+    eventMarkerPointMessage: { table: { disable: true } },
+    eventMarkerPointLabel: { table: { disable: true } },
+    eventMarkerPointLevel: { table: { disable: true } },
+    eventMarkerPointXPosition: { table: { disable: true } },
+    eventMarkerPointYPosition: { table: { disable: true } },
+    renderThresholdLine: { table: { disable: true } },
+    thresholdLineLabel: { table: { disable: true } },
+    thresholdLineValue: { table: { disable: true } },
+    thresholdLinePosition: { table: { disable: true } },
+  },
+  render: ({ containerWidth }) => {
+    const {
+      data,
+      verticalGridLines,
+      horizontalGridLines,
+      renderGrid,
+      renderXAxis,
+      renderYAxis,
+      xAxisType,
+      yAxisType,
+      renderTooltip,
+      tooltipSortDirection,
+      tooltipSortKey,
+      renderHeader,
+      headerTitle,
+      headerShowDivider,
+      zoomSelectXAxis,
+      zoomSelectYAxis,
+      zoomSelectCallback,
+      renderEventMarkerLine,
+      eventMarkerLineMessage,
+      eventMarkerLineLabel,
+      eventMarkerLineLevel,
+      eventMarkerLinePosition,
+      renderEventMarkerPoint,
+      eventMarkerPointMessage,
+      eventMarkerPointLabel,
+      eventMarkerPointLevel,
+      eventMarkerPointXPosition,
+      eventMarkerPointYPosition,
+      renderThresholdLine,
+      thresholdLineLabel,
+      thresholdLineValue,
+      thresholdLinePosition,
+    } = defaultArgs;
+
+    return (
+      <div style={{ width: containerWidth, overflow: 'hidden' }}>
+        <Chart
+          zoomSelect={{
+            xAxis: zoomSelectXAxis,
+            yAxis: zoomSelectYAxis,
+          }}
+          onZoomSelect={zoomSelectCallback}
+        >
+          {renderHeader && (
+            <Header title={headerTitle} showDivider={headerShowDivider} />
+          )}
+          {renderGrid && (
+            <Grid
+              vertical={verticalGridLines}
+              horizontal={horizontalGridLines}
+            />
+          )}
+          {renderTooltip && (
+            <Tooltip
+              sortDirection={tooltipSortDirection}
+              sortKey={tooltipSortKey}
+              valueFormatter={() => ''}
+            />
+          )}
+          {renderXAxis && <XAxis type={xAxisType} formatter={() => ''} />}
+          {renderYAxis && <YAxis type={yAxisType} formatter={() => ''} />}
           {data.map(({ name, data }) => (
             <Line name={name} data={data} key={name} />
           ))}

--- a/charts/core/src/Chart/Chart.styles.ts
+++ b/charts/core/src/Chart/Chart.styles.ts
@@ -5,7 +5,13 @@ export const chartContainerStyles = css`
   grid-template-areas:
     'chartHeader'
     'chart';
+  grid-template-columns: 100%;
+  grid-template-rows: auto auto;
   width: 100%;
+`;
+
+export const chartHeaderContainerStyles = css`
+  grid-area: chartHeader;
 `;
 
 export const chartStyles = css`

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -17,9 +17,9 @@ import { ChartProvider } from '../ChartContext';
 
 import {
   chartContainerStyles,
+  chartHeaderContainerStyles,
   chartStyles,
   chartWrapperStyles,
-  chartHeaderContainerStyles
   loadingOverlayStyles,
 } from './Chart.styles';
 import { ChartProps, ChartStates } from './Chart.types';

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -14,7 +14,11 @@ import LeafyGreenProvider, {
 
 import { ChartProvider } from '../ChartContext';
 
-import { chartContainerStyles, chartStyles } from './Chart.styles';
+import {
+  chartContainerStyles,
+  chartHeaderContainerStyles,
+  chartStyles,
+} from './Chart.styles';
 import { ChartProps } from './Chart.types';
 import { useChart } from './hooks';
 
@@ -41,7 +45,7 @@ export function Chart({
     <LeafyGreenProvider darkMode={darkModeProp}>
       <ChartProvider chart={chart}>
         <div className={cx(chartContainerStyles, className)}>
-          <div>
+          <div className={chartHeaderContainerStyles}>
             {/**
              * Children other than Header are not expected to be rendered to the DOM,
              * but are used to provide a more declarative API for adding functionality

--- a/charts/core/src/Chart/hooks/useChart.ts
+++ b/charts/core/src/Chart/hooks/useChart.ts
@@ -63,7 +63,11 @@ export function useChart({
       if (zoomSelect?.xAxis || zoomSelect?.yAxis) {
         function enableZoomOnRender() {
           echart.enableZoom();
-          // Zooming triggers a render itself. This prevents an infinite loop.
+          /**
+           * Enabling zoom triggers a render, so once we enable it, we want to
+           * remove the handler or else there will be an infinite loop of
+           * render -> enable -> render -> etc.
+           */
           echart?.off('rendered', enableZoomOnRender);
         }
 

--- a/charts/core/src/Echart/Echart.types.ts
+++ b/charts/core/src/Echart/Echart.types.ts
@@ -118,9 +118,12 @@ export interface EChartsInstance {
   removeSeries: (name: string) => void;
   addToGroup: (groupId: string) => void;
   removeFromGroup: () => void;
+  enableZoom: () => void;
+  disableZoom: () => void;
   setupZoomSelect: (props: EChartSetupZoomSelectProps) => void;
   error: Error | null;
   hideTooltip: () => void;
+  resize: () => void;
 }
 
 export interface EChartHookProps {

--- a/charts/core/src/Echart/useEchart.spec.ts
+++ b/charts/core/src/Echart/useEchart.spec.ts
@@ -194,39 +194,6 @@ describe('@lg-echarts/core/hooks/useChart', () => {
     expect(result?.current?._echartsInstance?.group).toBe('');
   });
 
-  test('should setup zoom select on call to `setupZoomSelect`', async () => {
-    const { result } = await setupHook();
-
-    // Store the 'rendered' event handler when it's registered
-    let renderedHandler: () => void;
-    mockEchartsInstance.on.mockImplementation(
-      (event: string, handler: () => void) => {
-        if (event === 'rendered') {
-          renderedHandler = handler;
-        }
-      },
-    );
-
-    await act(async () => {
-      result.current.setupZoomSelect({ xAxis: true, yAxis: false });
-      await Promise.resolve();
-    });
-
-    // Trigger the 'rendered' event handler
-    await act(async () => {
-      renderedHandler();
-      await Promise.resolve();
-    });
-
-    expect(
-      result?.current?._echartsInstance?.dispatchAction,
-    ).toHaveBeenCalledWith({
-      type: 'takeGlobalCursor',
-      key: 'dataZoomSelect',
-      dataZoomSelectActive: true,
-    });
-  });
-
   test('should set `ready` to true when chart instance is available', async () => {
     const { result } = await setupHook();
     expect(result.current.ready).toBe(true);


### PR DESCRIPTION
## ✍️ Proposed changes
- Currently, resizing only works if the browser resizes. However, if the container gets dynamically resized, such as when a sidebar opens, it doesn't currently resize. This PR switches to instead using a `ResizeObserver` on the chart container to trigger resize.

🎟 _Jira ticket:_ [LG-4797](https://jira.mongodb.org/browse/LG-4797)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- New story added for "Resizing with container" where you can dynamically resize the container and make sure the chart shrinks and expands correctly
- Can also test that browser resizing also still works on the live example
