### PR TITLE
LG-4736: Fix colors of LG Chat Messages in dark mode

### DIFF
--- a/.changeset/witty-llamas-rest.md
+++ b/.changeset/witty-llamas-rest.md
@@ -2,4 +2,5 @@
 '@lg-chat/message': patch
 ---
 
-Properly sets dark mode font color when `sourceType` is `text`
+- Properly sets dark mode font color when `sourceType` is `text`
+- Adds generated story to test both light and dark modes

--- a/.changeset/witty-llamas-rest.md
+++ b/.changeset/witty-llamas-rest.md
@@ -1,0 +1,5 @@
+---
+'@lg-chat/message': patch
+---
+
+Properly sets dark mode font color when `sourceType` is `text`

--- a/chat/message/src/Message/Message.stories.tsx
+++ b/chat/message/src/Message/Message.stories.tsx
@@ -5,10 +5,10 @@ import { WithMessageRating as MessageFeedbackStory } from '@lg-chat/message-feed
 import { storybookArgTypes, StoryMetaType } from '@lg-tools/storybook-utils';
 import { StoryFn } from '@storybook/react';
 
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 
 import { Message, MessageSourceType } from '..';
-import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 
 const MarkdownText = `
 # Heading 1

--- a/chat/message/src/Message/Message.stories.tsx
+++ b/chat/message/src/Message/Message.stories.tsx
@@ -8,6 +8,7 @@ import { StoryFn } from '@storybook/react';
 import { useUpdatedBaseFontSize } from '@leafygreen-ui/typography';
 
 import { Message, MessageSourceType } from '..';
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 
 const MarkdownText = `
 # Heading 1
@@ -79,6 +80,21 @@ const meta: StoryMetaType<typeof Message> = {
   parameters: {
     default: null,
     exclude: ['children'],
+    generate: {
+      combineArgs: {
+        darkMode: [false, true],
+        isSender: [false, true],
+        sourceType: [MessageSourceType.Text, MessageSourceType.Markdown],
+        messageBody: [UserText, MarkdownText, MongoText],
+      },
+      decorator: (Instance, context) => {
+        return (
+          <LeafyGreenProvider darkMode={context?.args.darkMode}>
+            <Instance glyph={context?.args.glyph} />
+          </LeafyGreenProvider>
+        );
+      },
+    },
   },
 };
 export default meta;
@@ -217,3 +233,5 @@ WithRichLinks.args = {
     },
   ],
 };
+
+export const Generated = () => {};

--- a/chat/message/src/Message/Message.styles.ts
+++ b/chat/message/src/Message/Message.styles.ts
@@ -1,7 +1,13 @@
 import { css } from '@leafygreen-ui/emotion';
 import { createUniqueClassName, Theme } from '@leafygreen-ui/lib';
 import { palette } from '@leafygreen-ui/palette';
-import { breakpoints, spacing } from '@leafygreen-ui/tokens';
+import {
+  breakpoints,
+  color,
+  InteractionState,
+  spacing,
+  Variant,
+} from '@leafygreen-ui/tokens';
 
 export const messageClassName = createUniqueClassName('lg-message');
 export const senderClassName = createUniqueClassName('lg-message');
@@ -9,11 +15,12 @@ export const avatarClassName = createUniqueClassName('lg-message-avatar');
 
 // Unless otherwise indicated, styles are defined as left-aligned and mobile-first by default
 
-export const baseStyles = css`
+export const getBaseStyles = (theme: Theme) => css`
   display: flex;
   gap: ${spacing[200]}px;
   align-items: flex-end;
   width: 100%;
+  color: ${color[theme].text[Variant.Primary][InteractionState.Default]};
 
   &:not(:last-child) {
     margin-bottom: ${spacing[3]}px;

--- a/chat/message/src/Message/Message.tsx
+++ b/chat/message/src/Message/Message.tsx
@@ -22,8 +22,8 @@ import { MessageLinks } from '../MessageLinks';
 
 import {
   avatarClassName,
-  baseStyles,
   desktopBaseStyles,
+  getBaseStyles,
   hiddenStyles,
   invisibleStyles,
   messageClassName,
@@ -102,7 +102,7 @@ export const Message = forwardRef(
       <LeafyGreenProvider darkMode={darkMode}>
         <div
           className={cx(
-            baseStyles,
+            getBaseStyles(theme),
             messageClassName,
             {
               [senderClassName]: isSender,


### PR DESCRIPTION
## ✍️ Proposed changes
- Properly sets dark mode font color when `sourceType` is `text`

🎟 _Jira ticket:_ [LG-4736](https://jira.mongodb.org/browse/LG-4736)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
### Functional
- Check storybook `?path=/story/chat-message--text&args=darkMode:!true` to verify working as expected

### Regression
- Check other `?path=/story/chat-message--*` stories in both dark and light modes to verify all is still working as expected
- Chromatic tests are passing

## Screenshots
### Before
<img width="854" alt="Screenshot 2025-02-06 at 11 30 02 AM" src="https://github.com/user-attachments/assets/eb3d9a22-027f-4002-b098-319dd9fa3768" />

### After
<img width="857" alt="Screenshot 2025-02-06 at 11 28 02 AM" src="https://github.com/user-attachments/assets/37490fc3-bc7d-4632-baa7-4e406770a5f6" />