### PR TITLE
chore(charts): adjust chromatic diffThreshold for charts

### DIFF
--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -33,6 +33,14 @@ export default {
   component: Chart,
   parameters: {
     default: 'LiveExample',
+    chromatic: {
+      /**
+       * For some reason diffs keep getting flagged on non-changes to the canvas.
+       * The default threshold is .063, so bumping it up to 1 to test. We might
+       * consider lowering this in the future.
+       */
+      diffThreshold: 1,
+    },
   },
 
   argTypes: {

--- a/charts/drag-provider/src/DragProvider.stories.tsx
+++ b/charts/drag-provider/src/DragProvider.stories.tsx
@@ -175,6 +175,17 @@ export default {
     onDragStart: fn(),
     onDragEnd: fn(),
   },
+  parameters: {
+    default: 'LiveExample',
+    chromatic: {
+      /**
+       * For some reason diffs keep getting flagged on non-changes to the canvas.
+       * The default threshold is .063, so bumping it up to 1 to test. We might
+       * consider lowering this in the future.
+       */
+      diffThreshold: 1,
+    },
+  },
 };
 
 export const LiveExample: StoryObj<{}> = {


### PR DESCRIPTION
## ✍️ Proposed changes

Bumps the canvas threshold on charts in attempt to avoid false negatives that keep occurring.