### PR TITLE
LG-4737: Remove full `lodash` import from `Menu`

### DIFF
--- a/.changeset/forty-steaks-wash.md
+++ b/.changeset/forty-steaks-wash.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/menu': patch
+---
+
+Remove full `lodash` import to decrease bundle size

--- a/packages/menu/src/Menu/utils/useMenuHeight.ts
+++ b/packages/menu/src/Menu/utils/useMenuHeight.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { isUndefined } from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 
 import { useAvailableSpace } from '@leafygreen-ui/hooks';
 


### PR DESCRIPTION
## ✍️ Proposed changes
I believe this was a mostly incorrect claim. We only have one import of `lodash` that isn't importing the module directly. The confusion might be due to the existence of `lodash-es` which is a more modern alternative with ESM support, providing treeshaking out of the box, but there shouldn't be a significant bundle size decrease using it compared to just importing the module.

🎟 _Jira ticket:_ [LG-4737](https://jira.mongodb.org/browse/LG-4737)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.