### PR TITLE
Include `^tsc` of upstream deps as a depend task of icon's `prebuild` task

### DIFF
--- a/packages/icon/turbo.json
+++ b/packages/icon/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "prebuild": {
-      "dependsOn": ["^prebuild"],
+      "dependsOn": ["^tsc", "^prebuild"],
       "inputs": ["src/glyphs/*.svg"],
       "outputs": ["src/generated/*.tsx"]
     }


### PR DESCRIPTION
## ✍️ Proposed changes

I just pulled `main`, did a `git clean` and `pnpm install` and now when running `pnpm run build` I'm getting:

```
@leafygreen-ui/icon:build: 
@leafygreen-ui/icon:build: > @leafygreen-ui/icon@13.1.2 prebuild /Users/kraen.hansen/Repositories/leafygreen-ui/packages/icon
@leafygreen-ui/icon:build: > ts-node ./scripts/prebuild.ts --files
@leafygreen-ui/icon:build: 
@leafygreen-ui/toggle:tsc: 
@leafygreen-ui/toggle:tsc: > @leafygreen-ui/toggle@11.0.2 tsc /Users/kraen.hansen/Repositories/leafygreen-ui/packages/toggle
@leafygreen-ui/toggle:tsc: > lg build-ts
@leafygreen-ui/toggle:tsc: 
@leafygreen-ui/icon:build: 
@leafygreen-ui/icon:build: > @leafygreen-ui/icon@13.1.2 build /Users/kraen.hansen/Repositories/leafygreen-ui/packages/icon
@leafygreen-ui/icon:build: > lg build-package
@leafygreen-ui/icon:build: 
@leafygreen-ui/toggle:tsc: src/Toggle/Toggle.tsx:5:27 - error TS2306: File '/Users/kraen.hansen/Repositories/leafygreen-ui/packages/icon/dist/generated/Checkmark.d.ts' is not a module.
@leafygreen-ui/toggle:tsc: 
@leafygreen-ui/toggle:tsc: 5 import CheckmarkIcon from '@leafygreen-ui/icon/dist/Checkmark';
@leafygreen-ui/toggle:tsc:                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@leafygreen-ui/toggle:tsc: 
@leafygreen-ui/toggle:tsc: 
@leafygreen-ui/toggle:tsc: Found 1 error.
@leafygreen-ui/toggle:tsc: 
@leafygreen-ui/toggle:tsc:  ELIFECYCLE  Command failed with exit code 1.
@leafygreen-ui/toggle:tsc: ERROR: command finished with error: command (/Users/kraen.hansen/Repositories/leafygreen-ui/packages/toggle) /Users/kraen.hansen/Library/pnpm/.tools/pnpm/9.15.0/bin/pnpm run tsc exited (1)
@leafygreen-ui/toggle#tsc: command (/Users/kraen.hansen/Repositories/leafygreen-ui/packages/toggle) /Users/kraen.hansen/Library/pnpm/.tools/pnpm/9.15.0/bin/pnpm run tsc exited (1)
```

As you can see, TurboRepo is parallelizing the execution of `icon`'s `build` (which generated the `Checkmark` file) and the toggle's `tsc` (which depends on the `Checkmark`).

I'm fairly confident this is the offending change: https://github.com/mongodb/leafygreen-ui/pull/2706 .. more specifically the removal of the `^tsc` upstream deps as a depend task of icon's `prebuild` task.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
