### PR TITLE
fix(Chart): Fix CSS so consumers can adjust height

### DIFF
--- a/.changeset/itchy-islands-draw.md
+++ b/.changeset/itchy-islands-draw.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': patch
+---
+
+Allow consumers to adjust height on Charts

--- a/charts/core/src/Chart/Chart.styles.ts
+++ b/charts/core/src/Chart/Chart.styles.ts
@@ -16,8 +16,9 @@ const getBaseContainerStyles = (theme: Theme) => css`
   grid-template-areas:
     'chartHeader'
     'chart';
+  height: 316px; // 280px + 36px for header
   grid-template-columns: 100%;
-  grid-template-rows: auto auto;
+  grid-template-rows: auto 1fr;
   width: 100%;
 `;
 
@@ -93,7 +94,6 @@ const baseChartWrapperStyles = css`
   position: relative;
   display: block;
   grid-area: chart;
-  height: 280px;
   width: 100%;
 `;
 

--- a/charts/core/src/Chart/Chart.tsx
+++ b/charts/core/src/Chart/Chart.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 
-import { cx } from '@leafygreen-ui/emotion';
+import { css, cx } from '@leafygreen-ui/emotion';
 import LeafyGreenProvider, {
   useDarkMode,
 } from '@leafygreen-ui/leafygreen-provider';


### PR DESCRIPTION
## ✍️ Proposed changes

A charts height was accidentally set to fixed. This instead sets the height of the container which the consumer does have control over, with the chart filling the remainder of the container.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
