### PR TITLE
LG-5064: resolve outstanding TS TODOs

### DIFF
--- a/.changeset/todo-charts.md
+++ b/.changeset/todo-charts.md
@@ -1,0 +1,10 @@
+---
+'@lg-charts/core': patch
+---
+
+Updates axis `formatter` prop signature to match echarts.
+```ts
+{
+  formatter?: (value: number, index?: number) => string | string;
+}
+```

--- a/.changeset/todo-polymorphic.md
+++ b/.changeset/todo-polymorphic.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/polymorphic': patch
+---
+
+Replace `ReactElement` with `ReactNode` in type definitions

--- a/charts/core/src/Echart/Echart.types.ts
+++ b/charts/core/src/Echart/Echart.types.ts
@@ -12,6 +12,10 @@ import type { ComposeOption, EChartsType } from 'echarts/core';
 
 import { Theme } from '@leafygreen-ui/lib';
 
+// Type not exported by echarts.
+// reference: https://github.com/apache/echarts/blob/master/src/coord/axisCommonTypes.ts#L193
+export type AxisLabelValueFormatter = (value: number, index?: number) => string;
+
 type RequiredSeriesProps = 'type' | 'name' | 'data';
 export type EChartSeriesOption = Pick<LineSeriesOption, RequiredSeriesProps> &
   Partial<Omit<LineSeriesOption, RequiredSeriesProps>>;

--- a/charts/core/src/XAxis/XAxis.tsx
+++ b/charts/core/src/XAxis/XAxis.tsx
@@ -33,7 +33,6 @@ const getOptions = ({
           width: 1,
         },
       },
-      // @ts-expect-error TODO:
       axisLabel: {
         show: true,
         fontFamily: fontFamilies.default,

--- a/charts/core/src/XAxis/XAxis.types.ts
+++ b/charts/core/src/XAxis/XAxis.types.ts
@@ -1,3 +1,5 @@
+import type { AxisLabelValueFormatter } from '../Echart/Echart.types';
+
 export const XAxisType = {
   Log: 'log',
   Time: 'time',
@@ -24,5 +26,5 @@ export interface XAxisProps {
    * formatter: (value, index) => `${value}GB`
    * ```
    */
-  formatter?: (value: string, index: number) => string;
+  formatter?: AxisLabelValueFormatter | string;
 }

--- a/charts/core/src/YAxis/YAxis.tsx
+++ b/charts/core/src/YAxis/YAxis.tsx
@@ -33,7 +33,6 @@ const getOptions = ({
           width: 1,
         },
       },
-      // @ts-expect-error TODO:
       axisLabel: {
         show: true,
         fontFamily: fontFamilies.default,

--- a/charts/core/src/YAxis/YAxis.types.ts
+++ b/charts/core/src/YAxis/YAxis.types.ts
@@ -1,3 +1,5 @@
+import type { AxisLabelValueFormatter } from '../Echart/Echart.types';
+
 export const YAxisType = {
   Log: 'log',
   Time: 'time',
@@ -28,5 +30,5 @@ export interface YAxisProps {
    *}
    * ```
    */
-  formatter?: (value: string, index: number) => string;
+  formatter?: AxisLabelValueFormatter | string;
 }

--- a/packages/box/src/Box.tsx
+++ b/packages/box/src/Box.tsx
@@ -51,7 +51,17 @@ type BoxComponent<TProps = {}, ExtraProps = {}> = Override2<
   ExtraProps
 >;
 
-// TODO: TSDoc
+/**
+ * A flexible polymorphic type for the Box component, which allows various implementations:
+ * - Default anchor element
+ * - Any intrinsic JSX element
+ * - Custom React component
+ * - Default element type
+ *
+ * @deprecated Prefer using Polymorphic types from `@leafygreen-ui/polymorphic` package.
+ * @typeParam Default - The default React element type to render, defaults to 'div'
+ * @typeParam ExtraProps - Additional props to extend the component with
+ */
 export type BoxProps<
   Default extends React.ElementType = 'div',
   ExtraProps = {},

--- a/packages/callout/src/Callout.stories.tsx
+++ b/packages/callout/src/Callout.stories.tsx
@@ -49,6 +49,12 @@ const meta: StoryMetaType<typeof Callout> = {
       control: { type: 'select' },
       defaultValue: Variant.Note,
     },
+    baseFontSize: {
+      options: Object.values(BaseFontSize),
+      control: { type: 'radio' },
+      description:
+        'The base font size of the title and text rendered in children',
+    },
   },
 };
 export default meta;

--- a/packages/callout/src/Callout/Callout.types.ts
+++ b/packages/callout/src/Callout/Callout.types.ts
@@ -24,7 +24,6 @@ export interface CalloutProps extends HTMLElementProps<'div'>, DarkModeProps {
    */
   title?: string;
 
-  // TODO: Make sure this prop generates a Storybook control.
   /**
    * The base font size of the title and text rendered in children.
    */

--- a/packages/code/src/CopyButton/CopyButton.spec.tsx
+++ b/packages/code/src/CopyButton/CopyButton.spec.tsx
@@ -192,6 +192,23 @@ describe('CopyButton', () => {
     );
   });
 
-  // TODO: get this to work https://jira.mongodb.org/browse/LG-4760
-  test.todo('copies the correct text when copy button is clicked');
+  test('copies the correct text when copy button is clicked', async () => {
+    const onCopy = jest.fn();
+    const clipboardTextFn = jest.fn().mockReturnValue(contents);
+
+    const { getByTestId, getByRole } = renderCopyButton({ onCopy });
+    const copyButton = getByTestId(testIds.copyButton);
+
+    userEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(onCopy).toHaveBeenCalledTimes(1);
+      expect(ClipboardJS).toHaveBeenCalled();
+      expect(clipboardTextFn()).toBe(contents);
+
+      // Check for screen reader announcement
+      const alert = getByRole('alert');
+      expect(alert).toHaveTextContent(COPIED_TEXT);
+    });
+  });
 });

--- a/packages/code/src/CopyButton/CopyButton.spec.tsx
+++ b/packages/code/src/CopyButton/CopyButton.spec.tsx
@@ -192,23 +192,6 @@ describe('CopyButton', () => {
     );
   });
 
-  test('copies the correct text when copy button is clicked', async () => {
-    const onCopy = jest.fn();
-    const clipboardTextFn = jest.fn().mockReturnValue(contents);
-
-    const { getByTestId, getByRole } = renderCopyButton({ onCopy });
-    const copyButton = getByTestId(testIds.copyButton);
-
-    userEvent.click(copyButton);
-
-    await waitFor(() => {
-      expect(onCopy).toHaveBeenCalledTimes(1);
-      expect(ClipboardJS).toHaveBeenCalled();
-      expect(clipboardTextFn()).toBe(contents);
-
-      // Check for screen reader announcement
-      const alert = getByRole('alert');
-      expect(alert).toHaveTextContent(COPIED_TEXT);
-    });
-  });
+  // TODO: get this to work https://jira.mongodb.org/browse/LG-4760
+  test.todo('copies the correct text when copy button is clicked');
 });

--- a/packages/combobox/src/Combobox/Combobox.spec.tsx
+++ b/packages/combobox/src/Combobox/Combobox.spec.tsx
@@ -428,7 +428,9 @@ describe('packages/combobox', () => {
         });
         waitFor(() => {
           const allChips = queryChipsByName(['Apple', 'Banana']);
-          allChips?.forEach(chip => expect(chip).toBeInTheDocument());
+          allChips?.forEach((chip: HTMLElement) =>
+            expect(chip).toBeInTheDocument(),
+          );
           expect(queryAllChips()).toHaveLength(2);
         });
       });
@@ -450,7 +452,9 @@ describe('packages/combobox', () => {
           const { openMenu } = renderCombobox('multiple', { initialValue });
           const { selectedElements } = openMenu();
           expect(
-            selectedElements?.every(element => element?.querySelector('input')),
+            selectedElements?.every((element: HTMLElement) =>
+              element?.querySelector('input'),
+            ),
           ).toBeTruthy();
         },
       );
@@ -547,13 +551,17 @@ describe('packages/combobox', () => {
             });
           waitFor(() => {
             const allChips = queryChipsByName(['Apple', 'Banana']);
-            allChips?.forEach(chip => expect(chip).toBeInTheDocument());
+            allChips?.forEach((chip: HTMLElement) =>
+              expect(chip).toBeInTheDocument(),
+            );
             expect(queryAllChips()).toHaveLength(2);
             value = ['banana', 'carrot'];
             rerenderCombobox({ value });
             waitFor(() => {
               const allChips = queryChipsByName(['Carrot', 'Banana']);
-              allChips?.forEach(chip => expect(chip).toBeInTheDocument());
+              allChips?.forEach((chip: HTMLElement) =>
+                expect(chip).toBeInTheDocument(),
+              );
               expect(queryAllChips()).toHaveLength(2);
             });
           });
@@ -566,7 +574,9 @@ describe('packages/combobox', () => {
           });
           waitFor(() => {
             const allChips = queryChipsByName(['Apple']);
-            allChips?.forEach(chip => expect(chip).toBeInTheDocument());
+            allChips?.forEach((chip: HTMLElement) =>
+              expect(chip).toBeInTheDocument(),
+            );
             expect(queryChipsByName('Jellybean')).not.toBeInTheDocument();
             expect(queryAllChips()).toHaveLength(1);
           });
@@ -872,7 +882,9 @@ describe('packages/combobox', () => {
           await waitFor(() => {
             expect(appleChip).not.toBeInTheDocument();
             const allChips = queryChipsByName(['Banana', 'Carrot']);
-            allChips?.forEach(chip => expect(chip).toBeInTheDocument());
+            allChips?.forEach((chip: HTMLElement) =>
+              expect(chip).toBeInTheDocument(),
+            );
             expect(queryAllChips()).toHaveLength(2);
           });
         });

--- a/packages/combobox/src/Combobox/Combobox.spec.tsx
+++ b/packages/combobox/src/Combobox/Combobox.spec.tsx
@@ -1410,46 +1410,65 @@ describe('packages/combobox', () => {
           expect(inputEl).toHaveFocus();
         });
 
-        // FIXME: act warning
-        testMultiSelect('Focuses input when focus is on last chip', () => {
-          const initialValue = ['apple', 'banana'];
-          const { inputEl } = renderCombobox(select, {
-            initialValue,
-          });
-          userEvent.type(
-            inputEl!,
-            'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
-          );
-          expect(inputEl!).toHaveFocus();
-          // This behavior passes in the browser, but not in jest
-          // expect(inputEl!.selectionStart).toEqual(0);
-        });
+        testMultiSelect(
+          'Focuses input when focus is on last chip',
+          async () => {
+            const initialValue = ['apple', 'banana'];
+            const { inputEl } = renderCombobox(select, {
+              initialValue,
+            });
 
-        // FIXME: act warning
-        testMultiSelect('Focuses input when focus is on only chip', () => {
-          const initialValue = ['apple'];
-          const { inputEl } = renderCombobox(select, {
-            initialValue,
-          });
-          userEvent.type(
-            inputEl!,
-            'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
-          );
-          expect(inputEl!).toHaveFocus();
-          // expect(inputEl!.selectionStart).toEqual(0);
-        });
+            await act(async () => {
+              userEvent.type(
+                inputEl!,
+                'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
+              );
+            });
 
-        // FIXME: act warning
+            await waitFor(() => {
+              expect(inputEl!).toHaveFocus();
+            });
+            // This behavior passes in the browser, but not in jest
+            // expect(inputEl!.selectionStart).toEqual(0);
+          },
+        );
+
+        testMultiSelect(
+          'Focuses input when focus is on only chip',
+          async () => {
+            const initialValue = ['apple'];
+            const { inputEl } = renderCombobox(select, {
+              initialValue,
+            });
+
+            await act(async () => {
+              userEvent.type(
+                inputEl!,
+                'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
+              );
+            });
+
+            await waitFor(() => {
+              expect(inputEl!).toHaveFocus();
+            });
+            // expect(inputEl!.selectionStart).toEqual(0);
+          },
+        );
+
         testMultiSelect(
           'Focuses next chip when focus is on an inner chip',
-          () => {
+          async () => {
             const initialValue = ['apple', 'banana', 'carrot'];
             const { inputEl, queryChipsByIndex } = renderCombobox(select, {
               initialValue,
             });
-            userEvent.type(inputEl!, '{arrowleft}{arrowleft}{arrowright}');
-            const lastChip = queryChipsByIndex('last');
-            expect(lastChip!).toContainFocus();
+            await act(async () => {
+              userEvent.type(inputEl!, '{arrowleft}{arrowleft}{arrowright}');
+            });
+            await waitFor(() => {
+              const lastChip = queryChipsByIndex('last');
+              expect(lastChip!).toContainFocus();
+            });
           },
         );
       });

--- a/packages/combobox/src/Combobox/Combobox.spec.tsx
+++ b/packages/combobox/src/Combobox/Combobox.spec.tsx
@@ -1422,65 +1422,46 @@ describe('packages/combobox', () => {
           expect(inputEl).toHaveFocus();
         });
 
-        testMultiSelect(
-          'Focuses input when focus is on last chip',
-          async () => {
-            const initialValue = ['apple', 'banana'];
-            const { inputEl } = renderCombobox(select, {
-              initialValue,
-            });
+        // FIXME: act warning
+        testMultiSelect('Focuses input when focus is on last chip', () => {
+          const initialValue = ['apple', 'banana'];
+          const { inputEl } = renderCombobox(select, {
+            initialValue,
+          });
+          userEvent.type(
+            inputEl!,
+            'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
+          );
+          expect(inputEl!).toHaveFocus();
+          // This behavior passes in the browser, but not in jest
+          // expect(inputEl!.selectionStart).toEqual(0);
+        });
 
-            await act(async () => {
-              userEvent.type(
-                inputEl!,
-                'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
-              );
-            });
+        // FIXME: act warning
+        testMultiSelect('Focuses input when focus is on only chip', () => {
+          const initialValue = ['apple'];
+          const { inputEl } = renderCombobox(select, {
+            initialValue,
+          });
+          userEvent.type(
+            inputEl!,
+            'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
+          );
+          expect(inputEl!).toHaveFocus();
+          // expect(inputEl!.selectionStart).toEqual(0);
+        });
 
-            await waitFor(() => {
-              expect(inputEl!).toHaveFocus();
-            });
-            // This behavior passes in the browser, but not in jest
-            // expect(inputEl!.selectionStart).toEqual(0);
-          },
-        );
-
-        testMultiSelect(
-          'Focuses input when focus is on only chip',
-          async () => {
-            const initialValue = ['apple'];
-            const { inputEl } = renderCombobox(select, {
-              initialValue,
-            });
-
-            await act(async () => {
-              userEvent.type(
-                inputEl!,
-                'abc{arrowleft}{arrowleft}{arrowleft}{arrowleft}{arrowright}',
-              );
-            });
-
-            await waitFor(() => {
-              expect(inputEl!).toHaveFocus();
-            });
-            // expect(inputEl!.selectionStart).toEqual(0);
-          },
-        );
-
+        // FIXME: act warning
         testMultiSelect(
           'Focuses next chip when focus is on an inner chip',
-          async () => {
+          () => {
             const initialValue = ['apple', 'banana', 'carrot'];
             const { inputEl, queryChipsByIndex } = renderCombobox(select, {
               initialValue,
             });
-            await act(async () => {
-              userEvent.type(inputEl!, '{arrowleft}{arrowleft}{arrowright}');
-            });
-            await waitFor(() => {
-              const lastChip = queryChipsByIndex('last');
-              expect(lastChip!).toContainFocus();
-            });
+            userEvent.type(inputEl!, '{arrowleft}{arrowleft}{arrowright}');
+            const lastChip = queryChipsByIndex('last');
+            expect(lastChip!).toContainFocus();
           },
         );
       });

--- a/packages/date-picker/src/DatePicker/DatePickerContext/useDatePickerComponentRefs.ts
+++ b/packages/date-picker/src/DatePicker/DatePickerContext/useDatePickerComponentRefs.ts
@@ -10,9 +10,6 @@ import { DatePickerComponentRefs } from './DatePickerContext.types';
 export const useDateRangeComponentRefs = (): DatePickerComponentRefs => {
   const segmentRefs = useSegmentRefs();
 
-  // TODO: https://jira.mongodb.org/browse/LG-3666
-  // useDynamicRefs may overflow if a user navigates to too many months.
-  // consider purging the refs map within the hook
   const calendarCellRefs = useDynamicRefs<HTMLTableCellElement>();
 
   const calendarButtonRef = useRef<HTMLButtonElement>(null);

--- a/packages/polymorphic/src/Polymorphic/Polymorph.tsx
+++ b/packages/polymorphic/src/Polymorphic/Polymorph.tsx
@@ -36,7 +36,6 @@ export const BasePolymorph = <T extends PolymorphicAs = 'div'>(
  * However: If you want to expose `as` as a prop of your component,
  * prefer the `{@link Polymorphic}` factory function and related hooks.
  */
-// @ts-expect-error TODO: Polymorphic TS
 export const Polymorph: PolymorphicComponentType =
   React.forwardRef(BasePolymorph);
 Polymorph.displayName = 'Polymorph';

--- a/packages/polymorphic/src/Polymorphic/Polymorphic.types.ts
+++ b/packages/polymorphic/src/Polymorphic/Polymorphic.types.ts
@@ -7,7 +7,7 @@ import {
   ElementType,
   PropsWithChildren,
   PropsWithoutRef,
-  ReactElement,
+  ReactNode,
   RefAttributes,
   WeakValidationMap,
 } from 'react';
@@ -109,7 +109,7 @@ export interface PolymorphicComponentType<
   <T extends PolymorphicAs = DefaultAs>(
     props: PolymorphicPropsWithRef<T, XP>,
     ref: PolymorphicRef<T>,
-  ): ReactElement | null;
+  ): ReactNode | null;
   displayName?: string;
   propTypes?:
     | WeakValidationMap<
@@ -133,7 +133,7 @@ export interface PolymorphicRenderFunction<
   <T extends PolymorphicAs = DefaultAs>(
     props: PolymorphicPropsWithRef<T, XP>,
     ref: PolymorphicRef<T>,
-  ): ReactElement | null;
+  ): ReactNode | null;
   displayName?: string;
   propTypes?: never;
 }


### PR DESCRIPTION
## ✍️ Proposed changes

[LG-5064](https://jira.mongodb.org/browse/LG-5064)

`@lg-charts/core`: patch
---

Updates axis `formatter` prop signature to match echarts.
```ts
{
  formatter?: (value: number, index?: number) => string | string;
}
```


`@leafygreen-ui/polymorphic`: patch
---

Replace `ReactElement` with `ReactNode` in type definitions
