### PR TITLE
Restore `version` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test": "lg test",
     "unlink": "lg unlink",
     "validate": "lg validate",
+    "version": "pnpm changeset version",
     "watch": "npx nodemon --watch packages/ -e tsx,ts --exec 'pnpm run storybook build --test'"
   },
   "devDependencies": {


### PR DESCRIPTION
In the Tooling PR, the `version` script was mistakenly removed. This is causing releases to fail.