### PR TITLE
LG-3568: search input dropdown cutoff

### DIFF
--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
@@ -6,7 +6,6 @@ import { borderRadius, color, spacing } from '@leafygreen-ui/tokens';
 
 export const searchResultsMenuStyles = css`
   box-shadow: 0px 4px 7px ${transparentize(0.75, '#000000')};
-  padding: 0;
   border-radius: ${borderRadius[300]}px;
 `;
 

--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
@@ -2,12 +2,12 @@ import { transparentize } from 'polished';
 
 import { css } from '@leafygreen-ui/emotion';
 import { Theme } from '@leafygreen-ui/lib';
-import { color } from '@leafygreen-ui/tokens';
+import { borderRadius, color, spacing } from '@leafygreen-ui/tokens';
 
 export const searchResultsMenuStyles = css`
   box-shadow: 0px 4px 7px ${transparentize(0.75, '#000000')};
   padding: 0;
-  border-radius: 12px;
+  border-radius: ${borderRadius[300]}px;
 `;
 
 export const getSearchResultsMenuThemeStyles = (theme: Theme) => css`
@@ -16,9 +16,9 @@ export const getSearchResultsMenuThemeStyles = (theme: Theme) => css`
 `;
 
 export const searchResultsListStyles = css`
-  padding: 12px 0;
+  padding: ${spacing[300]}px 0;
   margin: 0;
-  border-radius: 12px;
+  border-radius: ${borderRadius[300]}px;
   overflow-y: auto;
   scroll-behavior: smooth;
 `;

--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
@@ -16,7 +16,7 @@ export const getSearchResultsMenuThemeStyles = (theme: Theme) => css`
 `;
 
 export const searchResultsListStyles = css`
-  padding: 8px 0;
+  padding: 12px 0;
   margin: 0;
   border-radius: 12px;
   overflow-y: auto;

--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
@@ -6,7 +6,7 @@ import { color } from '@leafygreen-ui/tokens';
 
 export const searchResultsMenuStyles = css`
   box-shadow: 0px 4px 7px ${transparentize(0.75, '#000000')};
-  padding: 0px 0;
+  padding: 0;
   border-radius: 12px;
 `;
 

--- a/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
+++ b/packages/search-input/src/SearchResultsMenu/SearchResultsMenu.style.ts
@@ -6,7 +6,7 @@ import { color } from '@leafygreen-ui/tokens';
 
 export const searchResultsMenuStyles = css`
   box-shadow: 0px 4px 7px ${transparentize(0.75, '#000000')};
-  padding: 12px 0;
+  padding: 0px 0;
   border-radius: 12px;
 `;
 
@@ -16,9 +16,9 @@ export const getSearchResultsMenuThemeStyles = (theme: Theme) => css`
 `;
 
 export const searchResultsListStyles = css`
-  padding: 0;
+  padding: 8px 0;
   margin: 0;
-  border-radius: inherit;
+  border-radius: 12px;
   overflow-y: auto;
   scroll-behavior: smooth;
 `;


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Scroll behavior of search input dropdown now matches select dropdown - padding only exists at top and bottom, not while scrolling.

🎟 _Jira ticket:_ [LG-3568](https://jira.mongodb.org/browse/LG-3568)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
