### PR TITLE
Update Popover Reference element on rerender

### DIFF
--- a/.changeset/popover-ref-el.md
+++ b/.changeset/popover-ref-el.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/popover': patch
+---
+
+Updates reference element positioning logic to ensure the correct element is used as a reference in cases where the element `ref` or DOM node changes in between renders.

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -29,6 +29,7 @@
     "@leafygreen-ui/portal": "workspace:^",
     "@leafygreen-ui/tokens": "workspace:^",
     "@types/react-transition-group": "^4.4.5",
+    "lodash": "^4.17.21",
     "react-transition-group": "^4.4.5"
   },
   "devDependencies": {

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -15,11 +15,7 @@ import {
   getWindowSafePlacementValues,
 } from '../utils/positionUtils';
 
-import {
-  useContentNode,
-  usePopoverProps,
-  useReferenceElement,
-} from './Popover.hooks';
+import { useContentNode, usePopoverProps, useReferenceElement } from './hooks';
 import {
   contentClassName,
   getPopoverStyles,

--- a/packages/popover/src/Popover/hooks/Popover.hooks.spec.ts
+++ b/packages/popover/src/Popover/hooks/Popover.hooks.spec.ts
@@ -1,0 +1,72 @@
+import { createRef, MutableRefObject } from 'react';
+import { act, renderHook } from '@testing-library/react';
+
+import { useReferenceElement } from './Popover.hooks';
+
+describe('packages/popover/hooks', () => {
+  describe('useReferenceElement', () => {
+    test('if a `refEl` is provided, the ref value is used as the reference element', () => {
+      const testRef: MutableRefObject<HTMLDivElement | null> =
+        createRef<HTMLDivElement>();
+      testRef.current = document.createElement('div');
+
+      const { result } = renderHook(() => useReferenceElement(testRef));
+
+      expect(result.current.referenceElement).toBe(testRef.current);
+    });
+
+    test('if the `refEl` changes between renders, the reference element should update', () => {
+      const testRef: MutableRefObject<HTMLDivElement | null> =
+        createRef<HTMLDivElement>();
+      testRef.current = document.createElement('div');
+      testRef.current.setAttribute('data-testid', 'testRef');
+
+      const { result, rerender } = renderHook(
+        ({ refEl }) => useReferenceElement(refEl),
+        {
+          initialProps: { refEl: testRef },
+        },
+      );
+
+      const newRef: MutableRefObject<HTMLDivElement | null> =
+        createRef<HTMLDivElement>();
+      newRef.current = document.createElement('div');
+      newRef.current.setAttribute('data-testid', 'newRef');
+
+      rerender({ refEl: newRef });
+      expect(result.current.referenceElement).toBe(newRef.current);
+    });
+
+    test('if `refEl.current` changes between renders, the reference element should update', () => {
+      const testRef: MutableRefObject<HTMLDivElement | null> =
+        createRef<HTMLDivElement>();
+      testRef.current = document.createElement('div');
+      testRef.current.setAttribute('data-testid', 'testRef');
+
+      const { result, rerender } = renderHook(
+        ({ refEl }) => useReferenceElement(refEl),
+        {
+          initialProps: { refEl: testRef },
+        },
+      );
+      testRef.current = document.createElement('div');
+      testRef.current.setAttribute('data-testid', 'testRef2');
+
+      rerender({ refEl: testRef });
+      expect(result.current.referenceElement).toBe(testRef.current);
+    });
+
+    test('if a `refEl` is not provided, the parent element of the placeholder is used as the reference element', () => {
+      const { result } = renderHook(() => useReferenceElement());
+      const placeholderElement = document.createElement('span');
+      const parentElement = document.createElement('div');
+      parentElement.appendChild(placeholderElement);
+
+      act(() => {
+        result.current.setPlaceholderElement(placeholderElement);
+      });
+
+      expect(result.current.referenceElement).toBe(parentElement);
+    });
+  });
+});

--- a/packages/popover/src/Popover/hooks/Popover.hooks.ts
+++ b/packages/popover/src/Popover/hooks/Popover.hooks.ts
@@ -13,13 +13,12 @@ import {
 } from '@leafygreen-ui/leafygreen-provider';
 
 import { getElementDocumentPosition } from '../../utils/positionUtils';
-
 import {
   PopoverProps,
   RenderMode,
   UseContentNodeReturnObj,
   UseReferenceElementReturnObj,
-} from './Popover.types';
+} from '../Popover.types';
 
 /**
  * This hook handles logic for determining what prop values are used for the `Popover`
@@ -133,9 +132,13 @@ export function useReferenceElement(
 
   const prevReferenceElement = usePrevious(refEl?.current);
 
+  // If the DOM element has changed, we need to update the reference element.
+  // Store this variable so we can trigger the useLayoutEffect
+  const didRefElementChange = !isEqual(prevReferenceElement, refEl?.current);
+
   useIsomorphicLayoutEffect(() => {
     if (refEl && refEl.current) {
-      if (!isEqual(prevReferenceElement, referenceElement)) {
+      if (didRefElementChange) {
         setReferenceElement(refEl.current);
       }
 
@@ -149,7 +152,7 @@ export function useReferenceElement(
       setReferenceElement(maybeParentEl);
       return;
     }
-  }, [placeholderElement, prevReferenceElement, refEl, referenceElement]);
+  }, [placeholderElement, didRefElementChange, refEl, referenceElement]);
 
   const referenceElDocumentPos = useObjectDependency(
     useMemo(

--- a/packages/popover/src/Popover/hooks/Popover.hooks.ts
+++ b/packages/popover/src/Popover/hooks/Popover.hooks.ts
@@ -152,7 +152,7 @@ export function useReferenceElement(
       setReferenceElement(maybeParentEl);
       return;
     }
-  }, [placeholderElement, didRefElementChange, refEl, referenceElement]);
+  }, [didRefElementChange, placeholderElement, refEl]);
 
   const referenceElDocumentPos = useObjectDependency(
     useMemo(

--- a/packages/popover/src/Popover/hooks/Popover.hooks.ts
+++ b/packages/popover/src/Popover/hooks/Popover.hooks.ts
@@ -1,8 +1,10 @@
 import React, { useMemo, useRef, useState } from 'react';
+import isEqual from 'lodash/isEqual';
 
 import {
   useIsomorphicLayoutEffect,
   useObjectDependency,
+  usePrevious,
 } from '@leafygreen-ui/hooks';
 import {
   useMigrationContext,
@@ -10,7 +12,7 @@ import {
   usePopoverPropsContext,
 } from '@leafygreen-ui/leafygreen-provider';
 
-import { getElementDocumentPosition } from '../utils/positionUtils';
+import { getElementDocumentPosition } from '../../utils/positionUtils';
 
 import {
   PopoverProps,
@@ -129,9 +131,14 @@ export function useReferenceElement(
     null,
   );
 
+  const prevReferenceElement = usePrevious(refEl?.current);
+
   useIsomorphicLayoutEffect(() => {
     if (refEl && refEl.current) {
-      setReferenceElement(refEl.current);
+      if (!isEqual(prevReferenceElement, referenceElement)) {
+        setReferenceElement(refEl.current);
+      }
+
       return;
     }
 
@@ -142,7 +149,7 @@ export function useReferenceElement(
       setReferenceElement(maybeParentEl);
       return;
     }
-  }, [placeholderElement, refEl]);
+  }, [placeholderElement, prevReferenceElement, refEl, referenceElement]);
 
   const referenceElDocumentPos = useObjectDependency(
     useMemo(

--- a/packages/popover/src/Popover/hooks/index.ts
+++ b/packages/popover/src/Popover/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './Popover.hooks';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2163,6 +2163,9 @@ importers:
       '@types/react-transition-group':
         specifier: ^4.4.5
         version: 4.4.10
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
## ✍️ Proposed changes

`@leafygreen-ui/popover`: patch
---

Updates reference element positioning logic to ensure the correct element is used as a reference in cases where the element `ref` or DOM node changes in between renders.

I believe this is the root cause of https://jira.mongodb.org/browse/LG-5066
