### PR TITLE
chore: add `type` keyword to type exports to avoid warnings

### DIFF
--- a/charts/legend/src/Legend/index.ts
+++ b/charts/legend/src/Legend/index.ts
@@ -1,2 +1,2 @@
 export { Legend } from './Legend';
-export { LegendProps } from './Legend.types';
+export { type LegendProps } from './Legend.types';

--- a/chat/message-feedback/src/InlineMessageFeedback/index.ts
+++ b/chat/message-feedback/src/InlineMessageFeedback/index.ts
@@ -1,3 +1,3 @@
 export { InlineMessageFeedback } from './InlineMessageFeedback';
-export { InlineMessageFeedbackProps } from './InlineMessageFeedback.types';
+export { type InlineMessageFeedbackProps } from './InlineMessageFeedback.types';
 export { SubmittedState } from './SubmittedState';

--- a/chat/message-feedback/src/PopoverMessageFeedback/index.ts
+++ b/chat/message-feedback/src/PopoverMessageFeedback/index.ts
@@ -1,2 +1,2 @@
 export { PopoverMessageFeedback } from './PopoverMessageFeedback';
-export { PopoverMessageFeedbackProps } from './PopoverMessageFeedback.types';
+export { type PopoverMessageFeedbackProps } from './PopoverMessageFeedback.types';

--- a/chat/message/src/MessageContainer/index.ts
+++ b/chat/message/src/MessageContainer/index.ts
@@ -1,3 +1,3 @@
 export { MessageContainer } from './MessageContainer';
 export * as lgMessageContainerStyles from './MessageContainer.styles';
-export { MessageContainerProps, Variant } from './MessageContainer.types';
+export { type MessageContainerProps, Variant } from './MessageContainer.types';

--- a/packages/checkbox/src/Checkbox/index.ts
+++ b/packages/checkbox/src/Checkbox/index.ts
@@ -1,3 +1,3 @@
 export { default } from './Checkbox';
 export { checkWrapperClassName } from './Checkbox.style';
-export { CheckboxProps } from './Checkbox.types';
+export { type CheckboxProps } from './Checkbox.types';

--- a/packages/combobox/src/types/index.ts
+++ b/packages/combobox/src/types/index.ts
@@ -1,12 +1,12 @@
 export {
   ComboboxElement,
   ComboboxSize,
-  DiffObject,
+  type DiffObject,
   getNullSelection,
-  onChangeType,
+  type onChangeType,
   Overflow,
   SearchState,
-  SelectValueType,
+  type SelectValueType,
   State,
 } from './Combobox.types';
 export { TruncationLocation } from '@leafygreen-ui/chip';

--- a/packages/date-picker/src/DatePicker/DatePickerContent/index.ts
+++ b/packages/date-picker/src/DatePicker/DatePickerContent/index.ts
@@ -1,2 +1,2 @@
 export { DatePickerContent } from './DatePickerContent';
-export { DatePickerContentProps } from './DatePickerContent.types';
+export { type DatePickerContentProps } from './DatePickerContent.types';

--- a/packages/date-picker/src/DatePicker/DatePickerInput/index.ts
+++ b/packages/date-picker/src/DatePicker/DatePickerInput/index.ts
@@ -1,2 +1,2 @@
 export { DatePickerInput } from './DatePickerInput';
-export { DatePickerInputProps } from './DatePickerInput.types';
+export { type DatePickerInputProps } from './DatePickerInput.types';

--- a/packages/date-picker/src/DatePicker/DatePickerMenu/index.ts
+++ b/packages/date-picker/src/DatePicker/DatePickerMenu/index.ts
@@ -1,2 +1,2 @@
 export { DatePickerMenu } from './DatePickerMenu';
-export { DatePickerMenuProps } from './DatePickerMenu.types';
+export { type DatePickerMenuProps } from './DatePickerMenu.types';

--- a/packages/date-picker/src/shared/components/Calendar/CalendarGrid/index.ts
+++ b/packages/date-picker/src/shared/components/Calendar/CalendarGrid/index.ts
@@ -1,2 +1,2 @@
 export { CalendarGrid } from './CalendarGrid';
-export { CalendarGridProps } from './CalendarGrid.types';
+export { type CalendarGridProps } from './CalendarGrid.types';

--- a/packages/drawer/src/DrawerStackContext/index.ts
+++ b/packages/drawer/src/DrawerStackContext/index.ts
@@ -3,4 +3,4 @@ export {
   DrawerStackProvider,
   useDrawerStackContext,
 } from './DrawerStackContext';
-export { DrawerStackContextType } from './DrawerStackContext.types';
+export { type DrawerStackContextType } from './DrawerStackContext.types';

--- a/packages/drawer/src/EmbeddedDrawerLayout/index.tsx
+++ b/packages/drawer/src/EmbeddedDrawerLayout/index.tsx
@@ -1,2 +1,2 @@
 export { EmbeddedDrawerLayout } from './EmbeddedDrawerLayout';
-export { EmbeddedDrawerLayoutProps } from './EmbeddedDrawerLayout.types';
+export { type EmbeddedDrawerLayoutProps } from './EmbeddedDrawerLayout.types';

--- a/packages/drawer/src/LayoutComponent/index.ts
+++ b/packages/drawer/src/LayoutComponent/index.ts
@@ -1,2 +1,2 @@
 export { LayoutComponent } from './LayoutComponent';
-export { LayoutComponentProps } from './LayoutComponent.types';
+export { type LayoutComponentProps } from './LayoutComponent.types';

--- a/packages/drawer/src/OverlayDrawerLayout/index.ts
+++ b/packages/drawer/src/OverlayDrawerLayout/index.ts
@@ -1,2 +1,2 @@
 export { OverlayDrawerLayout } from './OverlayDrawerLayout';
-export { OverlayDrawerLayoutProps } from './OverlayDrawerLayout.types';
+export { type OverlayDrawerLayoutProps } from './OverlayDrawerLayout.types';

--- a/packages/form-field/src/FormFieldContext/index.ts
+++ b/packages/form-field/src/FormFieldContext/index.ts
@@ -1,7 +1,7 @@
 export {
   defaultFormFieldContext,
   FormFieldContext,
-  FormFieldContextProps,
+  type FormFieldContextProps,
   FormFieldProvider,
   useFormFieldContext,
 } from './FormFieldContext';

--- a/packages/form-field/src/FormFieldFeedback/index.ts
+++ b/packages/form-field/src/FormFieldFeedback/index.ts
@@ -1,2 +1,2 @@
 export { FormFieldFeedback } from './FormFieldFeedback';
-export { FormFieldFeedbackProps } from './FormFieldFeedback.types';
+export { type FormFieldFeedbackProps } from './FormFieldFeedback.types';

--- a/packages/form-field/src/FormFieldInputContainer/index.ts
+++ b/packages/form-field/src/FormFieldInputContainer/index.ts
@@ -1,2 +1,2 @@
 export { FormFieldInputContainer } from './FormFieldInputContainer';
-export { FormFieldInputContainerProps } from './FormFieldInputContainer.types';
+export { type FormFieldInputContainerProps } from './FormFieldInputContainer.types';

--- a/packages/guide-cue/src/GuideCue/index.ts
+++ b/packages/guide-cue/src/GuideCue/index.ts
@@ -1,2 +1,6 @@
 export { default } from './GuideCue';
-export { GuideCueProps, TooltipAlign, TooltipJustify } from './GuideCue.types';
+export {
+  type GuideCueProps,
+  TooltipAlign,
+  TooltipJustify,
+} from './GuideCue.types';

--- a/packages/leafygreen-provider/src/TypographyContext/index.ts
+++ b/packages/leafygreen-provider/src/TypographyContext/index.ts
@@ -1,5 +1,5 @@
 export {
   TypographyProvider,
-  TypographyProviderProps,
+  type TypographyProviderProps,
   useBaseFontSize,
 } from './TypographyContext';

--- a/packages/menu/src/MenuItem/index.ts
+++ b/packages/menu/src/MenuItem/index.ts
@@ -1,3 +1,3 @@
 export { MenuItem } from './MenuItem';
 export { menuItemClassName } from './MenuItem.styles';
-export { MenuItemProps, Variant } from './MenuItem.types';
+export { type MenuItemProps, Variant } from './MenuItem.types';

--- a/packages/menu/src/SubMenu/index.ts
+++ b/packages/menu/src/SubMenu/index.ts
@@ -3,4 +3,4 @@ export {
   subMenuContainerClassName,
   subMenuToggleClassName,
 } from './SubMenu.styles';
-export { InternalSubMenuProps, SubMenuProps } from './SubMenu.types';
+export { type InternalSubMenuProps, type SubMenuProps } from './SubMenu.types';

--- a/packages/ordered-list/src/OrderedList/index.ts
+++ b/packages/ordered-list/src/OrderedList/index.ts
@@ -1,2 +1,2 @@
 export { OrderedList } from './OrderedList';
-export { OrderedListProps } from './OrderedList.types';
+export { type OrderedListProps } from './OrderedList.types';

--- a/packages/ordered-list/src/OrderedListItem/index.ts
+++ b/packages/ordered-list/src/OrderedListItem/index.ts
@@ -1,2 +1,2 @@
 export { OrderedListItem } from './OrderedListItem';
-export { OrderedListItemProps } from './OrderedListItem.types';
+export { type OrderedListItemProps } from './OrderedListItem.types';

--- a/packages/password-input/src/PasswordInput/index.tsx
+++ b/packages/password-input/src/PasswordInput/index.tsx
@@ -1,6 +1,6 @@
 export { PasswordInput } from './PasswordInput';
 export {
-  NotificationProps,
+  type NotificationProps,
   Size,
   type StateNotificationProps,
 } from './PasswordInput.types';

--- a/packages/search-input/src/SearchResultsMenu/index.ts
+++ b/packages/search-input/src/SearchResultsMenu/index.ts
@@ -1,2 +1,2 @@
 export { SearchResultsMenu } from './SearchResultsMenu';
-export { SearchResultsMenuProps } from './SearchResultsMenu.types';
+export { type SearchResultsMenuProps } from './SearchResultsMenu.types';

--- a/packages/select/src/OptionGroup/index.ts
+++ b/packages/select/src/OptionGroup/index.ts
@@ -1,6 +1,6 @@
 export {
   InternalOptionGroup,
   OptionGroup,
-  OptionGroupElement,
+  type OptionGroupElement,
 } from './OptionGroup';
-export { OptionGroupProps } from './OptionGroup.types';
+export { type OptionGroupProps } from './OptionGroup.types';

--- a/packages/side-nav/src/SideNavGroup/index.ts
+++ b/packages/side-nav/src/SideNavGroup/index.ts
@@ -1,2 +1,2 @@
 export { default as SideNavGroup } from './SideNavGroup';
-export { SideNavGroupProps } from './SideNavGroup.types';
+export { type SideNavGroupProps } from './SideNavGroup.types';

--- a/packages/side-nav/src/SideNavItem/index.ts
+++ b/packages/side-nav/src/SideNavItem/index.ts
@@ -1,2 +1,5 @@
 export { default as SideNavItem } from './SideNavItem';
-export { BaseSideNavItemProps, SideNavItemProps } from './SideNavItem.types';
+export {
+  type BaseSideNavItemProps,
+  type SideNavItemProps,
+} from './SideNavItem.types';

--- a/packages/skeleton-loader/src/ListSkeleton/index.ts
+++ b/packages/skeleton-loader/src/ListSkeleton/index.ts
@@ -1,2 +1,2 @@
 export { ListSkeleton } from './ListSkeleton';
-export { ListSkeletonProps } from './ListSkeleton.types';
+export { type ListSkeletonProps } from './ListSkeleton.types';

--- a/packages/split-button/src/SplitButton/index.tsx
+++ b/packages/split-button/src/SplitButton/index.tsx
@@ -2,7 +2,7 @@ export { SplitButton } from './SplitButton';
 export {
   Align,
   Justify,
-  MenuItemType,
+  type MenuItemType,
   type SplitButtonProps,
   Variant,
 } from './SplitButton.types';

--- a/packages/stepper/src/EllipsesStep/index.ts
+++ b/packages/stepper/src/EllipsesStep/index.ts
@@ -1,6 +1,6 @@
 export { EllipsesStep } from './EllipsesStep';
 export {
-  EllipsesStepProps,
-  EllipsesStepState,
+  type EllipsesStepProps,
+  type EllipsesStepState,
   EllipsesStepStates,
 } from './EllipsesStep.types';

--- a/packages/stepper/src/InternalStep/index.ts
+++ b/packages/stepper/src/InternalStep/index.ts
@@ -1,2 +1,2 @@
 export { InternalStep } from './InternalStep';
-export { InternalStepProps } from './InternalStep.types';
+export { type InternalStepProps } from './InternalStep.types';

--- a/packages/stepper/src/StepIcon/index.ts
+++ b/packages/stepper/src/StepIcon/index.ts
@@ -1,2 +1,2 @@
 export { StepIcon } from './StepIcon';
-export { StepIconProps } from './StepIcon.types';
+export { type StepIconProps } from './StepIcon.types';

--- a/packages/stepper/src/StepLabel/index.ts
+++ b/packages/stepper/src/StepLabel/index.ts
@@ -1,2 +1,2 @@
 export { StepLabel } from './StepLabel';
-export { StepLabelProps } from './StepLabel.types';
+export { type StepLabelProps } from './StepLabel.types';

--- a/packages/table/src/ToggleExpandedIcon/index.ts
+++ b/packages/table/src/ToggleExpandedIcon/index.ts
@@ -1,3 +1,3 @@
 import ToggleExpandedIcon from './ToggleExpandedIcon';
-export { ToggleExpandedIconProps } from './ToggleExpandedIcon.types';
+export { type ToggleExpandedIconProps } from './ToggleExpandedIcon.types';
 export default ToggleExpandedIcon;

--- a/packages/tabs/src/context/index.ts
+++ b/packages/tabs/src/context/index.ts
@@ -6,4 +6,8 @@ export {
   TabPanelDescendantsContext,
   useTabPanelDescendantsContext,
 } from './TabPanelDescendantsContext';
-export { TabsContext, TabsContextProps, useTabsContext } from './TabsContext';
+export {
+  TabsContext,
+  type TabsContextProps,
+  useTabsContext,
+} from './TabsContext';

--- a/packages/toast/src/InternalToast/index.ts
+++ b/packages/toast/src/InternalToast/index.ts
@@ -1,3 +1,3 @@
 export { InternalToast } from './InternalToast';
 export { toastBGColor } from './InternalToast.styles';
-export { InternalToastProps } from './InternalToast.types';
+export { type InternalToastProps } from './InternalToast.types';

--- a/packages/toolbar/src/Toolbar/index.ts
+++ b/packages/toolbar/src/Toolbar/index.ts
@@ -1,3 +1,3 @@
 export { Toolbar } from './Toolbar';
 export { toolbarClassName } from './Toolbar.styles';
-export { ToolbarProps } from './Toolbar.types';
+export { type ToolbarProps } from './Toolbar.types';

--- a/packages/toolbar/src/ToolbarIconButton/index.ts
+++ b/packages/toolbar/src/ToolbarIconButton/index.ts
@@ -1,2 +1,2 @@
 export { ToolbarIconButton } from './ToolbarIconButton';
-export { ToolbarIconButtonProps } from './ToolbarIconButton.types';
+export { type ToolbarIconButtonProps } from './ToolbarIconButton.types';


### PR DESCRIPTION
## ✍️ Proposed changes

Super tiny but wanted to get rid of the huge list of warnings when running `storybook dev`. Remaining warnings are clearer now. Note that this has already been fixed in the `lg create` template moving forward in a separate (merged) PR.

🎟 _Jira ticket:_ [Name of ticket](https://jira.mongodb.org/browse/[name-of-ticket])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
