### PR TITLE
Always show hover line on charts

### DIFF
--- a/.changeset/cold-planes-listen.md
+++ b/.changeset/cold-planes-listen.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Renders a vertical line on hover regardless of whether a ChartTooltip is rendered

--- a/charts/core/src/Chart/config/getDefaultChartOptions.ts
+++ b/charts/core/src/Chart/config/getDefaultChartOptions.ts
@@ -91,4 +91,14 @@ export const getDefaultChartOptions = (
       },
     },
   },
+
+  // Adds vertical dashed line on hover, even when no tooltip is shown
+  tooltip: {
+    axisPointer: {
+      z: 0, // Prevents dashed emphasis line from being rendered on top of mark lines and labels
+    },
+    show: true,
+    trigger: 'axis',
+    formatter: () => '',
+  },
 });

--- a/charts/core/src/ChartTooltip/ChartTooltip.tsx
+++ b/charts/core/src/ChartTooltip/ChartTooltip.tsx
@@ -23,13 +23,12 @@ export function ChartTooltip({
   useEffect(() => {
     if (!chart.ready) return;
 
+    /**
+     * Some settings are configured in default chart options in order to always
+     * render the dashed vertical line on hover, even when no tooltip is shown.
+     */
     chart.updateOptions({
       tooltip: {
-        axisPointer: {
-          z: 0, // Prevents dashed emphasis line from being rendered on top of mark lines and labels
-        },
-        show: true,
-        trigger: 'axis',
         // Still adding background color to prevent peak of color at corners
         backgroundColor:
           color[theme].background[Variant.InversePrimary][
@@ -67,8 +66,9 @@ export function ChartTooltip({
 
     return () => {
       chart.updateOptions({
+        // Keeps vertical dashed line on hover, even when no tooltip is shown
         tooltip: {
-          show: false,
+          formatter: () => '',
         },
       });
     };

--- a/charts/core/src/ChartTooltip/ChartTooltip.tsx
+++ b/charts/core/src/ChartTooltip/ChartTooltip.tsx
@@ -74,6 +74,11 @@ export function ChartTooltip({
         {
           tooltip: {
             id,
+            axisPointer: {
+              z: 0, // Prevents dashed emphasis line from being rendered on top of mark lines and labels
+            },
+            show: true,
+            trigger: 'axis',
             formatter: () => '',
           },
         },


### PR DESCRIPTION
## ✍️ Proposed changes

Currently the vertical line that displays on hover, which also shows the colored points, only shows IF the ChartTooltip rendered. Instead we want that line to just always show on hover, even when the ChartTooltip isn't rendered.

🎟 _Jira ticket:_ [LG-5090](https://jira.mongodb.org/browse/LG-5090)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
Charts > Core > Basic Storybook

## Screenshots
### Before On Hover Without `ChartTooltip`
![Screenshot 2025-04-28 at 4 15 03 PM](https://github.com/user-attachments/assets/44dc0397-f46f-4897-b794-bed33068ee5e)


### After On Hover Without `ChartTooltip`
![Screenshot 2025-04-28 at 4 09 29 PM](https://github.com/user-attachments/assets/a1fefbed-431e-4172-b15c-2f685aee0de5)
