### PR TITLE
LG-4866: pass readOnly to textarea

### DIFF
--- a/.changeset/funny-moons-share.md
+++ b/.changeset/funny-moons-share.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/text-area': patch
+---
+
+Resolves the issue where the `readOnly` prop was not being forwarded to the `textarea` component.

--- a/.changeset/funny-moons-share.md
+++ b/.changeset/funny-moons-share.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/text-area': patch
 ---
 
-Resolves the issue where the `readOnly` prop was not being forwarded to the `textarea` component.
+Resolves the issue where the `readOnly` prop was not being forwarded to the `textarea` component. [LG-4866](https://jira.mongodb.org/browse/LG-4866)

--- a/packages/text-area/src/TextArea.stories.tsx
+++ b/packages/text-area/src/TextArea.stories.tsx
@@ -49,6 +49,7 @@ const meta: StoryMetaType<typeof TextArea> = {
     errorMessage: 'This is an error message',
     disabled: false,
     placeholder: 'Placeholder',
+    readOnly: false,
   },
 };
 export default meta;

--- a/packages/text-area/src/TextArea/TextArea.spec.tsx
+++ b/packages/text-area/src/TextArea/TextArea.spec.tsx
@@ -170,6 +170,18 @@ describe('packages/text-area', () => {
     });
   });
 
+  describe('readOnly', () => {
+    test('renders readOnly attribute when readOnly is present', () => {
+      const { textArea } = renderTextArea({ readOnly: true });
+      expect(textArea).toHaveAttribute('readonly');
+    });
+
+    test('does not render readOnly attribute when readOnly is not present', () => {
+      const { textArea } = renderTextArea();
+      expect(textArea).not.toHaveAttribute('readonly');
+    });
+  });
+
   /* eslint-disable jest/no-disabled-tests */
   describe.skip('types behave as expected', () => {
     test('TextArea throws error when neither aria-labelledby or label is supplied', () => {

--- a/packages/text-area/src/TextArea/TextArea.tsx
+++ b/packages/text-area/src/TextArea/TextArea.tsx
@@ -42,6 +42,7 @@ export const TextArea: TextArea = forwardRef<
   TextAreaProps
 >(function TextArea(
   {
+    readOnly,
     label,
     description,
     className,
@@ -120,6 +121,7 @@ export const TextArea: TextArea = forwardRef<
     label,
     state,
     successMessage,
+    readOnly,
     ...ariaProps,
   } as const;
 

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -40,6 +40,7 @@ const meta: StoryMetaType<typeof TextInput> = {
     label: 'Label',
     description: 'This is a description',
     errorMessage: 'Invalid email',
+    readOnly: false,
   },
   argTypes: {
     darkMode: {

--- a/packages/text-input/src/TextInput/TextInput.spec.tsx
+++ b/packages/text-input/src/TextInput/TextInput.spec.tsx
@@ -205,6 +205,18 @@ describe('packages/text-input', () => {
     });
   });
 
+  describe('readOnly', () => {
+    test('renders readOnly attribute when readOnly is present', () => {
+      const { textInput } = renderTextInput({ readOnly: true });
+      expect(textInput).toHaveAttribute('readonly');
+    });
+
+    test('does not render readOnly attribute when readOnly is not present', () => {
+      const { textInput } = renderTextInput();
+      expect(textInput).not.toHaveAttribute('readonly');
+    });
+  });
+
   /* eslint-disable jest/no-disabled-tests */
   describe.skip('types behave as expected', () => {
     test('TextInput throws error when no label is supplied', () => {


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

🎟 _Jira ticket:_ [LG-4866](https://jira.mongodb.org/browse/LG-4866)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
