### PR TITLE
Add title attribute to chat input button

### DIFF
--- a/.changeset/spotty-areas-work.md
+++ b/.changeset/spotty-areas-work.md
@@ -1,0 +1,5 @@
+---
+'@lg-chat/input-bar': patch
+---
+
+Add an accessible title to the submit button

--- a/chat/input-bar/src/InputBar/InputBar.spec.tsx
+++ b/chat/input-bar/src/InputBar/InputBar.spec.tsx
@@ -71,7 +71,7 @@ describe('packages/input-bar', () => {
 
     test('fires when enter is clicked', () => {
       const textarea = screen.getByRole('textbox');
-      const sendButton = screen.getByRole('button');
+      const sendButton = screen.getByTitle('Send message');
       userEvent.type(textarea, testText);
       userEvent.click(sendButton);
 

--- a/chat/input-bar/src/InputBar/InputBar.tsx
+++ b/chat/input-bar/src/InputBar/InputBar.tsx
@@ -433,6 +433,7 @@ export const InputBar = forwardRef<HTMLFormElement, InputBarProps>(
                   className={cx({
                     [sendButtonDisabledStyles]: isSendButtonDisabled(),
                   })}
+                  title="Send message"
                 >
                   {shouldRenderButtonText && 'Enter'}
                 </Button>


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The submit button for the lg-chat InputBar often has only an icon or just the text `enter`. By adding a title we can be more descriptive for screen readers and allow more realistic targeting in tests.

Would appreciate some feedback on using the `title` attribute instead of `aria-label`. The issue with `aria-label` is that it should match the contents of the button ([a WCAG 2.1 requirement](https://www.w3.org/WAI/WCAG21/quickref/#label-in-name)), but `enter` is not very descriptive of the action. On the flip-side `title` has the side effect of a system tooltip on hover, so it does change the look and feel of the component.


## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
