### PR TITLE
Remove `loading-indicator` / `lottie` dependency from `@lg-charts/core`

### DIFF
--- a/.changeset/ten-spies-breathe.md
+++ b/.changeset/ten-spies-breathe.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Removes spinner animation from `Chart` loading state

--- a/charts/core/package.json
+++ b/charts/core/package.json
@@ -20,7 +20,6 @@
     "@leafygreen-ui/icon": "workspace:^",
     "@leafygreen-ui/icon-button": "workspace:^",
     "@leafygreen-ui/lib": "workspace:^",
-    "@leafygreen-ui/loading-indicator": "workspace:^",
     "@leafygreen-ui/palette": "workspace:^",
     "@leafygreen-ui/tokens": "workspace:^",
     "@leafygreen-ui/typography": "workspace:^",

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -78,6 +78,7 @@ const defaultArgs: Omit<
   | 'tooltipValueFormatter'
 > = {
   data: makeLineData(5),
+  chartState: 'unset',
   horizontalGridLines: true,
   verticalGridLines: false,
   renderGrid: true,
@@ -126,7 +127,7 @@ export default {
     },
     chartState: {
       control: 'select',
-      options: ['default', 'loading'],
+      options: ['unset', 'loading'],
       description: 'The state of the chart',
       table: {
         category: 'Chart',

--- a/charts/core/src/Chart/Chart.styles.ts
+++ b/charts/core/src/Chart/Chart.styles.ts
@@ -1,4 +1,6 @@
 import { css } from '@leafygreen-ui/emotion';
+import { Theme } from '@leafygreen-ui/lib';
+import { color, InteractionState, Variant } from '@leafygreen-ui/tokens';
 
 export const chartContainerStyles = css`
   display: grid;
@@ -28,8 +30,10 @@ export const chartStyles = css`
   z-index: 0;
 `;
 
-export const loadingOverlayStyles = css`
-  background: white;
+export const getLoadingOverlayStyles = (theme: Theme) => css`
+  background: ${color[theme].background[Variant.Primary][
+    InteractionState.Default
+  ]};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -37,4 +41,8 @@ export const loadingOverlayStyles = css`
   height: 100%;
   width: 100%;
   z-index: 1;
+`;
+
+export const getLoadingTextStyles = (theme: Theme) => css`
+  color: ${color[theme].text[Variant.Secondary][InteractionState.Default]};
 `;

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -11,7 +11,8 @@ import { cx } from '@leafygreen-ui/emotion';
 import LeafyGreenProvider, {
   useDarkMode,
 } from '@leafygreen-ui/leafygreen-provider';
-import { Spinner } from '@leafygreen-ui/loading-indicator';
+import { BaseFontSize } from '@leafygreen-ui/tokens';
+import { Body } from '@leafygreen-ui/typography';
 
 import { ChartProvider } from '../ChartContext';
 
@@ -25,8 +26,6 @@ import {
 } from './Chart.styles';
 import { ChartProps, ChartStates } from './Chart.types';
 import { useChart } from './hooks';
-import { Body } from '@leafygreen-ui/typography';
-import { BaseFontSize } from '@leafygreen-ui/tokens';
 
 export function Chart({
   children,

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -20,10 +20,13 @@ import {
   chartHeaderContainerStyles,
   chartStyles,
   chartWrapperStyles,
-  loadingOverlayStyles,
+  getLoadingOverlayStyles,
+  getLoadingTextStyles,
 } from './Chart.styles';
 import { ChartProps, ChartStates } from './Chart.types';
 import { useChart } from './hooks';
+import { Body } from '@leafygreen-ui/typography';
+import { BaseFontSize } from '@leafygreen-ui/tokens';
 
 export function Chart({
   children,
@@ -60,8 +63,13 @@ export function Chart({
           </div>
           <div className={chartWrapperStyles}>
             {chartState === ChartStates.Loading && (
-              <div className={loadingOverlayStyles}>
-                <Spinner description="Loading chart..." />
+              <div className={getLoadingOverlayStyles(theme)}>
+                <Body
+                  className={getLoadingTextStyles(theme)}
+                  baseFontSize={BaseFontSize.Body2}
+                >
+                  Loading chart...
+                </Body>
               </div>
             )}
             <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,6 @@ importers:
       '@leafygreen-ui/lib':
         specifier: workspace:^
         version: link:../../packages/lib
-      '@leafygreen-ui/loading-indicator':
-        specifier: workspace:^
-        version: link:../../packages/loading-indicator
       '@leafygreen-ui/palette':
         specifier: workspace:^
         version: link:../../packages/palette


### PR DESCRIPTION
## ✍️ Proposed changes
This had 2 issues:
1. Lottie is currently breaking SSR components in updated LTS versions of Node.
2. Lottie is very heavy for what it's doing. This bloated the package size significantly.

It was decided to just remove the spinner altogether from now from this state.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- Verify in Storybook by updating the `ChartState` prop to "loading"