### PR TITLE
Update turbo configs [LG-5014]

### DIFF
--- a/.changeset/build-cli-verbose.md
+++ b/.changeset/build-cli-verbose.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/build': patch
+---
+
+Logs `tsconfig.json` path for `--verbose` flag

--- a/.changeset/icon-update-build.md
+++ b/.changeset/icon-update-build.md
@@ -1,0 +1,6 @@
+---
+'@leafygreen-ui/icon': patch
+---
+
+- Adds `glyphs/index.ts` to prebuild cache `turbo.json` 
+- Removes reference path `"@leafygreen-ui/icon/dist/*"` from `tsconfig.json`

--- a/packages/icon/tsconfig.json
+++ b/packages/icon/tsconfig.json
@@ -6,7 +6,6 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
-      "@leafygreen-ui/icon/dist/*": ["../icon/src/generated/*"],
       "@leafygreen-ui/*": ["../*/src"]
     }
   },

--- a/packages/icon/turbo.json
+++ b/packages/icon/turbo.json
@@ -5,7 +5,7 @@
     "prebuild": {
       "dependsOn": ["^tsc", "^prebuild"],
       "inputs": ["src/glyphs/*.svg"],
-      "outputs": ["src/generated/*.tsx"]
+      "outputs": ["src/generated/*.tsx", "src/glyphs/index.ts"]
     }
   }
 }

--- a/tools/build/src/typescript/build-ts.ts
+++ b/tools/build/src/typescript/build-ts.ts
@@ -20,7 +20,8 @@ export function buildTypescript(
     process.exit(1);
   }
 
-  verbose && console.log(chalk.gray('Building TypeScript'));
+  verbose && console.log(chalk.blue('Building TypeScript'));
+  verbose && console.log(chalk.gray(tsConfigPath));
 
   spawn('tsc', ['--build', tsConfigPath, ...(passThru ?? [''])], {
     cwd: packageDir,

--- a/turbo.json
+++ b/turbo.json
@@ -7,11 +7,15 @@
     "build": {
       "dependsOn": ["^build", "prebuild", "^prebuild"],
       "inputs": ["$TURBO_DEFAULT$", "!**/*.stories.{tsx,jsx,mdx}"],
-      "outputs": ["dist/**", "stories.js"]
+      "outputs": ["dist/**/*.js", "dist/**/*.js.map", "stories.js"]
     },
     "tsc": {
-      "dependsOn": ["^tsc", "prebuild"],
-      "outputs": ["dist/**", "tsconfig.tsbuildinfo"]
+      "dependsOn": ["^tsc", "prebuild", "^prebuild"],
+      "outputs": [
+        "dist/**/*.d.ts",
+        "dist/**/*.d.ts.map",
+        "tsconfig.tsbuildinfo"
+      ]
     },
     "docs": {
       "dependsOn": ["^tsc"],


### PR DESCRIPTION
## ✍️ Proposed changes

Logs `tsconfig.json` path for `--verbose` flag in build script

Adds `glyphs/index.ts` to prebuild cache `turbo.json` 
Removes reference path `"@leafygreen-ui/icon/dist/*"` from `tsconfig.json`

🎟 _Jira ticket:_ [LG-5014](https://jira.mongodb.org/browse/LG-5014)
