### PR TITLE
LG-4217: retain className styles for tooltip triggers passed as functions

### DIFF
--- a/.changeset/hip-goats-rule.md
+++ b/.changeset/hip-goats-rule.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/tooltip': patch
+---
+
+Bug fix for overwritten class names if tooltip trigger is an inline function

--- a/packages/tooltip/src/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip.stories.tsx
@@ -158,7 +158,10 @@ FunctionTriggerStyleRetention.args = {
     return (
       <Button
         className={css`
-          size: xsmall;
+          outline: unset;
+          border: unset;
+          background-color: lavender;
+          color: rebeccapurple;
         `}
         {...props}
       >

--- a/packages/tooltip/src/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip.stories.tsx
@@ -140,7 +140,7 @@ InitialOpen.parameters = {
   },
 };
 
-export const WithOriginalStyling = (args: TooltipProps) => {
+export const FunctionTriggerStyleRetention = (args: TooltipProps) => {
   return (
     <div
       className={css`
@@ -151,15 +151,24 @@ export const WithOriginalStyling = (args: TooltipProps) => {
     </div>
   );
 };
-WithOriginalStyling.args = {
+FunctionTriggerStyleRetention.args = {
   enabled: true,
   renderMode: RenderMode.TopLayer,
-  trigger: () => {
-    return <Button size={Size.XSmall}>Trigger</Button>;
+  trigger: (props: any) => {
+    return (
+      <Button
+        className={css`
+          size: xsmall;
+        `}
+        {...props}
+      >
+        Trigger
+      </Button>
+    );
   },
   children: 'I am a tooltip!',
 };
-WithOriginalStyling.parameters = {
+FunctionTriggerStyleRetention.parameters = {
   chromatic: {
     disableSnapshot: true,
   },

--- a/packages/tooltip/src/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip.stories.tsx
@@ -140,43 +140,6 @@ InitialOpen.parameters = {
   },
 };
 
-export const FunctionTriggerStyleRetention = (args: TooltipProps) => {
-  return (
-    <div
-      className={css`
-        padding: 100px;
-      `}
-    >
-      <Tooltip {...args} />
-    </div>
-  );
-};
-FunctionTriggerStyleRetention.args = {
-  enabled: true,
-  renderMode: RenderMode.TopLayer,
-  trigger: (props: any) => {
-    return (
-      <Button
-        className={css`
-          outline: unset;
-          border: unset;
-          background-color: lavender;
-          color: rebeccapurple;
-        `}
-        {...props}
-      >
-        Trigger
-      </Button>
-    );
-  },
-  children: 'I am a tooltip!',
-};
-FunctionTriggerStyleRetention.parameters = {
-  chromatic: {
-    disableSnapshot: true,
-  },
-};
-
 export const WithLeafyGreenChildren = LiveExample.bind({});
 WithLeafyGreenChildren.args = {
   children: (

--- a/packages/tooltip/src/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip.stories.tsx
@@ -140,6 +140,31 @@ InitialOpen.parameters = {
   },
 };
 
+export const WithOriginalStyling = (args: TooltipProps) => {
+  return (
+    <div
+      className={css`
+        padding: 100px;
+      `}
+    >
+      <Tooltip {...args} />
+    </div>
+  );
+};
+WithOriginalStyling.args = {
+  enabled: true,
+  renderMode: RenderMode.TopLayer,
+  trigger: () => {
+    return <Button size={Size.XSmall}>Trigger</Button>;
+  },
+  children: 'I am a tooltip!',
+};
+WithOriginalStyling.parameters = {
+  chromatic: {
+    disableSnapshot: true,
+  },
+};
+
 export const WithLeafyGreenChildren = LiveExample.bind({});
 WithLeafyGreenChildren.args = {
   children: (

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -429,13 +429,13 @@ describe('packages/tooltip', () => {
   });
 
   describe('when trigger is an inline function', () => {
-    function renderInlineTrigger(props = {}, trigger: any = undefined) {
+    function renderInlineTrigger(props = {}, customTrigger: any = undefined) {
       const utils = render(
         <>
           <div data-testid="backdrop" />
           <Tooltip
             trigger={
-              trigger ??
+              customTrigger ??
               (({ children, ...rest }: ButtonTestProps) => (
                 <button {...rest} data-testid="inline-trigger">
                   {buttonText}
@@ -472,22 +472,24 @@ describe('packages/tooltip', () => {
       await waitForElementToBeRemoved(tooltip);
     });
 
-    test(`retains class names of trigger component`, () => {
-      const styledTrigger = ({ children, ...rest }: ButtonTestProps) => (
+    test(`retains existing class names of trigger component`, () => {
+      const TEST_CLASS_NAME = 'test-class-name';
+
+      const customTrigger = ({ children, ...rest }: ButtonTestProps) => (
         <button
-          {...rest}
-          className="styled-trigger"
+          className={TEST_CLASS_NAME}
           data-testid="inline-trigger"
+          {...rest}
         >
           {buttonText}
           {children}
         </button>
       );
 
-      const { button } = renderInlineTrigger({}, styledTrigger);
+      const { button } = renderInlineTrigger({}, customTrigger);
 
       expect(button).toBeInTheDocument();
-      expect(button).toHaveClass('styled-trigger');
+      expect(button).toHaveClass(TEST_CLASS_NAME);
     });
   });
 

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -429,7 +429,10 @@ describe('packages/tooltip', () => {
   });
 
   describe('when trigger is an inline function', () => {
-    function renderInlineTrigger(props = {}, customTrigger: any = undefined) {
+    function renderInlineTrigger(
+      props = {},
+      customTrigger?: (props: ButtonTestProps) => ReactElement,
+    ) {
       const utils = render(
         <>
           <div data-testid="backdrop" />

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -429,17 +429,20 @@ describe('packages/tooltip', () => {
   });
 
   describe('when trigger is an inline function', () => {
-    function renderInlineTrigger(props = {}) {
+    function renderInlineTrigger(props = {}, trigger: any = undefined) {
       const utils = render(
         <>
           <div data-testid="backdrop" />
           <Tooltip
-            trigger={({ children, ...rest }: ButtonTestProps) => (
-              <button {...rest} data-testid="inline-trigger">
-                {buttonText}
-                {children}
-              </button>
-            )}
+            trigger={
+              trigger ??
+              (({ children, ...rest }: ButtonTestProps) => (
+                <button {...rest} data-testid="inline-trigger">
+                  {buttonText}
+                  {children}
+                </button>
+              ))
+            }
             {...props}
           >
             <div data-testid={tooltipTestId}>Tooltip Contents!</div>
@@ -467,6 +470,24 @@ describe('packages/tooltip', () => {
 
       fireEvent.click(button);
       await waitForElementToBeRemoved(tooltip);
+    });
+
+    test(`retains class names of trigger component`, () => {
+      const styledTrigger = ({ children, ...rest }: ButtonTestProps) => (
+        <button
+          {...rest}
+          className="styled-trigger"
+          data-testid="inline-trigger"
+        >
+          {buttonText}
+          {children}
+        </button>
+      );
+
+      const { button } = renderInlineTrigger({}, styledTrigger);
+
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveClass('styled-trigger');
     });
   });
 

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -478,14 +478,13 @@ describe('packages/tooltip', () => {
     test(`retains existing class names of trigger component`, () => {
       const TEST_CLASS_NAME = 'test-class-name';
 
-      const customTrigger = ({ children, ...rest }: ButtonTestProps) => (
+      const customTrigger = (props: ButtonTestProps) => (
         <button
           className={TEST_CLASS_NAME}
           data-testid="inline-trigger"
-          {...rest}
+          {...props}
         >
           {buttonText}
-          {children}
         </button>
       );
 

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -429,29 +429,25 @@ describe('packages/tooltip', () => {
   });
 
   describe('when trigger is an inline function', () => {
-    function renderInlineTrigger(
-      props = {},
-      customTrigger?: (props: ButtonTestProps) => ReactElement,
-    ) {
+    function renderInlineTrigger(props: TooltipProps = {}) {
+      props.trigger =
+        props.trigger ??
+        (({ children, ...rest }: ButtonTestProps) => (
+          <button {...rest} data-testid="inline-trigger">
+            {buttonText}
+            {children}
+          </button>
+        ));
+
       const utils = render(
         <>
           <div data-testid="backdrop" />
-          <Tooltip
-            trigger={
-              customTrigger ??
-              (({ children, ...rest }: ButtonTestProps) => (
-                <button {...rest} data-testid="inline-trigger">
-                  {buttonText}
-                  {children}
-                </button>
-              ))
-            }
-            {...props}
-          >
+          <Tooltip {...props}>
             <div data-testid={tooltipTestId}>Tooltip Contents!</div>
           </Tooltip>
         </>,
       );
+
       const button = utils.getByTestId('inline-trigger');
       const backdrop = utils.getByTestId('backdrop');
       return { ...utils, button, backdrop };
@@ -488,7 +484,7 @@ describe('packages/tooltip', () => {
         </button>
       );
 
-      const { button } = renderInlineTrigger({}, customTrigger);
+      const { button } = renderInlineTrigger({ trigger: customTrigger });
 
       expect(button).toBeInTheDocument();
       expect(button).toHaveClass(TEST_CLASS_NAME);

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -292,10 +292,13 @@ function Tooltip({
   );
 
   if (trigger) {
-    const originalTrigger = typeof trigger === 'function' ? trigger() : trigger;
+    const originalTrigger =
+      typeof trigger === 'function'
+        ? (trigger() as React.ReactElement<unknown>)
+        : trigger;
 
     return React.cloneElement(originalTrigger, {
-      ...(createTriggerProps(triggerEvent, originalTrigger.props) as any),
+      ...createTriggerProps(triggerEvent, originalTrigger.props),
       'aria-describedby': active ? tooltipId : undefined,
       children: (
         <>

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -293,9 +293,7 @@ function Tooltip({
 
   if (trigger) {
     const originalTrigger =
-      typeof trigger === 'function'
-        ? (trigger({}) as React.ReactElement<unknown>)
-        : trigger;
+      typeof trigger === 'function' ? trigger({}) : trigger;
 
     return React.cloneElement(originalTrigger, {
       ...createTriggerProps(triggerEvent, originalTrigger.props),

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -292,21 +292,32 @@ function Tooltip({
   );
 
   if (trigger) {
-    const originalTrigger =
-      typeof trigger === 'function'
-        ? (trigger() as React.ReactElement<unknown>)
-        : trigger;
+    if (typeof trigger === 'function') {
+      const originalTrigger = trigger({}) as React.ReactElement<any>;
 
-    return React.cloneElement(originalTrigger, {
-      ...createTriggerProps(triggerEvent, originalTrigger.props),
+      return React.cloneElement(originalTrigger, {
+        ...createTriggerProps(triggerEvent, originalTrigger.props),
+        'aria-describedby': active ? tooltipId : undefined,
+        children: (
+          <>
+            {originalTrigger.props.children}
+            {tooltip}
+          </>
+        ),
+        className: cx(positionRelative, originalTrigger.props.className),
+      });
+    }
+
+    return React.cloneElement(trigger, {
+      ...createTriggerProps(triggerEvent, trigger.props),
       'aria-describedby': active ? tooltipId : undefined,
       children: (
         <>
-          {originalTrigger.props.children}
+          {trigger.props.children}
           {tooltip}
         </>
       ),
-      className: cx(positionRelative, originalTrigger.props.className),
+      className: cx(positionRelative, trigger.props.className),
     });
   }
 

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -294,7 +294,7 @@ function Tooltip({
   if (trigger) {
     const originalTrigger =
       typeof trigger === 'function'
-        ? (trigger({}) as React.ReactElement<any>)
+        ? (trigger({}) as React.ReactElement<unknown>)
         : trigger;
 
     return React.cloneElement(originalTrigger, {

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -292,32 +292,21 @@ function Tooltip({
   );
 
   if (trigger) {
-    if (typeof trigger === 'function') {
-      const originalTrigger = trigger({}) as React.ReactElement<any>;
+    const originalTrigger =
+      typeof trigger === 'function'
+        ? (trigger({}) as React.ReactElement<any>)
+        : trigger;
 
-      return React.cloneElement(originalTrigger, {
-        ...createTriggerProps(triggerEvent, originalTrigger.props),
-        'aria-describedby': active ? tooltipId : undefined,
-        children: (
-          <>
-            {originalTrigger.props.children}
-            {tooltip}
-          </>
-        ),
-        className: cx(positionRelative, originalTrigger.props.className),
-      });
-    }
-
-    return React.cloneElement(trigger, {
-      ...createTriggerProps(triggerEvent, trigger.props),
+    return React.cloneElement(originalTrigger, {
+      ...createTriggerProps(triggerEvent, originalTrigger.props),
       'aria-describedby': active ? tooltipId : undefined,
       children: (
         <>
-          {trigger.props.children}
+          {originalTrigger.props.children}
           {tooltip}
         </>
       ),
-      className: cx(positionRelative, trigger.props.className),
+      className: cx(positionRelative, originalTrigger.props.className),
     });
   }
 

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -293,11 +293,18 @@ function Tooltip({
 
   if (trigger) {
     if (typeof trigger === 'function') {
-      return trigger({
-        ...createTriggerProps(triggerEvent),
-        className: positionRelative,
+      const originalTrigger = trigger();
+
+      return React.cloneElement(originalTrigger, {
+        ...(createTriggerProps(triggerEvent, originalTrigger.props) as any),
+        className: cx(positionRelative, originalTrigger.props.className),
         'aria-describedby': active ? tooltipId : undefined,
-        children: tooltip,
+        children: (
+          <>
+            {originalTrigger.props.children}
+            {tooltip}
+          </>
+        ),
       });
     }
 

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -292,32 +292,18 @@ function Tooltip({
   );
 
   if (trigger) {
-    if (typeof trigger === 'function') {
-      const originalTrigger = trigger();
+    const originalTrigger = typeof trigger === 'function' ? trigger() : trigger;
 
-      return React.cloneElement(originalTrigger, {
-        ...(createTriggerProps(triggerEvent, originalTrigger.props) as any),
-        className: cx(positionRelative, originalTrigger.props.className),
-        'aria-describedby': active ? tooltipId : undefined,
-        children: (
-          <>
-            {originalTrigger.props.children}
-            {tooltip}
-          </>
-        ),
-      });
-    }
-
-    return React.cloneElement(trigger, {
-      ...createTriggerProps(triggerEvent, trigger.props),
+    return React.cloneElement(originalTrigger, {
+      ...(createTriggerProps(triggerEvent, originalTrigger.props) as any),
       'aria-describedby': active ? tooltipId : undefined,
       children: (
         <>
-          {trigger.props.children}
+          {originalTrigger.props.children}
           {tooltip}
         </>
       ),
-      className: cx(positionRelative, trigger.props.className),
+      className: cx(positionRelative, originalTrigger.props.className),
     });
   }
 

--- a/packages/tooltip/src/Tooltip/Tooltip.types.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.types.ts
@@ -67,7 +67,7 @@ export type TooltipProps = Omit<
      * The `tooltip` content is rendered (via `Popover`) as a child of the trigger,
      * and if the trigger does not render any children, then the trigger will not be rendered.
      */
-    trigger?: React.ReactElement | Function;
+    trigger?: React.ReactElement | ((props: any) => React.ReactElement);
 
     /**
      * Determines if a `hover` or `click` event will trigger the opening of a `Tooltip`.


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Originally, tooltip triggers passed as functions may have styles overwritten if they use class names. Tooltip triggers passed as functions are now called to get a reference to the component's original class names, which are then applied as a combination rather than an overwrite.

🎟 _Jira ticket:_ [Tooltip trigger requires implicit pass-through className](https://jira.mongodb.org/browse/LG-4217])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
