### PR TITLE
Restore github releases on publish [LG-4973]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,7 @@ jobs:
         with:
           version: pnpm changeset version
           publish: pnpm publish -r --no-git-checks
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           NPM_TOKEN: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
## ✍️ Proposed changes

Updates `release.yml` to create a GH release on publish (`createGithubReleases`)

[LG-4973](https://jira.mongodb.org/browse/LG-4973)