### PR TITLE
LG-5318: progress bar hidden live region and aria attributes

### DIFF
--- a/packages/progress-bar/src/ProgressBar/ProgressBar.spec.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.spec.tsx
@@ -8,6 +8,10 @@ import {
   resolveProgressBarProps,
 } from './ProgressBar.utils';
 
+const getAnnouncementMessage = (value: number, maxValue: number): string => {
+  return `Update: current progress is ${value}% (${value} out of ${maxValue}).`;
+};
+
 describe('packages/progress-bar', () => {
   describe('basic rendering', () => {
     test('renders with a label', () => {
@@ -113,8 +117,8 @@ describe('packages/progress-bar', () => {
       expect(screen.queryByRole('status')).toBeNull();
     });
 
-    test('does not announce if progress under 50%', () => {
-      render(
+    test('announces initial progress, but not any further changes if next threshold is not met', () => {
+      const { rerender } = render(
         <ProgressBar
           type={Type.Loader}
           isIndeterminate={false}
@@ -122,11 +126,37 @@ describe('packages/progress-bar', () => {
           maxValue={TEST_MAX_VALUE}
         />,
       );
-      expect(screen.queryByRole('status')).toHaveTextContent('');
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        getAnnouncementMessage(TEST_VALUE_UNDER_50, TEST_MAX_VALUE),
+      );
+
+      rerender(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE_UNDER_50 + 1}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        getAnnouncementMessage(TEST_VALUE_UNDER_50, TEST_MAX_VALUE),
+      );
     });
 
     test('announces if 50% threshold passed', () => {
-      render(
+      const { rerender } = render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE_UNDER_50}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        getAnnouncementMessage(TEST_VALUE_UNDER_50, TEST_MAX_VALUE),
+      );
+
+      rerender(
         <ProgressBar
           type={Type.Loader}
           isIndeterminate={false}
@@ -135,12 +165,24 @@ describe('packages/progress-bar', () => {
         />,
       );
       expect(screen.queryByRole('status')).toHaveTextContent(
-        `Update: current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100).`,
+        getAnnouncementMessage(TEST_VALUE_OVER_50, TEST_MAX_VALUE),
       );
     });
 
     test('announces if 100% threshold passed', () => {
-      render(
+      const { rerender } = render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE_UNDER_50}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        getAnnouncementMessage(TEST_VALUE_UNDER_50, TEST_MAX_VALUE),
+      );
+
+      rerender(
         <ProgressBar
           type={Type.Loader}
           isIndeterminate={false}
@@ -149,11 +191,11 @@ describe('packages/progress-bar', () => {
         />,
       );
       expect(screen.queryByRole('status')).toHaveTextContent(
-        'Update: current progress is 100% (100 out of 100).',
+        getAnnouncementMessage(TEST_MAX_VALUE, TEST_MAX_VALUE),
       );
     });
 
-    test('additionally announces color if yellow or red', () => {
+    test('additionally announces variant if yellow or red', () => {
       render(
         <ProgressBar
           type={Type.Loader}
@@ -164,7 +206,10 @@ describe('packages/progress-bar', () => {
         />,
       );
       expect(screen.queryByRole('status')).toHaveTextContent(
-        `Update: current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100). Status is yellow.`,
+        `${getAnnouncementMessage(
+          TEST_VALUE_OVER_50,
+          TEST_MAX_VALUE,
+        )} Status is ${Color.Yellow}.`,
       );
     });
   });

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.spec.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.spec.tsx
@@ -135,7 +135,7 @@ describe('packages/progress-bar', () => {
         />,
       );
       expect(screen.queryByRole('status')).toHaveTextContent(
-        `Current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100).`,
+        `Update: current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100).`,
       );
     });
 
@@ -149,7 +149,7 @@ describe('packages/progress-bar', () => {
         />,
       );
       expect(screen.queryByRole('status')).toHaveTextContent(
-        'Current progress is 100% (100 out of 100).',
+        'Update: current progress is 100% (100 out of 100).',
       );
     });
 
@@ -164,8 +164,72 @@ describe('packages/progress-bar', () => {
         />,
       );
       expect(screen.queryByRole('status')).toHaveTextContent(
-        `Current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100). Status is yellow.`,
+        `Update: current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100). Status is yellow.`,
       );
+    });
+  });
+
+  describe('aria attributes', () => {
+    test('renders with aria-labelledby and aria-describedby', () => {
+      const LABEL_TEXT = 'Test Progress Bar';
+      const DESCRIPTION_TEXT = 'Test description for the progress bar.';
+
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={true}
+          label={LABEL_TEXT}
+          description={DESCRIPTION_TEXT}
+        />,
+      );
+
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-labelledby');
+      expect(progressBar).toHaveAttribute('aria-describedby');
+    });
+
+    test('renders with aria-label when no label is provided', () => {
+      render(<ProgressBar type={Type.Loader} isIndeterminate={true} />);
+
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-label', 'progressbar');
+    });
+
+    test('renders with aria-value attributes if value and maxValue are provided', () => {
+      const TEST_VALUE = 75;
+      const TEST_MAX_VALUE = 100;
+
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+      expect(progressBar).toHaveAttribute(
+        'aria-valuemax',
+        String(TEST_MAX_VALUE),
+      );
+      expect(progressBar).toHaveAttribute('aria-valuenow', String(TEST_VALUE));
+    });
+
+    test('renders with aria-valuetext if maxValue is not provided', () => {
+      const TEST_VALUE = 50;
+
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={true}
+          value={TEST_VALUE}
+        />,
+      );
+
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuetext', String(TEST_VALUE));
     });
   });
 

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.spec.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.spec.tsx
@@ -97,6 +97,78 @@ describe('packages/progress-bar', () => {
     });
   });
 
+  describe('screen reader behavior', () => {
+    const TEST_VALUE_UNDER_50 = 43;
+    const TEST_VALUE_OVER_50 = 57;
+    const TEST_MAX_VALUE = 100;
+
+    test('does not have a live region for meter types', () => {
+      render(
+        <ProgressBar
+          type={Type.Meter}
+          value={TEST_VALUE_OVER_50}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toBeNull();
+    });
+
+    test('does not announce if progress under 50%', () => {
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE_UNDER_50}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent('');
+    });
+
+    test('announces if 50% threshold passed', () => {
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE_OVER_50}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        `Current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100).`,
+      );
+    });
+
+    test('announces if 100% threshold passed', () => {
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_MAX_VALUE}
+          maxValue={TEST_MAX_VALUE}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        'Current progress is 100% (100 out of 100).',
+      );
+    });
+
+    test('additionally announces color if yellow or red', () => {
+      render(
+        <ProgressBar
+          type={Type.Loader}
+          isIndeterminate={false}
+          value={TEST_VALUE_OVER_50}
+          maxValue={TEST_MAX_VALUE}
+          variant={LoaderVariant.Warning}
+        />,
+      );
+      expect(screen.queryByRole('status')).toHaveTextContent(
+        `Current progress is ${TEST_VALUE_OVER_50}% (${TEST_VALUE_OVER_50} out of 100). Status is yellow.`,
+      );
+    });
+  });
+
   describe('getFormattedValue', () => {
     test('renders a fraction correctly', () => {
       expect(getFormattedValue(50, 100, 'fraction')).toBe('50/100');

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.styles.ts
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.styles.ts
@@ -180,3 +180,12 @@ export const getBarFillStyles = ({
     typedBarFillStyles,
   );
 };
+
+export const getInvisibleStyles = () => css`
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+`;

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
-import { getNodeTextContent } from '@leafygreen-ui/lib';
 import { Body, Description, Label } from '@leafygreen-ui/typography';
 
 import {
@@ -15,6 +14,7 @@ import {
 } from './ProgressBar.styles';
 import { ProgressBarProps, Size, Type } from './ProgressBar.types';
 import {
+  getDivAriaAttributes,
   getFormattedValue,
   getHeaderIcon,
   getLastAnnouncedThresholdIndex,
@@ -44,12 +44,10 @@ export function ProgressBar(props: ProgressBarProps) {
     ? showIconProp && value === maxValue
     : showIconProp;
 
-  const role = type === 'meter' ? 'meter' : 'progressbar';
+  const { role, rootId, labelId, descId } = getDivAriaAttributes(type, label);
 
-  const progressBarId = `${role}-${getNodeTextContent(label) || 'default'}`;
-
-  // automatically announces live once past 50% and 100% progress
-  // otherwise, only heard when user reaches the bar via virtual cursor
+  // automatically announces live once past 50% and 100% progress for minimal disturbance
+  // otherwise, progress only head if user reaches the bar via virtual cursor
   const [screenReaderMessage, setScreenReaderMessage] = useState<string>('');
   const lastAnnouncedThresholdIndex = useRef(-1);
 
@@ -70,7 +68,7 @@ export function ProgressBar(props: ProgressBarProps) {
 
     const announceStatus = shouldAnnounceStatus(color);
 
-    const baseMessage = `Current progress is ${getPercentage(
+    const baseMessage = `Update: current progress is ${getPercentage(
       value,
       maxValue,
     )}% (${value} out of ${maxValue}).`;
@@ -86,7 +84,12 @@ export function ProgressBar(props: ProgressBarProps) {
   return (
     <div className={containerStyles} aria-disabled={disabled}>
       <div className={headerStyles}>
-        <Label htmlFor={progressBarId} darkMode={darkMode} disabled={disabled}>
+        <Label
+          id={labelId}
+          htmlFor={rootId}
+          darkMode={darkMode}
+          disabled={disabled}
+        >
           {label}
         </Label>
 
@@ -111,8 +114,10 @@ export function ProgressBar(props: ProgressBarProps) {
 
       <div
         role={role}
-        id={progressBarId}
-        aria-label={progressBarId}
+        id={rootId}
+        aria-labelledby={label ? labelId : undefined}
+        aria-label={!label ? role : undefined}
+        aria-describedby={descId}
         {...getValueAriaAttributes(value, maxValue)}
       >
         <div
@@ -134,7 +139,7 @@ export function ProgressBar(props: ProgressBarProps) {
       </div>
 
       {description && (
-        <Description darkMode={darkMode} disabled={disabled}>
+        <Description id={descId} darkMode={darkMode} disabled={disabled}>
           {description}
         </Description>
       )}

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.tsx
@@ -44,7 +44,7 @@ export function ProgressBar(props: ProgressBarProps) {
     ? showIconProp && value === maxValue
     : showIconProp;
 
-  const { role, rootId, labelId, descId } = getDivAriaAttributes(type, label);
+  const { role, barId, labelId, descId } = getDivAriaAttributes(type, label);
 
   // automatically announces live once past 50% and 100% progress for minimal disturbance
   // otherwise, progress only head if user reaches the bar via virtual cursor
@@ -86,7 +86,7 @@ export function ProgressBar(props: ProgressBarProps) {
       <div className={headerStyles}>
         <Label
           id={labelId}
-          htmlFor={rootId}
+          htmlFor={barId}
           darkMode={darkMode}
           disabled={disabled}
         >
@@ -114,7 +114,7 @@ export function ProgressBar(props: ProgressBarProps) {
 
       <div
         role={role}
-        id={rootId}
+        id={barId}
         aria-labelledby={label ? labelId : undefined}
         aria-label={!label ? role : undefined}
         aria-describedby={description ? descId : undefined}

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.tsx
@@ -117,7 +117,7 @@ export function ProgressBar(props: ProgressBarProps) {
         id={rootId}
         aria-labelledby={label ? labelId : undefined}
         aria-label={!label ? role : undefined}
-        aria-describedby={descId}
+        aria-describedby={description ? descId : undefined}
         {...getValueAriaAttributes(value, maxValue)}
       >
         <div

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
@@ -139,7 +139,7 @@ export const getValueAriaAttributes = (value?: number, maxValue?: number) => ({
         'aria-valuenow': value,
       }
     : {
-        'aria-valuetext': `${value}`,
+        'aria-valuetext': value.toString(),
       }),
 });
 

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
@@ -18,6 +18,7 @@ import {
 export const DEFAULT_MAX_VALUE = 1;
 export const DEFAULT_COLOR = Color.Blue;
 export const iconsPendingCompletion: Array<Color> = [Color.Green];
+export const screenReaderMessageThresholds = [0.5, 1.0];
 
 const getMeterStatusColor = (status?: MeterStatus): Color => {
   switch (status) {
@@ -142,4 +143,23 @@ export const getHeaderIcon = ({
     default:
       return <InfoWithCircleIcon {...props} />;
   }
+};
+
+export const shouldAnnounceStatus = (color: Color): boolean =>
+  color === Color.Yellow || color === Color.Red;
+
+export const getLastAnnouncedThresholdIndex = (
+  value: number,
+  maxValue?: number,
+): number => {
+  const percentage =
+    maxValue == null ? value : getPercentage(value, maxValue) / 100;
+
+  for (let i = 0; i < screenReaderMessageThresholds.length; i++) {
+    if (percentage >= screenReaderMessageThresholds[i]) {
+      return i;
+    }
+  }
+
+  return -1;
 };

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
@@ -4,6 +4,7 @@ import CheckmarkWithCircleIcon from '@leafygreen-ui/icon/dist/CheckmarkWithCircl
 import ImportantWithCircleIcon from '@leafygreen-ui/icon/dist/ImportantWithCircle';
 import InfoWithCircleIcon from '@leafygreen-ui/icon/dist/InfoWithCircle';
 import WarningIcon from '@leafygreen-ui/icon/dist/Warning';
+import { getNodeTextContent } from '@leafygreen-ui/lib';
 
 import {
   Color,
@@ -113,13 +114,34 @@ export const getFormattedValue = (
   }
 };
 
-export const getValueAriaAttributes = (value?: number, maxValue?: number) => {
+export const getDivAriaAttributes = (type: Type, label?: React.ReactNode) => {
+  const role = type === Type.Meter ? 'meter' : 'progressbar';
+
+  const progressBarId = label
+    ? `${role} for ${getNodeTextContent(label)}`
+    : role;
+
   return {
-    'aria-valuemin': 0,
-    ...(value && { 'aria-valuenow': value }),
-    ...(maxValue && { 'aria-valuemax': maxValue }),
+    role,
+    rootId: progressBarId,
+    labelId: `label for ${progressBarId}`,
+    descId: `description for ${progressBarId}`,
   };
 };
+
+export const getValueAriaAttributes = (value?: number, maxValue?: number) => ({
+  ...(value == null
+    ? { 'aria-busy': true }
+    : maxValue != null
+    ? {
+        'aria-valuemin': 0,
+        'aria-valuemax': maxValue,
+        'aria-valuenow': value,
+      }
+    : {
+        'aria-valuetext': `${value}`,
+      }),
+});
 
 export const getHeaderIcon = ({
   color,

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
@@ -19,7 +19,6 @@ import {
 export const DEFAULT_MAX_VALUE = 1;
 export const DEFAULT_COLOR = Color.Blue;
 export const iconsPendingCompletion: Array<Color> = [Color.Green];
-export const screenReaderMessageThresholds = [0.5, 1.0];
 
 const getMeterStatusColor = (status?: MeterStatus): Color => {
   switch (status) {
@@ -114,25 +113,25 @@ export const getFormattedValue = (
   }
 };
 
-export const getDivAriaAttributes = (type: Type, label?: React.ReactNode) => {
+export const getDivAttributes = (type: Type, label?: React.ReactNode) => {
   const role = type === Type.Meter ? 'meter' : 'progressbar';
 
   const progressBarId = label
-    ? `${role} for ${getNodeTextContent(label)}`
+    ? `${role}-for-${getNodeTextContent(label)}`
     : role;
 
   return {
     role,
     barId: progressBarId,
-    labelId: `label for ${progressBarId}`,
-    descId: `description for ${progressBarId}`,
+    labelId: `label-for-${progressBarId}`,
+    descId: `desc-for-${progressBarId}`,
   };
 };
 
 export const getValueAriaAttributes = (value?: number, maxValue?: number) => ({
-  ...(value == null
+  ...(value == undefined
     ? { 'aria-busy': true }
-    : maxValue != null
+    : maxValue != undefined
     ? {
         'aria-valuemin': 0,
         'aria-valuemax': maxValue,
@@ -165,23 +164,4 @@ export const getHeaderIcon = ({
     default:
       return <InfoWithCircleIcon {...props} />;
   }
-};
-
-export const shouldAnnounceStatus = (color: Color): boolean =>
-  color === Color.Yellow || color === Color.Red;
-
-export const getLastAnnouncedThresholdIndex = (
-  value: number,
-  maxValue?: number,
-): number => {
-  const percentage =
-    maxValue == null ? value : getPercentage(value, maxValue) / 100;
-
-  for (let i = 0; i < screenReaderMessageThresholds.length; i++) {
-    if (percentage >= screenReaderMessageThresholds[i]) {
-      return i;
-    }
-  }
-
-  return -1;
 };

--- a/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
+++ b/packages/progress-bar/src/ProgressBar/ProgressBar.utils.tsx
@@ -123,7 +123,7 @@ export const getDivAriaAttributes = (type: Type, label?: React.ReactNode) => {
 
   return {
     role,
-    rootId: progressBarId,
+    barId: progressBarId,
     labelId: `label for ${progressBarId}`,
     descId: `description for ${progressBarId}`,
   };

--- a/packages/progress-bar/src/ProgressBar/hooks/index.ts
+++ b/packages/progress-bar/src/ProgressBar/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useScreenReaderAnnouncer } from './useScreenReaderAnnouncer';

--- a/packages/progress-bar/src/ProgressBar/hooks/useScreenReaderAnnouncer.tsx
+++ b/packages/progress-bar/src/ProgressBar/hooks/useScreenReaderAnnouncer.tsx
@@ -23,6 +23,7 @@ export function useScreenReaderAnnouncer({
   const [message, setMessage] = useState('');
 
   useEffect(() => {
+    // no live region messages for non-loader types or if value is undefined
     if (type !== Type.Loader || value == undefined) {
       thresholdIndexRef.current = -1;
       setMessage('');
@@ -31,6 +32,7 @@ export function useScreenReaderAnnouncer({
 
     const percentage = maxValue ? getPercentage(value, maxValue) : value * 100;
 
+    // determinate largest threshold passed by current percentage
     let newThresholdIndex = -1;
 
     for (let i = 0; i < announcementThresholds.length; i++) {
@@ -40,6 +42,8 @@ export function useScreenReaderAnnouncer({
     }
 
     if (newThresholdIndex === thresholdIndexRef.current) return;
+
+    // if new threshold was passed, update live region message
     thresholdIndexRef.current = newThresholdIndex;
 
     const baseMessage = `Update: current progress is ${getPercentage(

--- a/packages/progress-bar/src/ProgressBar/hooks/useScreenReaderAnnouncer.tsx
+++ b/packages/progress-bar/src/ProgressBar/hooks/useScreenReaderAnnouncer.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { Color, Type } from '../ProgressBar.types';
+import { getPercentage } from '../ProgressBar.utils';
+
+const announcementThresholds = [0, 50, 100];
+const variantsAnnounced = [Color.Yellow, Color.Red] as Array<Color>;
+
+interface UseScreenReaderAnnouncerProps {
+  type: Type;
+  value?: number;
+  maxValue?: number;
+  color?: Color;
+}
+
+export function useScreenReaderAnnouncer({
+  type,
+  value,
+  maxValue,
+  color,
+}: UseScreenReaderAnnouncerProps): string {
+  const thresholdIndexRef = useRef(-1);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (type !== Type.Loader || value == undefined) {
+      thresholdIndexRef.current = -1;
+      setMessage('');
+      return;
+    }
+
+    const percentage = maxValue ? getPercentage(value, maxValue) : value * 100;
+
+    let newThresholdIndex = -1;
+
+    for (let i = 0; i < announcementThresholds.length; i++) {
+      if (percentage >= announcementThresholds[i]) {
+        newThresholdIndex = i;
+      }
+    }
+
+    if (newThresholdIndex === thresholdIndexRef.current) return;
+    thresholdIndexRef.current = newThresholdIndex;
+
+    const baseMessage = `Update: current progress is ${getPercentage(
+      value,
+      maxValue,
+    )}% (${value} out of ${maxValue}).`;
+
+    const newMessage =
+      color && variantsAnnounced.includes(color)
+        ? `${baseMessage} Status is ${color}.`
+        : baseMessage;
+
+    setMessage(newMessage);
+  }, [type, value, maxValue, color]);
+
+  return message;
+}


### PR DESCRIPTION
## ✍️ Proposed changes

- hook for live screen reader announcements (only initially, once past halfway, and once at completion)*
- utils for extracting aria attributes and necessary ids

*Note that the progress value is _always_ available to users via virtual cursor due to the aria-value attributes. Live announcements (which are unprompted and automatic no matter what content the user is on) are intended to be minimally disturbing, and therefore only at significant changes.

🎟 _Jira ticket:_ [LG-5318](https://jira.mongodb.org/browse/LG-5318)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
