### PR TITLE
Validate builds based on `package.json`

### DIFF
--- a/.changeset/validate-build-package-json.md
+++ b/.changeset/validate-build-package-json.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/validate': minor
+---
+
+Updates build validation to use the entry files defined in the package.json

--- a/tools/validate/src/builds/getModuleTypes.ts
+++ b/tools/validate/src/builds/getModuleTypes.ts
@@ -1,0 +1,90 @@
+import fse from 'fs-extra';
+import vm from 'vm';
+
+import { ModuleType } from './modules.types';
+
+/**
+ * Adapted from https://github.com/formatjs/js-module-formats
+ *
+ * Analyze JavaScript source, collecting the module or modules information when possible.
+ * @method extract
+ * @default
+ * @param {string} path The JavaScript source path to be analyzed
+ * @return {object|array} an object or a collection of object with the info gathered from the analysis, it usually includes objects with `type` and `name` per module.
+ **/
+export function getModuleTypes(path: string): Array<ModuleType> {
+  // Essentially we're looking for import/export statements
+  const ES6ImportExportRegExp =
+    /(?:^\s*|[}{();,\n]\s*)(import\s*['"][a-zA-Z]+['"]|(import|module)\s*[^"'()\n;]+\s*from\s*['"]|export\s*((\*|\{|default|function|var|const|let|[_$a-zA-Z\xA0-\uFFFF])[\s_$a-zA-Z0-9\xA0-\uFFFF]*))/;
+  const ES6AliasRegExp =
+    /(?:^\s*|[}{();,\n]\s*)(export\s*\*\s*from\s*(?:'([^']+)'|"([^"]+)"))/;
+  const context = vm.createContext({});
+  const mods: Array<ModuleType> = [];
+
+  /**
+   * YUI detection is based on a simple rule:
+   * - if `YUI.add()` is called
+   **/
+  context.YUI = {
+    add: function () {
+      mods.push(ModuleType.yui);
+    },
+  };
+
+  /**
+  AMD detection is based on a simple rule:
+  - if `define()` is called
+  **/
+  context.define = function () {
+    mods.push(ModuleType.amd);
+  };
+
+  /**
+  Steal detection is based on a simple rule:
+  - if `steal()` is called
+  **/
+  context.steal = function () {
+    mods.push(ModuleType.steal);
+  };
+
+  /**
+  CommonJS detection is based on simple rules:
+  -    if the script calls `require()`
+  - or if the script tries to export a function thru `module.exports`
+  - or if the script tries to export an object thru `module.exports`
+  - or if the script tries to export a function thru `exports`
+  - or if the script tries to export an object thru `exports`
+  - or if the script tries to add a new member to `module.exports`
+  **/
+  context.require = function () {
+    mods.push(ModuleType.cjs);
+    throw new Error('Confirmed CJS Package. Stop Execution');
+  };
+  context.exports = Object.create(null);
+  context.module = context;
+
+  const src = fse.readFileSync(path, 'utf-8');
+
+  // executing the JavaScript source into a new context to avoid leaking
+  // globals during the detection process.
+  try {
+    vm.runInContext(src, context);
+  } catch (_e) {
+    if (ES6ImportExportRegExp.test(src) || ES6AliasRegExp.test(src)) {
+      mods.push(ModuleType.esm);
+    }
+  } finally {
+    // very dummy detection process for CommonJS modules
+    if (
+      typeof context.exports === 'function' ||
+      typeof context.exports === 'string' ||
+      typeof context.exports === 'number' ||
+      Object.keys(context.exports).length > 0 ||
+      Object.getPrototypeOf(context.exports)
+    ) {
+      mods.push(ModuleType.cjs);
+    }
+  }
+
+  return mods;
+}

--- a/tools/validate/src/builds/index.ts
+++ b/tools/validate/src/builds/index.ts
@@ -11,10 +11,6 @@ import path from 'path';
 import { ValidateCommandOptions } from '../validate.types';
 
 import { getModuleTypes } from './getModuleTypes';
-
-// A list of packages to ignore
-const ignorePackages = ['@lg-tools/storybook'];
-
 /**
  * Validates `umd`, `esm` and TS build integrity for all packages in the repository.
  */
@@ -52,12 +48,6 @@ export const validateBuilds = ({
         isESMValid: true,
         tsExists: true,
       };
-
-      // Skip some packages
-      if (ignorePackages.includes(pkgName)) {
-        verbose && console.log(chalk.gray(`Skipping package ${pkgName}`));
-        continue;
-      }
 
       const distDir = path.resolve(pkgPath, 'dist');
       const buildExists = fse.existsSync(distDir);

--- a/tools/validate/src/index.ts
+++ b/tools/validate/src/index.ts
@@ -21,7 +21,7 @@ export const validate = async (options: ValidateCommandOptions) => {
       process.exit(0);
     })
     .catch(err => {
-      console.log('Some validation failed.');
+      console.log('❌ Some validation failed.');
       console.error(err);
       process.exit(1);
     });

--- a/tools/validate/src/index.ts
+++ b/tools/validate/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { validateBuilds } from './builds';
 import { validateDependencies } from './dependencies';
 import { ValidateCommandOptions } from './validate.types';
@@ -6,14 +7,22 @@ import { ValidateCommandOptions } from './validate.types';
 export const validate = async (options: ValidateCommandOptions) => {
   const validators: Array<Promise<void>> = [];
 
-  if (!options.buildsOnly) validators.push(validateDependencies(options));
-  if (!options.depsOnly) validators.push(validateBuilds(options));
+  if (!options.buildsOnly) {
+    validators.push(validateDependencies(options));
+  }
+
+  if (!options.depsOnly) {
+    validators.push(validateBuilds(options));
+  }
 
   Promise.all(validators)
     .then(() => {
+      options.verbose && console.log('All validations passed. ✅');
       process.exit(0);
     })
-    .catch(() => {
+    .catch(err => {
+      console.log('Some validation failed.');
+      console.error(err);
       process.exit(1);
     });
 };


### PR DESCRIPTION
## ✍️ Proposed changes


`@lg-tools/validate`: patch
---

Updates build validation to use the entry files defined in the package.json


### Why?

Changing the entry point in the package.json  (e.g. `main`, `module` or `types`) can break the bundle.
This change ensures that the bundle files exist in the directory we say they'll be in