### PR TITLE
Exports missing descendants highlight type

### DIFF
--- a/.changeset/descendants-missing-types.md
+++ b/.changeset/descendants-missing-types.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/descendants': patch
+---
+
+Exports missing `UseHighlightOptions` and `HighlightContextType` types

--- a/packages/descendants/src/Highlight/index.ts
+++ b/packages/descendants/src/Highlight/index.ts
@@ -4,8 +4,12 @@ export type {
   HighlightContextProps,
   HighlightHookReturnType,
   Index,
+  UseHighlightOptions,
 } from './highlight.types';
-export { createHighlightContext } from './HighlightContext';
+export {
+  createHighlightContext,
+  type HighlightContextType,
+} from './HighlightContext';
 export { HighlightProvider } from './HighlightProvider';
 export { useHighlight } from './useHighlight';
 export { useHighlightContext } from './useHighlightContext';

--- a/packages/descendants/src/index.ts
+++ b/packages/descendants/src/index.ts
@@ -18,9 +18,11 @@ export {
   type Direction,
   type HighlightChangeHandler,
   type HighlightContextProps,
+  type HighlightContextType,
   type HighlightHookReturnType,
   HighlightProvider,
   type Index,
   useHighlight,
   useHighlightContext,
+  type UseHighlightOptions,
 } from './Highlight';


### PR DESCRIPTION
## ✍️ Proposed changes

`@leafygreen-ui/descendants`: patch
---

Exports missing `UseHighlightOptions` and `HighlightContextType` types