### PR TITLE
LG-5338: Allow `null` and `undefined` values in data points

### DIFF
--- a/.changeset/itchy-things-know.md
+++ b/.changeset/itchy-things-know.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/core': minor
+---
+
+Allow `null` and `undefined` values in data points

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -31,13 +31,13 @@ import { Chart, ChartGrid, ChartHeader, Line, XAxis, YAxis, type ChartStates } f
   <EventMarkerPoint
     label='2024/01/04 (value 3)'
     message='Critical event occurred'
-    position={[new Date(2020, 01, 04), 3]}
+    position={[new Date(2020, 1, 4), 3]}
     level='warning'
   />
   <EventMarkerLine
     label='2024/01/02'
     message='Something happened of note'
-    position={new Date(2020, 01, 02)}
+    position={new Date(2020, 1, 2)}
     level='info'
   />
   <ThresholdLine
@@ -48,21 +48,21 @@ import { Chart, ChartGrid, ChartHeader, Line, XAxis, YAxis, type ChartStates } f
   <Line
     name="Series 1"
     data={[
-      [new Date(2020, 01, 01), 0],
-      [new Date(2020, 01, 02), 1],
-      [new Date(2020, 01, 03), 2],
-      [new Date(2020, 01, 04), 3],
-      [new Date(2020, 01, 05), 4],
+      [new Date(2020, 1, 1), 0],
+      [new Date(2020, 1, 2), 1],
+      [new Date(2020, 1, 3), 2],
+      [new Date(2020, 1, 4), 3],
+      [new Date(2020, 1, 5), 4],
     ]}
   />
   <Line
     name="Series 2"
     data={[
-      [new Date(2020, 01, 01), 4],
-      [new Date(2020, 01, 02), 3],
-      [new Date(2020, 01, 03), 2],
-      [new Date(2020, 01, 04), 1],
-      [new Date(2020, 01, 05), 0],
+      [new Date(2020, 1, 1), 4],
+      [new Date(2020, 1, 2), 3],
+      [new Date(2020, 1, 3), 2],
+      [new Date(2020, 1, 4), 1],
+      [new Date(2020, 1, 5), 0],
     ]}
   />
 </Chart>;

--- a/charts/core/src/Chart.stories.tsx
+++ b/charts/core/src/Chart.stories.tsx
@@ -829,6 +829,26 @@ export const Basic: StoryObj<{}> = {
   },
 };
 
+export const NullValues: StoryObj<{}> = {
+  render: () => {
+    return (
+      <Chart>
+        <Line
+          name={'My Data'}
+          data={[
+            [new Date(2020, 1, 1), 0],
+            [new Date(2020, 1, 2), 1],
+            [new Date(2020, 1, 3), null], // line should visually skip this point
+            [new Date(2020, 1, 4), 3],
+            [new Date(2020, 1, 5), 4],
+          ]}
+        />
+        <ChartTooltip />
+      </Chart>
+    );
+  },
+};
+
 export const WithTooltip: StoryObj<{}> = {
   render: () => {
     return (

--- a/charts/core/src/Line/Line.types.ts
+++ b/charts/core/src/Line/Line.types.ts
@@ -1,7 +1,7 @@
 import { SeriesName } from '@lg-charts/series-provider';
 
-type XValue = string | number | Date;
-type YValue = string | number | Date;
+type XValue = string | number | Date | null | undefined;
+type YValue = string | number | Date | null | undefined;
 
 export interface LineProps {
   /**


### PR DESCRIPTION
## ✍️ Proposed changes
- Updates types to allow `null` and `undefined` values in data points. This allows consumers to skip over points on the line which was a requested feature.
- Drive by fix to correct README examples.

🎟 _Jira ticket:_ [LG-5338](https://jira.mongodb.org/browse/LG-5338)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes
- Visual regression story added in Storybook for null values