### PR TITLE
Remove unused @starting-style rule from Popover

### DIFF
--- a/.changeset/tricky-points-design.md
+++ b/.changeset/tricky-points-design.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/popover': patch
+---
+
+Remove unused `@starting-style` rule from `Popover` styles

--- a/packages/popover/src/Popover/Popover.styles.ts
+++ b/packages/popover/src/Popover/Popover.styles.ts
@@ -23,7 +23,7 @@ const basePopoverStyles = css`
   background-color: transparent;
   width: max-content;
 
-  transition-property: opacity, transform, overlay, display;
+  transition-property: opacity, transform, overlay;
   transition-duration: ${TRANSITION_DURATION}ms;
   transition-timing-function: ease-in-out;
   transition-behavior: allow-discrete;
@@ -32,17 +32,10 @@ const basePopoverStyles = css`
   transform: scale(${TRANSFORM_INITIAL_SCALE});
 
   &::backdrop {
-    transition-property: background, overlay, display;
+    transition-property: background, overlay;
     transition-duration: ${TRANSITION_DURATION}ms;
     transition-timing-function: ease-in-out;
     transition-behavior: allow-discrete;
-  }
-
-  @starting-style {
-    :popover-open {
-      opacity: 0;
-      transform: scale(${TRANSFORM_INITIAL_SCALE});
-    }
   }
 `;
 


### PR DESCRIPTION
## ✍️ Proposed changes

- remove unused `@starting-style` rule from `Popover` styles
  - this will also address console errors due to `js-dom` not being able to parse `@starting-style`

🎟 _Jira ticket:_ [LG-4844](https://jira.mongodb.org/browse/LG-4844)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
