### PR TITLE
Updates build scripts & devDeps

### DIFF
--- a/.changeset/all-lg-build-dev-dep.md
+++ b/.changeset/all-lg-build-dev-dep.md
@@ -89,4 +89,5 @@
 '@lg-chat/avatar': patch
 ---
 
-Adds missing `@lg-tools/` devDependencies
+Adds missing `@lg-tools/` devDependencies.
+Updates `build`, `tsc` & `docs` scripts to use `lg-build *` cli

--- a/.changeset/all-lg-build-dev-dep.md
+++ b/.changeset/all-lg-build-dev-dep.md
@@ -6,7 +6,6 @@
 '@leafygreen-ui/inline-definition': patch
 '@leafygreen-ui/loading-indicator': patch
 '@leafygreen-ui/segmented-control': patch
-'@lg-tools/storybook-decorators': patch
 '@leafygreen-ui/expandable-card': patch
 '@leafygreen-ui/marketing-modal': patch
 '@leafygreen-ui/radio-box-group': patch
@@ -21,7 +20,6 @@
 '@leafygreen-ui/ordered-list': patch
 '@leafygreen-ui/search-input': patch
 '@leafygreen-ui/split-button': patch
-'@lg-tools/storybook-addon': patch
 '@lg-tools/storybook-utils': patch
 '@lg-charts/drag-provider': patch
 '@lg-chat/chat-disclaimer': patch
@@ -33,7 +31,6 @@
 '@leafygreen-ui/icon-button': patch
 '@leafygreen-ui/polymorphic': patch
 '@leafygreen-ui/radio-group': patch
-'@leafygreen-ui/testing-lib': patch
 '@lg-tools/test-harnesses': patch
 '@lg-chat/message-rating': patch
 '@leafygreen-ui/date-utils': patch
@@ -75,9 +72,6 @@
 '@leafygreen-ui/modal': patch
 '@leafygreen-ui/table': patch
 '@leafygreen-ui/toast': patch
-'@lg-tools/codemods': patch
-'@lg-tools/slackbot': patch
-'@lg-tools/validate': patch
 '@lg-charts/colors': patch
 '@lg-charts/legend': patch
 '@leafygreen-ui/a11y': patch
@@ -88,20 +82,11 @@
 '@leafygreen-ui/logo': patch
 '@leafygreen-ui/menu': patch
 '@leafygreen-ui/tabs': patch
-'@lg-tools/install': patch
 '@lg-chat/message': patch
 '@leafygreen-ui/box': patch
 '@leafygreen-ui/lib': patch
-'@lg-tools/create': patch
-'@lg-tools/update': patch
 '@lg-charts/core': patch
 '@lg-chat/avatar': patch
-'@lg-tools/build': patch
-'@lg-tools/link': patch
-'@lg-tools/lint': patch
-'@lg-tools/meta': patch
-'@lg-tools/test': patch
-'@lg-tools/cli': patch
 ---
 
-Updates `main` entry point in package.json to `./dist/umd`
+Adds missing `@lg-tools/` devDependencies

--- a/.changeset/olive-ways-repeat.md
+++ b/.changeset/olive-ways-repeat.md
@@ -1,0 +1,5 @@
+---
+'@lg-tools/build': patch
+---
+
+Removes direct build warning. Using `lg-build` directly is now the preferred approach

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,5 @@
 enable-pre-post-scripts=true
 public-hoist-pattern[]=@leafygreen-ui/testing-lib
-public-hoist-pattern[]=@lg-tools/build
 public-hoist-pattern[]=@lg-tools/storybook-addon
 public-hoist-pattern[]=@lg-tools/storybook-utils
 public-hoist-pattern[]=@storybook/react

--- a/charts/chart-card/package.json
+++ b/charts/chart-card/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -34,5 +34,8 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/charts/colors/package.json
+++ b/charts/colors/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "@leafygreen-ui/emotion": "workspace:^",
-    "@leafygreen-ui/tokens": "workspace:^"
+    "@leafygreen-ui/tokens": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/charts/core/package.json
+++ b/charts/core/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@faker-js/faker": "8.0.2",
     "@leafygreen-ui/icon": "workspace:^",
+    "@lg-tools/build": "workspace:^",
     "@types/lodash.debounce": "^4.0.9"
   },
   "repository": {

--- a/charts/drag-provider/package.json
+++ b/charts/drag-provider/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -31,6 +31,7 @@
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
   "devDependencies": {
+    "@lg-tools/build": "workspace:^",
     "@storybook/test": "8.5.3"
   }
 }

--- a/charts/legend/package.json
+++ b/charts/legend/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "@leafygreen-ui/icon": "workspace:^",
-    "@lg-charts/core": "workspace:^"
+    "@lg-charts/core": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/charts/series-provider/package.json
+++ b/charts/series-provider/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -23,5 +23,8 @@
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/chat/avatar/package.json
+++ b/chat/avatar/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -25,5 +25,7 @@
     "@leafygreen-ui/leafygreen-provider": "workspace:^",
     "@lg-chat/leafygreen-chat-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/chat/chat-disclaimer/package.json
+++ b/chat/chat-disclaimer/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/chat/chat-window/package.json
+++ b/chat/chat-window/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/chat/fixed-chat-window/package.json
+++ b/chat/fixed-chat-window/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/chat/input-bar/package.json
+++ b/chat/input-bar/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/chat/leafygreen-chat-provider/package.json
+++ b/chat/leafygreen-chat-provider/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -16,5 +16,8 @@
   },
   "dependencies": {
     "use-resize-observer": "^9.1.0"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/chat/lg-markdown/package.json
+++ b/chat/lg-markdown/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/chat/message-feed/package.json
+++ b/chat/message-feed/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/chat/message-feedback/package.json
+++ b/chat/message-feedback/package.json
@@ -8,9 +8,9 @@
   "typesVersions": {},
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/chat/message-prompts/package.json
+++ b/chat/message-prompts/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -32,5 +32,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/chat/message-rating/package.json
+++ b/chat/message-rating/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -26,5 +26,7 @@
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/chat/message/package.json
+++ b/chat/message/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/chat/rich-links/package.json
+++ b/chat/rich-links/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -36,5 +36,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/chat/title-bar/package.json
+++ b/chat/title-bar/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -28,5 +28,7 @@
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -7,18 +7,18 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
+    "@leafygreen-ui/emotion": "workspace:^",
     "@leafygreen-ui/hooks": "workspace:^",
-    "@leafygreen-ui/lib": "workspace:^",
-    "@leafygreen-ui/emotion": "workspace:^"
+    "@leafygreen-ui/lib": "workspace:^"
   },
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/a11y",
   "repository": {
@@ -27,5 +27,8 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -27,5 +27,7 @@
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -33,5 +33,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -7,20 +7,20 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@leafygreen-ui/lib": "workspace:^",
     "@leafygreen-ui/emotion": "workspace:^",
-    "@leafygreen-ui/palette": "workspace:^",
     "@leafygreen-ui/icon": "workspace:^",
     "@leafygreen-ui/icon-button": "workspace:^",
+    "@leafygreen-ui/lib": "workspace:^",
+    "@leafygreen-ui/palette": "workspace:^",
     "@leafygreen-ui/tokens": "workspace:^",
     "@leafygreen-ui/typography": "workspace:^"
   },
@@ -35,5 +35,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -24,5 +24,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -27,7 +27,8 @@
   },
   "devDependencies": {
     "@leafygreen-ui/icon": "workspace:^",
-    "@leafygreen-ui/loading-indicator": "workspace:^"
+    "@leafygreen-ui/loading-indicator": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"

--- a/packages/callout/package.json
+++ b/packages/callout/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -35,5 +35,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -38,5 +38,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc",
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs",
     "postinstall": "npx ts-node scripts/postinstall.ts"
   },
   "keywords": [],

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/confirmation-modal/package.json
+++ b/packages/confirmation-modal/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/copyable/package.json
+++ b/packages/copyable/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -7,9 +7,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/date-utils/package.json
+++ b/packages/date-utils/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -23,6 +23,7 @@
     "weekstart": "^2.0.0"
   },
   "devDependencies": {
+    "@lg-tools/build": "workspace:^",
     "@types/jest": "^29.5.12"
   },
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/date-utils",

--- a/packages/descendants/package.json
+++ b/packages/descendants/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -8,9 +8,9 @@
   "typesVersions": {},
   "scripts": {
     "prebuild": "ts-node scripts/prebuild.ts",
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "keywords": [],
   "license": "Apache-2.0",
@@ -22,6 +22,7 @@
     "@emotion/server": "^11.4.0"
   },
   "devDependencies": {
+    "@lg-tools/build": "workspace:^",
     "@lg-tools/meta": "workspace:^",
     "fs-extra": "11.1.1"
   },

--- a/packages/empty-state/package.json
+++ b/packages/empty-state/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/empty-state",
@@ -35,5 +35,7 @@
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/expandable-card/package.json
+++ b/packages/expandable-card/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -38,5 +38,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/form-field/package.json
+++ b/packages/form-field/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "@leafygreen-ui/button": "workspace:^",
-    "@leafygreen-ui/icon-button": "workspace:^"
+    "@leafygreen-ui/icon-button": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/form-field",
   "repository": {

--- a/packages/form-footer/package.json
+++ b/packages/form-footer/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -35,5 +35,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/gallery-indicator/package.json
+++ b/packages/gallery-indicator/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"
@@ -32,5 +32,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/guide-cue/package.json
+++ b/packages/guide-cue/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/guide-cue",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -29,6 +29,7 @@
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
   "devDependencies": {
-    "@leafygreen-ui/emotion": "workspace:^"
+    "@leafygreen-ui/emotion": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -36,5 +36,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -8,9 +8,9 @@
   "typesVersions": {},
   "scripts": {
     "prebuild": "ts-node ./scripts/prebuild.ts",
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@leafygreen-ui/lib": "workspace:^",
     "@leafygreen-ui/palette": "workspace:^",
+    "@lg-tools/build": "workspace:^",
     "@lg-tools/lint": "workspace:^",
     "@svgr/core": "^5.3.1",
     "@types/xml2json": "^0.11.0",

--- a/packages/info-sprinkle/package.json
+++ b/packages/info-sprinkle/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/inline-definition/package.json
+++ b/packages/inline-definition/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/input-option/package.json
+++ b/packages/input-option/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/input-option",
@@ -33,7 +33,8 @@
     "@leafygreen-ui/typography": "workspace:^"
   },
   "devDependencies": {
-    "@leafygreen-ui/icon": "workspace:^"
+    "@leafygreen-ui/icon": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"

--- a/packages/leafygreen-provider/package.json
+++ b/packages/leafygreen-provider/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -28,5 +28,8 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "keywords": [],
   "license": "Apache-2.0",
@@ -30,5 +30,8 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/packages/loading-indicator/package.json
+++ b/packages/loading-indicator/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/loading-indicator",
@@ -34,5 +34,7 @@
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -28,5 +28,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/marketing-modal/package.json
+++ b/packages/marketing-modal/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/number-input/package.json
+++ b/packages/number-input/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/number-input",

--- a/packages/ordered-list/package.json
+++ b/packages/ordered-list/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/pagination",

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/password-input/package.json
+++ b/packages/password-input/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/password-input",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/polymorphic/package.json
+++ b/packages/polymorphic/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/polymorphic",
@@ -24,7 +24,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@emotion/styled": "^11.10.5"
+    "@emotion/styled": "^11.10.5",
+    "@lg-tools/build": "workspace:^"
   },
   "dependencies": {
     "@leafygreen-ui/lib": "workspace:^",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "@leafygreen-ui/button": "workspace:^",
-    "@leafygreen-ui/palette": "workspace:^"
+    "@leafygreen-ui/palette": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -23,7 +23,8 @@
     "@leafygreen-ui/lib": "workspace:^"
   },
   "devDependencies": {
-    "@leafygreen-ui/emotion": "workspace:^"
+    "@leafygreen-ui/emotion": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "gitHead": "dd71a2d404218ccec2e657df9c0263dc1c15b9e0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/portal",

--- a/packages/radio-box-group/package.json
+++ b/packages/radio-box-group/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -35,5 +35,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -26,5 +26,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/search-input/package.json
+++ b/packages/search-input/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/search-input",

--- a/packages/segmented-control/package.json
+++ b/packages/segmented-control/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -28,7 +28,8 @@
     "polished": "^4.2.2"
   },
   "devDependencies": {
-    "@leafygreen-ui/button": "workspace:^"
+    "@leafygreen-ui/button": "workspace:^",
+    "@lg-tools/build": "workspace:^"
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/skeleton-loader/package.json
+++ b/packages/skeleton-loader/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/skeleton-loader",
@@ -36,5 +36,7 @@
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/split-button",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.0.0",
     "@leafygreen-ui/button": "workspace:^",
+    "@lg-tools/build": "workspace:^",
     "react-test-renderer": "^18.2.0"
   },
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/toast",

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -21,8 +21,8 @@
     "@leafygreen-ui/icon": "workspace:^",
     "@leafygreen-ui/lib": "workspace:^",
     "@leafygreen-ui/palette": "workspace:^",
-    "@lg-tools/test-harnesses": "workspace:^",
-    "@leafygreen-ui/tokens": "workspace:^"
+    "@leafygreen-ui/tokens": "workspace:^",
+    "@lg-tools/test-harnesses": "workspace:^"
   },
   "peerDependencies": {
     "@leafygreen-ui/leafygreen-provider": "workspace:^"
@@ -36,5 +36,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -22,6 +22,7 @@
     "polished": "^4.2.2"
   },
   "devDependencies": {
+    "@lg-tools/build": "workspace:^",
     "lodash": "^4.17.21"
   },
   "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/tokens",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/types/index.d.ts",
   "typesVersions": {},
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -34,5 +34,7 @@
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,10 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../../packages/typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   charts/colors:
     dependencies:
@@ -165,6 +169,9 @@ importers:
       '@leafygreen-ui/tokens':
         specifier: workspace:^
         version: link:../../packages/tokens
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   charts/core:
     dependencies:
@@ -217,6 +224,9 @@ importers:
       '@leafygreen-ui/icon':
         specifier: workspace:^
         version: link:../../packages/icon
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       '@types/lodash.debounce':
         specifier: ^4.0.9
         version: 4.0.9
@@ -239,6 +249,9 @@ importers:
         specifier: workspace:^
         version: link:../core
     devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       '@storybook/test':
         specifier: 8.5.3
         version: 8.5.3(storybook@8.6.12(prettier@3.5.3))
@@ -276,12 +289,19 @@ importers:
       '@lg-charts/core':
         specifier: workspace:^
         version: link:../core
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   charts/series-provider:
     dependencies:
       '@leafygreen-ui/leafygreen-provider':
         specifier: workspace:^
         version: link:../../packages/leafygreen-provider
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   chat/avatar:
     dependencies:
@@ -306,6 +326,10 @@ importers:
       '@lg-chat/leafygreen-chat-provider':
         specifier: workspace:^
         version: link:../leafygreen-chat-provider
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   chat/chat-disclaimer:
     dependencies:
@@ -498,6 +522,10 @@ importers:
       use-resize-observer:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   chat/lg-markdown:
     dependencies:
@@ -678,6 +706,10 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../../packages/typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   chat/message-rating:
     dependencies:
@@ -705,6 +737,10 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../../packages/typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   chat/rich-links:
     dependencies:
@@ -735,6 +771,10 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../../packages/typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   chat/title-bar:
     dependencies:
@@ -768,6 +808,10 @@ importers:
       '@lg-chat/avatar':
         specifier: workspace:^
         version: link:../avatar
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/a11y:
     dependencies:
@@ -780,6 +824,10 @@ importers:
       '@leafygreen-ui/lib':
         specifier: workspace:^
         version: link:../lib
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/avatar:
     dependencies:
@@ -807,6 +855,10 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/badge:
     dependencies:
@@ -825,6 +877,10 @@ importers:
       '@leafygreen-ui/tokens':
         specifier: workspace:^
         version: link:../tokens
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/banner:
     dependencies:
@@ -852,8 +908,16 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
-  packages/box: {}
+  packages/box:
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/button:
     dependencies:
@@ -891,6 +955,9 @@ importers:
       '@leafygreen-ui/loading-indicator':
         specifier: workspace:^
         version: link:../loading-indicator
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/callout:
     dependencies:
@@ -943,6 +1010,10 @@ importers:
       polished:
         specifier: ^4.2.2
         version: 4.3.1
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/checkbox:
     dependencies:
@@ -976,6 +1047,10 @@ importers:
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/chip:
     dependencies:
@@ -1294,6 +1369,9 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
     devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
@@ -1387,6 +1465,9 @@ importers:
         specifier: ^11.4.0
         version: 11.11.0(@emotion/css@11.11.2)
     devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       '@lg-tools/meta':
         specifier: workspace:^
         version: link:../../tools/meta
@@ -1420,6 +1501,10 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/expandable-card:
     dependencies:
@@ -1456,6 +1541,10 @@ importers:
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/form-field:
     dependencies:
@@ -1490,6 +1579,9 @@ importers:
       '@leafygreen-ui/icon-button':
         specifier: workspace:^
         version: link:../icon-button
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/form-footer:
     dependencies:
@@ -1517,6 +1609,10 @@ importers:
       polished:
         specifier: ^4.2.2
         version: 4.3.1
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/gallery-indicator:
     dependencies:
@@ -1538,6 +1634,10 @@ importers:
       '@lg-tools/test-harnesses':
         specifier: workspace:^
         version: link:../../tools/test-harnesses
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/guide-cue:
     dependencies:
@@ -1599,6 +1699,9 @@ importers:
       '@leafygreen-ui/emotion':
         specifier: workspace:^
         version: link:../emotion
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/icon:
     dependencies:
@@ -1615,6 +1718,9 @@ importers:
       '@leafygreen-ui/palette':
         specifier: workspace:^
         version: link:../palette
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       '@lg-tools/lint':
         specifier: workspace:^
         version: link:../../tools/lint
@@ -1629,7 +1735,7 @@ importers:
         version: 11.0.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.17.12)(typescript@5.9.0-dev.20250428)
+        version: 10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.17.12)(typescript@5.9.0-dev.20250512)
       xml2json:
         specifier: ^0.12.0
         version: 0.12.0
@@ -1663,6 +1769,10 @@ importers:
       polished:
         specifier: ^4.2.2
         version: 4.3.1
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/info-sprinkle:
     dependencies:
@@ -1743,6 +1853,9 @@ importers:
       '@leafygreen-ui/icon':
         specifier: workspace:^
         version: link:../icon
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/leafygreen-provider:
     dependencies:
@@ -1755,6 +1868,10 @@ importers:
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/lib:
     dependencies:
@@ -1764,6 +1881,10 @@ importers:
       react:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.2.0
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/loading-indicator:
     dependencies:
@@ -1788,6 +1909,10 @@ importers:
       react-lottie-player:
         specifier: ^1.5.6
         version: 1.5.6(react@18.2.0)
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/logo:
     dependencies:
@@ -1800,6 +1925,10 @@ importers:
       '@leafygreen-ui/palette':
         specifier: workspace:^
         version: link:../palette
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/marketing-modal:
     dependencies:
@@ -2145,6 +2274,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.10.5
         version: 11.11.0(@emotion/react@11.11.1(@types/react@18.2.23)(react@18.2.0))(@types/react@18.2.23)(react@18.2.0)
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/popover:
     dependencies:
@@ -2185,6 +2317,9 @@ importers:
       '@leafygreen-ui/palette':
         specifier: workspace:^
         version: link:../palette
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/portal:
     dependencies:
@@ -2201,6 +2336,9 @@ importers:
       '@leafygreen-ui/emotion':
         specifier: workspace:^
         version: link:../emotion
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/radio-box-group:
     dependencies:
@@ -2250,12 +2388,20 @@ importers:
       '@leafygreen-ui/typography':
         specifier: workspace:^
         version: link:../typography
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/ripple:
     dependencies:
       '@leafygreen-ui/tokens':
         specifier: workspace:^
         version: link:../tokens
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/search-input:
     dependencies:
@@ -2344,6 +2490,9 @@ importers:
       '@leafygreen-ui/button':
         specifier: workspace:^
         version: link:../button
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/select:
     dependencies:
@@ -2477,6 +2626,10 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/split-button:
     dependencies:
@@ -2799,6 +2952,9 @@ importers:
       '@leafygreen-ui/button':
         specifier: workspace:^
         version: link:../button
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       react-test-renderer:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
@@ -2829,6 +2985,10 @@ importers:
       '@lg-tools/test-harnesses':
         specifier: workspace:^
         version: link:../../tools/test-harnesses
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   packages/tokens:
     dependencies:
@@ -2845,6 +3005,9 @@ importers:
         specifier: ^4.2.2
         version: 4.3.1
     devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -2912,6 +3075,10 @@ importers:
       '@leafygreen-ui/tokens':
         specifier: workspace:^
         version: link:../tokens
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../../tools/build
 
   tools/build:
     dependencies:
@@ -3387,10 +3554,10 @@ importers:
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
       '@storybook/react':
         specifier: 8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)
       '@storybook/react-webpack5':
         specifier: 8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)
       '@storybook/test':
         specifier: 8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
@@ -3399,7 +3566,7 @@ importers:
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
       '@svgr/webpack':
         specifier: 8.0.1
-        version: 8.0.1(typescript@5.9.0-dev.20250428)
+        version: 8.0.1(typescript@5.9.0-dev.20250512)
       assert:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3441,7 +3608,7 @@ importers:
         version: 18.2.0
       react-docgen-typescript:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.9.0-dev.20250428)
+        version: 2.2.2(typescript@5.9.0-dev.20250512)
       react-dom:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.2.0(react@18.2.0)
@@ -3520,6 +3687,10 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../build
 
   tools/test:
     dependencies:
@@ -3588,7 +3759,7 @@ importers:
         version: 11.1.1
       jest:
         specifier: 29.6.2
-        version: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))
+        version: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))
       jest-axe:
         specifier: 8.0.0
         version: 8.0.0
@@ -3613,6 +3784,10 @@ importers:
       '@testing-library/dom':
         specifier: 9.3.4
         version: 9.3.4
+    devDependencies:
+      '@lg-tools/build':
+        specifier: workspace:^
+        version: link:../build
 
   tools/update:
     dependencies:
@@ -10452,8 +10627,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.0-dev.20250428:
-    resolution: {integrity: sha512-/6K3WJlc0zjdAgLJMpU40jIxBIQ4fpAfE3o35EsPBTaqvDh9X6rY+c0NBYpYb/3UG0a2wgSr0yD0sS1l6Km7Fw==}
+  typescript@5.9.0-dev.20250512:
+    resolution: {integrity: sha512-NcgQ6vEdWlMri2/6lThf1Q23ggLulazqxe7stYe05g3UEz7bStZ593yo5FqMTDDo03+GQaHZHh6YnbXgxLdk5w==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -13188,7 +13363,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))':
+  '@jest/core@29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))':
     dependencies:
       '@jest/console': 29.6.2
       '@jest/reporters': 29.6.2
@@ -13202,7 +13377,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))
+      jest-config: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13679,7 +13854,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@storybook/builder-webpack5@8.6.12(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)':
+  '@storybook/builder-webpack5@8.6.12(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)':
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.12(prettier@3.5.3))
       '@types/semver': 7.5.0
@@ -13689,7 +13864,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.8.1(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))
       es-module-lexer: 1.6.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.0-dev.20250428)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.0-dev.20250512)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))
       html-webpack-plugin: 5.5.3(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))
       magic-string: 0.30.17
       path-browserify: 1.0.1
@@ -13707,7 +13882,7 @@ snapshots:
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -13825,11 +14000,11 @@ snapshots:
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/preset-react-webpack@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)':
+  '@storybook/preset-react-webpack@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)':
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.12(prettier@3.5.3))
-      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250428)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))
+      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250512)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))
       '@types/semver': 7.5.0
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -13842,7 +14017,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       webpack: 5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)
     optionalDependencies:
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
     transitivePeerDependencies:
       - '@storybook/test'
       - '@swc/core'
@@ -13859,16 +14034,16 @@ snapshots:
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250428)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250512)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2))':
     dependencies:
       debug: 4.4.0
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2(typescript@5.9.0-dev.20250428)
+      react-docgen-typescript: 2.2.2(typescript@5.9.0-dev.20250512)
       tslib: 2.6.2
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
       webpack: 5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)
     transitivePeerDependencies:
       - supports-color
@@ -13885,16 +14060,16 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/react-webpack5@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)':
+  '@storybook/react-webpack5@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.12(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)
-      '@storybook/preset-react-webpack': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)
-      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)
+      '@storybook/builder-webpack5': 8.6.12(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)
+      '@storybook/preset-react-webpack': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)
+      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       storybook: 8.6.12(prettier@3.5.3)
     optionalDependencies:
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
     transitivePeerDependencies:
       - '@storybook/test'
       - '@swc/core'
@@ -13933,7 +14108,7 @@ snapshots:
       '@storybook/test': 8.6.12(storybook@8.6.12(prettier@3.5.3))
       typescript: 5.8.3
 
-  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250428)':
+  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.9.0-dev.20250512)':
     dependencies:
       '@storybook/components': 8.6.12(storybook@8.6.12(prettier@3.5.3))
       '@storybook/global': 5.0.0
@@ -13946,7 +14121,7 @@ snapshots:
       storybook: 8.6.12(prettier@3.5.3)
     optionalDependencies:
       '@storybook/test': 8.6.12(storybook@8.6.12(prettier@3.5.3))
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
 
   '@storybook/test@8.5.3(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
@@ -14113,12 +14288,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.0.0(typescript@5.9.0-dev.20250428)':
+  '@svgr/core@8.0.0(typescript@5.9.0-dev.20250512)':
     dependencies:
       '@babel/core': 7.24.3
       '@svgr/babel-preset': 8.0.0(@babel/core@7.24.3)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250428)
+      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250512)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -14163,11 +14338,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250428))':
+  '@svgr/plugin-jsx@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250512))':
     dependencies:
       '@babel/core': 7.24.3
       '@svgr/babel-preset': 8.0.0(@babel/core@7.24.3)
-      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250428)
+      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250512)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -14198,10 +14373,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/plugin-svgo@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250428))(typescript@5.9.0-dev.20250428)':
+  '@svgr/plugin-svgo@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250512))(typescript@5.9.0-dev.20250512)':
     dependencies:
-      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250428)
-      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250428)
+      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250512)
+      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250512)
       deepmerge: 4.3.1
       svgo: 3.0.2
     transitivePeerDependencies:
@@ -14232,16 +14407,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/webpack@8.0.1(typescript@5.9.0-dev.20250428)':
+  '@svgr/webpack@8.0.1(typescript@5.9.0-dev.20250512)':
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-transform-react-constant-elements': 7.22.5(@babel/core@7.24.3)
       '@babel/preset-env': 7.24.3(@babel/core@7.24.3)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.3)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.3)
-      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250428)
-      '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250428))
-      '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250428))(typescript@5.9.0-dev.20250428)
+      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250512)
+      '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250512))
+      '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250512))(typescript@5.9.0-dev.20250512)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15582,14 +15757,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  cosmiconfig@8.3.6(typescript@5.9.0-dev.20250428):
+  cosmiconfig@8.3.6(typescript@5.9.0-dev.20250512):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
 
   create-ecdh@4.0.4:
     dependencies:
@@ -15985,7 +16160,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
 
   dunder-proto@1.0.1:
     dependencies:
@@ -16610,7 +16785,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.0-dev.20250428)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.0-dev.20250512)(webpack@5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)):
     dependencies:
       '@babel/code-frame': 7.24.2
       chalk: 4.1.2
@@ -16624,7 +16799,7 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.6.3
       tapable: 2.2.1
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
       webpack: 5.88.0(@swc/core@1.4.2(@swc/helpers@0.5.1))(esbuild@0.24.2)
 
   form-data@2.5.1:
@@ -17304,16 +17479,16 @@ snapshots:
       - ts-node
     optional: true
 
-  jest-cli@29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428)):
+  jest-cli@29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512)):
     dependencies:
-      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))
+      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))
       '@jest/test-result': 29.6.2
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))
+      jest-config: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))
       jest-util: 29.7.0
       jest-validate: 29.6.2
       prompts: 2.4.2
@@ -17388,7 +17563,7 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-config@29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428)):
+  jest-config@29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512)):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.6.2
@@ -17414,7 +17589,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.4.8
-      ts-node: 10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428)
+      ts-node: 10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17682,12 +17857,12 @@ snapshots:
       - ts-node
     optional: true
 
-  jest@29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428)):
+  jest@29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512)):
     dependencies:
-      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))
+      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428))
+      jest-cli: 29.6.2(@types/node@20.4.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19120,9 +19295,9 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  react-docgen-typescript@2.2.2(typescript@5.9.0-dev.20250428):
+  react-docgen-typescript@2.2.2(typescript@5.9.0-dev.20250512):
     dependencies:
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
 
   react-docgen@7.0.3:
     dependencies:
@@ -20074,7 +20249,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.2(@swc/helpers@0.5.1)
 
-  ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.17.12)(typescript@5.9.0-dev.20250428):
+  ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.17.12)(typescript@5.9.0-dev.20250512):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -20088,13 +20263,13 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.4.2(@swc/helpers@0.5.1)
 
-  ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250428):
+  ts-node@10.9.2(@swc/core@1.4.2(@swc/helpers@0.5.1))(@types/node@20.4.8)(typescript@5.9.0-dev.20250512):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -20108,7 +20283,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.0-dev.20250428
+      typescript: 5.9.0-dev.20250512
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -20235,7 +20410,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.0-dev.20250428: {}
+  typescript@5.9.0-dev.20250512: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -14,9 +14,9 @@ For each package you want turbo to build, add the following scripts to package.j
 
 ```json
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   }
 ```
 

--- a/tools/build/src/rollup/build-package.ts
+++ b/tools/build/src/rollup/build-package.ts
@@ -25,19 +25,11 @@ interface BuildPackageOptions {
 /**
  * Builds packages using rollup for the current directory
  */
-export function buildPackage({ direct, verbose }: BuildPackageOptions) {
+export function buildPackage({ verbose }: BuildPackageOptions) {
   const packageDir = process.cwd();
 
   const splitPath = packageDir.split('/');
   const packageName = splitPath[splitPath.length - 1];
-  const scopeName = splitPath[splitPath.length - 2];
-
-  if (direct && scopeName !== 'tools') {
-    console.warn(
-      `Building package @${scopeName}/${packageName} using the \`lg-internal-build-package\` command directly from \`@lg-tools/build\`.`,
-      'Consider using the global `lg build-package` command from `@lg-tools/cli` instead.',
-    );
-  }
 
   // If there is a local rollup config defined, use that
   // Otherwise use the default one

--- a/tools/create/src/templates/component/package.json.ts
+++ b/tools/create/src/templates/component/package.json.ts
@@ -17,9 +17,9 @@ export const pkgJson = ({
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lg build-package",
-    "tsc": "lg build-ts",
-    "docs": "lg build-tsdoc"
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
   },
   "publishConfig": {
     "access": "public"

--- a/tools/storybook-utils/package.json
+++ b/tools/storybook-utils/package.json
@@ -27,5 +27,8 @@
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/PD/summary"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/tools/test-harnesses/package.json
+++ b/tools/test-harnesses/package.json
@@ -15,5 +15,8 @@
   },
   "dependencies": {
     "@testing-library/dom": "9.3.1"
+  },
+  "devDependencies": {
+    "@lg-tools/build": "workspace:^"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,15 +2,15 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "prebuild": {
-      "dependsOn": ["^prebuild"]
+      "dependsOn": ["^prebuild", "^build"]
     },
     "build": {
-      "dependsOn": ["^build", "prebuild", "^prebuild"],
+      "dependsOn": ["^build", "^prebuild", "prebuild"],
       "inputs": ["$TURBO_DEFAULT$", "!**/*.stories.{tsx,jsx,mdx}"],
       "outputs": ["dist/**/*.js", "dist/**/*.js.map", "stories.js"]
     },
     "tsc": {
-      "dependsOn": ["^tsc", "prebuild", "^prebuild"],
+      "dependsOn": ["^tsc", "^prebuild", "prebuild"],
       "outputs": [
         "dist/**/*.d.ts",
         "dist/**/*.d.ts.map",


### PR DESCRIPTION
## ✍️ Proposed changes

Removes global dependency on `@lg-tools/build` & adds it as a devDep for all packages.
Updates package build scripts to use `lg-build *` rather than the full cli
Ensures deterministic turbo builds, and speeds up individual package builds by not depending on the entire `cli` package

