### PR TITLE
LG-5136: render named React components to get node text content

### DIFF
--- a/packages/lib/src/getNodeTextContent/index.ts
+++ b/packages/lib/src/getNodeTextContent/index.ts
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, ReactText } from 'react';
+import { FunctionComponent, ReactElement, ReactNode, ReactText } from 'react';
 
 /**
  * Returns the text string of a React node
@@ -12,15 +12,24 @@ export default function getNodeTextContent(node?: ReactNode): string {
     return node.map(getNodeTextContent).join(' ').trim();
   }
 
-  if (hasChildren(node)) {
-    return getNodeTextContent(node.props.children);
+  if (isReactElement(node)) {
+    if (isRendered(node)) {
+      return getNodeTextContent(node.props.children);
+    }
+
+    const Component = node.type as FunctionComponent<any>;
+    return getNodeTextContent(Component(node.props));
   }
 
   return '';
 }
 
-function hasChildren(item?: any): item is ReactElement {
+function isReactElement(item?: any): item is ReactElement {
   return item && typeof item === 'object' && item.props;
+}
+
+function isRendered(item?: any): boolean {
+  return isReactElement(item) && item.props.children;
 }
 
 function isText(item?: any): item is ReactText {


### PR DESCRIPTION
## ✍️ Proposed changes

Previously, passing functional components into `getNodeTextContent` returned an empty string. Changed to render, then continue recursion.

🎟 _Jira ticket:_ [LG-5136](https://jira.mongodb.org/browse/LG-5136)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
