### PR TITLE
fix: pseudo-element selectors

### DIFF
--- a/charts/legend/src/LegendCheckbox/LegendCheckbox.styles.ts
+++ b/charts/legend/src/LegendCheckbox/LegendCheckbox.styles.ts
@@ -31,7 +31,7 @@ const getBaseLegendCheckboxStyles = ({
     .${checkWrapperClassName} {
       border-color: ${checkboxColor || defaultCheckboxColor};
 
-      &:before {
+      &::before {
         background-color: ${checkboxColor || defaultCheckboxColor};
       }
     }

--- a/chat/input-bar/src/InputBar/InputBar.styles.ts
+++ b/chat/input-bar/src/InputBar/InputBar.styles.ts
@@ -157,8 +157,8 @@ const gradientWidth = 3;
 const gradientOffset = 1;
 
 export const gradientAnimationStyles = css`
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     content: '';
     position: absolute;
     top: -${gradientWidth + gradientOffset}px;
@@ -171,11 +171,11 @@ export const gradientAnimationStyles = css`
     background-position: 800% 800%; // set final state of animation
   }
 
-  &:after {
+  &::after {
     animation: 4s animateBg linear;
   }
 
-  &:before {
+  &::before {
     filter: blur(4px) opacity(0.6);
     animation: 4s animateBg, animateShadow linear infinite;
     opacity: 0;

--- a/chat/message/src/Message/Message.styles.ts
+++ b/chat/message/src/Message/Message.styles.ts
@@ -56,7 +56,7 @@ export const messageContainerWrapperStyles = css`
 
 const sharedMessageContainerWedgeStyles = css`
   // Left wedge
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     left: 0;
@@ -70,13 +70,13 @@ const sharedMessageContainerWedgeStyles = css`
 export const messageContainerWedgeStyles = {
   [Theme.Dark]: css`
     ${sharedMessageContainerWedgeStyles}
-    &:before {
+    &::before {
       background-color: ${palette.green.base};
     }
   `,
   [Theme.Light]: css`
     ${sharedMessageContainerWedgeStyles}
-    &:before {
+    &::before {
       background-color: ${palette.green.dark2};
     }
   `,

--- a/chat/message/src/MessageBanner/MessageBanner.styles.ts
+++ b/chat/message/src/MessageBanner/MessageBanner.styles.ts
@@ -6,7 +6,7 @@ import { spacing } from '@leafygreen-ui/tokens';
  */
 export const baseStyles = css`
   // Remove the Banner's left border wedge
-  &:before {
+  &::before {
     content: '';
     background: transparent;
   }

--- a/packages/banner/src/Banner/styles.ts
+++ b/packages/banner/src/Banner/styles.ts
@@ -15,7 +15,7 @@ export const baseBannerStyles = css`
   border-radius: 12px;
   font-family: ${fontFamilies.default};
 
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     width: 13px;
@@ -44,7 +44,7 @@ const darkModeInfoBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -71,7 +71,7 @@ const darkModeWarningBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -98,7 +98,7 @@ const darkModeDangerBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -125,7 +125,7 @@ const darkModeSuccessBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -152,7 +152,7 @@ const lightModeInfoBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -179,7 +179,7 @@ const lightModeWarningBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -206,7 +206,7 @@ const lightModeDangerBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,
@@ -233,7 +233,7 @@ const lightModeSuccessBannerStyles = css`
     }
   }
 
-  &:before {
+  &::before {
     background: linear-gradient(
       to left,
       transparent 6px,

--- a/packages/banner/src/BannerDismissButton/styles.ts
+++ b/packages/banner/src/BannerDismissButton/styles.ts
@@ -24,7 +24,7 @@ const darkModeInfoStyles = css`
     box-shadow: 0 0 0 2px ${palette.blue.dark3},
       0 0 0 4px ${palette.blue.light1};
 
-    &:before {
+    &::before {
       background-color: ${palette.blue.dark2};
     }
   }
@@ -39,7 +39,7 @@ const darkModeWarningStyles = css`
     box-shadow: 0 0 0 2px ${palette.yellow.dark3},
       0 0 0 4px ${palette.blue.light1};
 
-    &:before {
+    &::before {
       background-color: ${palette.yellow.dark2};
     }
   }
@@ -54,7 +54,7 @@ const darkModeDangerStyles = css`
     color: ${palette.red.light2};
     box-shadow: 0 0 0 2px ${palette.red.dark3}, 0 0 0 4px ${palette.blue.light1};
 
-    &:before {
+    &::before {
       background-color: ${palette.red.dark2};
     }
   }
@@ -70,7 +70,7 @@ const darkModeSuccessStyles = css`
     box-shadow: 0 0 0 2px ${palette.green.dark3},
       0 0 0 4px ${palette.blue.light1};
 
-    &:before {
+    &::before {
       background-color: ${palette.green.dark2};
     }
   }
@@ -84,7 +84,7 @@ const lightModeInfoStyles = css`
   &:focus-visible {
     color: ${palette.blue.dark2};
 
-    &:before {
+    &::before {
       background-color: ${palette.blue.light2};
     }
   }
@@ -98,7 +98,7 @@ const lightModeWarningStyles = css`
   &:focus-visible {
     color: ${palette.yellow.dark2};
 
-    &:before {
+    &::before {
       background-color: ${palette.yellow.light2};
     }
   }
@@ -112,7 +112,7 @@ const lightModeDangerStyles = css`
   &:focus-visible {
     color: ${palette.red.dark2};
 
-    &:before {
+    &::before {
       background-color: ${palette.red.light2};
     }
   }
@@ -126,7 +126,7 @@ const lightModeSuccessStyles = css`
   &:focus-visible {
     color: ${palette.green.dark2};
 
-    &:before {
+    &::before {
       background-color: ${palette.green.light2};
     }
   }

--- a/packages/callout/src/Callout/Callout.styles.ts
+++ b/packages/callout/src/Callout/Callout.styles.ts
@@ -77,7 +77,7 @@ export const getBaseStyles = (theme: Theme, variant: Variant) =>
     padding-inline-start: ${spacing[300]}px;
     position: relative;
 
-    &:after {
+    &::after {
       content: '';
       position: absolute;
       width: 3px;

--- a/packages/checkbox/src/Check/Check.style.ts
+++ b/packages/checkbox/src/Check/Check.style.ts
@@ -18,7 +18,7 @@ export const checkBorderSizePx = 2;
 
 export const disableAnimation = css`
   &,
-  &:before {
+  &::before {
     transition: unset;
     transition-delay: 0ms;
     transition-duration: 0ms;
@@ -47,7 +47,7 @@ export const wrapperBaseStyle = css`
   /**
    * The animated background circle
    */
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     inset: ${insetPct}%;
@@ -64,14 +64,14 @@ export const wrapperThemeStyle: Record<Theme, string> = {
   [Theme.Light]: css`
     border-color: ${palette.gray.dark2};
 
-    &:before {
+    &::before {
       background-color: ${palette.blue.base};
     }
   `,
   [Theme.Dark]: css`
     border-color: ${palette.gray.base};
 
-    &:before {
+    &::before {
       background-color: ${palette.blue.light1};
     }
   `,
@@ -81,7 +81,7 @@ export const wrapperCheckedBaseStyle = css`
   // Delay background transition in
   transition-delay: 0ms, ${checkAnimationDuration}ms, 0ms;
 
-  &:before {
+  &::before {
     transform: scale(1);
     // No delay on enter
     transition-delay: 0ms;
@@ -105,7 +105,7 @@ export const wrapperDisabledStyle: Record<Theme, string> = {
     background-color: ${palette.gray.light3};
     box-shadow: unset;
 
-    &:before {
+    &::before {
       background-color: ${palette.gray.light3};
     }
   `,
@@ -115,7 +115,7 @@ export const wrapperDisabledStyle: Record<Theme, string> = {
     background-color: ${palette.gray.dark3};
     box-shadow: unset;
 
-    &:before {
+    &::before {
       background-color: ${palette.gray.dark3};
     }
   `,
@@ -125,14 +125,14 @@ export const wrapperCheckedDisabledStyle: Record<Theme, string> = {
   [Theme.Light]: css`
     background-color: ${palette.gray.light2};
 
-    &:before {
+    &::before {
       background-color: ${palette.gray.light2};
     }
   `,
   [Theme.Dark]: css`
     background-color: ${palette.gray.dark2};
 
-    &:before {
+    &::before {
       background-color: ${palette.gray.dark2};
     }
   `,

--- a/packages/code/src/Code/Code.styles.ts
+++ b/packages/code/src/Code/Code.styles.ts
@@ -156,7 +156,7 @@ export const codeWithoutPanelStyles = css`
   // No panel, all code
   grid-template-areas: 'code code';
 
-  &:after {
+  &::after {
     grid-column: -1; // Placed on the right edge
   }
 `;
@@ -167,8 +167,8 @@ export const codeWithPanelStyles = css`
     'code';
   grid-template-columns: unset;
 
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     grid-row: 2; // Placed on the top under the Picker Panel
   }
 `;
@@ -307,8 +307,8 @@ export function getExpandButtonUtilsVariantStyle(theme: Theme): string {
 }
 
 export const baseScrollShadowStyles = css`
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     content: '';
     display: block;
     position: absolute;
@@ -320,11 +320,11 @@ export const baseScrollShadowStyles = css`
     box-shadow: unset;
     transition: box-shadow ${transitionDuration.faster}ms ease-in-out;
   }
-  &:before {
+  &::before {
     grid-column: 1;
     left: -40px;
   }
-  &:after {
+  &::after {
     grid-column: 2; // Placed either under Panel, or on the right edge
   }
 `;
@@ -344,14 +344,14 @@ export function getScrollShadow(
       : `-15px 0px 15px 0 ${transparentize(0.7, 'black')}`;
 
   return css`
-    &:before {
+    &::before {
       ${(scrollState === ScrollState.Both ||
         scrollState === ScrollState.Left) &&
       css`
         box-shadow: ${dropShadowBefore};
       `};
     }
-    &:after {
+    &::after {
       ${(scrollState === ScrollState.Both ||
         scrollState === ScrollState.Right) &&
       `

--- a/packages/code/src/CopyButton/CopyButton.styles.ts
+++ b/packages/code/src/CopyButton/CopyButton.styles.ts
@@ -56,7 +56,7 @@ export const copiedThemeStyle: Record<Theme, string> = {
     &:focus,
     &:hover {
       background-color: ${palette.green.dark1};
-      &:before {
+      &::before {
         background-color: ${palette.green.dark1};
       }
     }
@@ -78,7 +78,7 @@ export const copiedThemeStyle: Record<Theme, string> = {
     &:hover {
       background-color: ${palette.green.base};
 
-      &:before {
+      &::before {
         background-color: ${palette.green.base};
       }
     }

--- a/packages/copyable/src/Copyable/Copyable.styles.ts
+++ b/packages/copyable/src/Copyable/Copyable.styles.ts
@@ -107,7 +107,7 @@ export const buttonWrapperStyle = css`
 `;
 
 export const buttonWrapperStyleShadow = css`
-  &:before {
+  &::before {
     content: '';
     display: block;
     position: absolute;
@@ -122,7 +122,7 @@ export const buttonWrapperStyleShadow = css`
 
 export const buttonWrapperStyleShadowTheme: Record<Theme, string> = {
   [Theme.Light]: css`
-    &:before {
+    &::before {
       box-shadow: 0 0 10px 0 ${transparentize(0.65, palette.gray.dark1)};
     }
 
@@ -131,7 +131,7 @@ export const buttonWrapperStyleShadowTheme: Record<Theme, string> = {
     }
   `,
   [Theme.Dark]: css`
-    &:before {
+    &::before {
       box-shadow: -10px 0 10px 0 ${transparentize(0.4, palette.black)};
     }
 

--- a/packages/date-picker/src/shared/components/Calendar/CalendarCell/CalendarCell.styles.ts
+++ b/packages/date-picker/src/shared/components/Calendar/CalendarCell/CalendarCell.styles.ts
@@ -110,7 +110,7 @@ export const calendarCellCurrentStyles: ThemedStateStyles = {
  */
 
 const _baseRangeStartStyles = css`
-  &:after {
+  &::after {
     content: '';
     position: absolute;
     width: 50%;
@@ -122,7 +122,7 @@ const _baseRangeStartStyles = css`
 `;
 
 const _baseRangeEndStyles = css`
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     width: 50%;
@@ -141,7 +141,7 @@ export const calendarCellRangeStyles: Record<
     [CalendarCellRangeState.Start]: cx(
       _baseRangeStartStyles,
       css`
-        &:after {
+        &::after {
           background-color: ${palette.blue.light3};
         }
       `,
@@ -149,7 +149,7 @@ export const calendarCellRangeStyles: Record<
     [CalendarCellRangeState.End]: cx(
       _baseRangeEndStyles,
       css`
-        &:before {
+        &::before {
           background-color: ${palette.blue.light3};
         }
       `,
@@ -159,8 +159,8 @@ export const calendarCellRangeStyles: Record<
       _baseRangeEndStyles,
       css`
         color: ${palette.black};
-        &:before,
-        &:after {
+        &::before,
+        &::after {
           background-color: ${palette.blue.light3};
         }
       `,
@@ -171,7 +171,7 @@ export const calendarCellRangeStyles: Record<
     [CalendarCellRangeState.Start]: cx(
       _baseRangeStartStyles,
       css`
-        &:after {
+        &::after {
           background-color: ${palette.blue.dark3};
         }
       `,
@@ -179,7 +179,7 @@ export const calendarCellRangeStyles: Record<
     [CalendarCellRangeState.End]: cx(
       _baseRangeEndStyles,
       css`
-        &:before {
+        &::before {
           background-color: ${palette.blue.dark3};
         }
       `,
@@ -189,8 +189,8 @@ export const calendarCellRangeStyles: Record<
       _baseRangeEndStyles,
       css`
         color: ${palette.blue.light3};
-        &:before,
-        &:after {
+        &::before,
+        &::after {
           background-color: ${palette.blue.dark3};
         }
       `,
@@ -321,7 +321,7 @@ export const cellTextStyles = css`
 export const cellTextCurrentStyles = css`
   font-weight: ${fontWeights.medium};
 
-  &:after {
+  &::after {
     position: absolute;
     content: '';
     bottom: 0;

--- a/packages/descendants/src/Descendants.stories.tsx
+++ b/packages/descendants/src/Descendants.stories.tsx
@@ -25,7 +25,7 @@ import { useInitDescendants } from '.';
 faker.seed(0);
 
 const testItemStyle = css`
-  &:before {
+  &::before {
     content: attr(data-index);
     color: gray;
     padding-right: 4px;

--- a/packages/icon-button/src/IconButton/IconButton.styles.tsx
+++ b/packages/icon-button/src/IconButton/IconButton.styles.tsx
@@ -28,7 +28,7 @@ export const baseIconButtonStyle = css`
   // which can make things render differently across browsers if not defined explicitly.
   background-color: rgba(255, 255, 255, 0);
 
-  &:before {
+  &::before {
     content: '';
     transition: ${transitionDuration.default}ms all ease-in-out;
     position: absolute;
@@ -77,7 +77,7 @@ export const iconButtonMode: Record<Theme, string> = {
     &[data-hover='true'] {
       color: ${palette.black};
 
-      &:before {
+      &::before {
         background-color: ${transparentize(0.9, palette.gray.dark2)};
       }
     }
@@ -90,7 +90,7 @@ export const iconButtonMode: Record<Theme, string> = {
     &[data-hover='true'] {
       color: ${palette.gray.light3};
 
-      &:before {
+      &::before {
         background-color: ${transparentize(0.9, palette.gray.light2)};
       }
     }
@@ -104,7 +104,7 @@ export const focusStyle: Record<Theme, string> = {
       color: ${palette.black};
       box-shadow: ${focusRing[Theme.Light].default};
 
-      &:before {
+      &::before {
         background-color: ${transparentize(0.9, palette.gray.dark2)};
       }
     }
@@ -115,7 +115,7 @@ export const focusStyle: Record<Theme, string> = {
       color: ${palette.gray.light3};
       box-shadow: ${focusRing[Theme.Dark].default};
 
-      &:before {
+      &::before {
         background-color: ${transparentize(0.9, palette.gray.light2)};
       }
     }
@@ -133,7 +133,7 @@ export const disabledStyle: Record<Theme, string> = {
     &[data-hover='true'] {
       color: ${palette.gray.light1};
 
-      &:before {
+      &::before {
         background-color: rgba(255, 255, 255, 0);
       }
     }
@@ -142,7 +142,7 @@ export const disabledStyle: Record<Theme, string> = {
     &[data-focus='true'] {
       color: ${palette.gray.light1};
 
-      &:before {
+      &::before {
         background-color: rgba(255, 255, 255, 0);
       }
     }
@@ -158,7 +158,7 @@ export const disabledStyle: Record<Theme, string> = {
     &[data-hover='true'] {
       color: ${palette.gray.dark1};
 
-      &:before {
+      &::before {
         background-color: rgba(255, 255, 255, 0);
       }
     }
@@ -167,7 +167,7 @@ export const disabledStyle: Record<Theme, string> = {
     &[data-focus='true'] {
       color: ${palette.gray.dark1};
 
-      &:before {
+      &::before {
         background-color: rgba(255, 255, 255, 0);
       }
     }
@@ -178,7 +178,7 @@ export const activeStyle: Record<Theme, string> = {
   [Theme.Light]: css`
     color: ${palette.black};
 
-    &:before {
+    &::before {
       background-color: ${transparentize(0.9, palette.gray.dark2)};
       transform: scale(1);
     }
@@ -186,7 +186,7 @@ export const activeStyle: Record<Theme, string> = {
   [Theme.Dark]: css`
     color: ${palette.gray.light3};
 
-    &:before {
+    &::before {
       background-color: ${transparentize(0.9, palette.gray.light2)};
       transform: scale(1);
     }

--- a/packages/input-option/src/InputOption/InputOption.style.ts
+++ b/packages/input-option/src/InputOption/InputOption.style.ts
@@ -96,7 +96,7 @@ export const getInputOptionWedge = ({
   highlighted,
 }: InputOptionStyleArgs) => css`
   // Left wedge
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     left: 0;

--- a/packages/lib/src/getNodeTextContent/getNodeTextContent.stories.mdx
+++ b/packages/lib/src/getNodeTextContent/getNodeTextContent.stories.mdx
@@ -25,7 +25,7 @@ It is mainly used in conjunction with CSS pseudo-elements to ensure that compone
         font-weight: 700;
       }
 
-      &:after {
+      &::after {
         content: attr(data-text);
         visibility: hidden;
         font-weight: 700;

--- a/packages/menu/src/MenuItem/InternalMenuItemContent.tsx
+++ b/packages/menu/src/MenuItem/InternalMenuItemContent.tsx
@@ -126,7 +126,7 @@ export const InternalMenuItemContent = React.forwardRef<
               menuVariant: menuVariant,
             })]: theme === 'light' && renderDarkMenu,
             [css`
-              &:after {
+              &::after {
                 background-color: ${color.dark.border.secondary.default};
               }
             `]: theme === 'light' && renderDarkMenu && submenuDepth > 0,

--- a/packages/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/menu/src/MenuItem/MenuItem.styles.ts
@@ -70,7 +70,7 @@ export const getMenuItemStyles = ({
         &:hover {
           background-color: ${menuColor[theme].background.active};
 
-          &:before {
+          &::before {
             transform: scaleY(1) translateY(-50%);
             background-color: ${menuColor[theme].border.active};
           }
@@ -93,7 +93,7 @@ export const getMenuItemStyles = ({
         &:focus-visible {
           background-color: ${menuColor[theme].background.focus};
 
-          &:before {
+          &::before {
             transform: scaleY(1) translateY(-50%);
             background-color: ${menuColor[theme].border.focus};
           }
@@ -180,7 +180,7 @@ export const getNestedMenuItemStyles = ({
     {
       // The inset border for submenu items
       [css`
-        &:after {
+        &::after {
           content: '';
           position: absolute;
           top: 0;

--- a/packages/menu/src/SubMenu/SubMenu.styles.ts
+++ b/packages/menu/src/SubMenu/SubMenu.styles.ts
@@ -32,7 +32,7 @@ const getBaseSubmenuToggleStyles = (theme: Theme) => css`
 
   &:hover {
     color: ${menuColor[theme].icon.hover};
-    &:before {
+    &::before {
       // the icon button hover circle
       background-color: ${menuColor[theme].background.hover};
     }

--- a/packages/radio-group/src/Radio/Radio.styles.ts
+++ b/packages/radio-group/src/Radio/Radio.styles.ts
@@ -56,7 +56,7 @@ export const inputThemeStyles: Record<Theme, string> = {
         background-color: ${palette.blue.base};
         border-color: ${palette.blue.base};
 
-        &:after {
+        &::after {
           transform: scale(1);
         }
       }
@@ -65,7 +65,7 @@ export const inputThemeStyles: Record<Theme, string> = {
         background-color: ${palette.gray.light2};
         border-color: ${palette.gray.light2};
 
-        &:after {
+        &::after {
           background-color: ${palette.gray.light3};
           transform: scale(1);
         }
@@ -82,7 +82,7 @@ export const inputThemeStyles: Record<Theme, string> = {
       border-color: ${palette.gray.light2};
       background-color: ${palette.gray.light3};
 
-      &:after {
+      &::after {
         transform: scale(1);
         background-color: ${palette.gray.light3};
       }
@@ -95,7 +95,7 @@ export const inputThemeStyles: Record<Theme, string> = {
         background-color: ${palette.blue.light1};
         border-color: ${palette.blue.light1};
 
-        &:after {
+        &::after {
           transform: scale(1);
         }
       }
@@ -103,7 +103,7 @@ export const inputThemeStyles: Record<Theme, string> = {
       &:disabled + .${inputDisplayWrapperClassName} .${inputDisplayClassName} {
         border-color: ${palette.gray.dark3};
 
-        &:after {
+        &::after {
           background-color: ${palette.gray.dark2};
           transform: scale(1);
         }
@@ -120,7 +120,7 @@ export const inputThemeStyles: Record<Theme, string> = {
       border-color: ${palette.gray.dark2};
       background-color: ${palette.gray.dark3};
 
-      &:after {
+      &::after {
         transform: scale(1);
         background-color: ${palette.gray.dark3};
       }
@@ -176,13 +176,13 @@ export const inputDisplayBaseStyle = css`
   border-radius: 100%;
   border-style: solid;
 
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     border-radius: 100%;
   }
 
-  &:after {
+  &::after {
     content: '';
     background-color: white;
     border-radius: 100%;
@@ -190,7 +190,7 @@ export const inputDisplayBaseStyle = css`
   }
 
   .${inputClassName}:disabled + .${inputDisplayWrapperClassName} & {
-    &:after {
+    &::after {
       box-shadow: none;
     }
   }
@@ -200,7 +200,7 @@ export const inputDisplaySizeStyles: Omit<Record<Size, string>, 'xsmall'> = {
   [Size.Small]: css`
     border-width: 2px;
 
-    &:after {
+    &::after {
       width: 6px;
       height: 6px;
       transition: transform ${transitionDuration.default}ms
@@ -211,7 +211,7 @@ export const inputDisplaySizeStyles: Omit<Record<Size, string>, 'xsmall'> = {
   [Size.Default]: css`
     border-width: 3px;
 
-    &:after {
+    &::after {
       width: 8px;
       height: 8px;
       transition: transform ${transitionDuration.default}ms

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.styles.ts
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.styles.ts
@@ -106,7 +106,7 @@ export const optionsWrapperStyle = ({
       }
 
       // Frame shadow
-      &:after {
+      &::after {
         content: '';
         position: absolute;
         width: 100%;

--- a/packages/segmented-control/src/SegmentedControlOption/SegmentedControlOption.styles.ts
+++ b/packages/segmented-control/src/SegmentedControlOption/SegmentedControlOption.styles.ts
@@ -112,7 +112,7 @@ export const getContainerStyles = ({
       /* 
       * Adds the divider line to unselected segments 
       */
-      &:before {
+      &::before {
         --divider-width: ${spacing[25]}px;
         content: '';
         position: absolute;

--- a/packages/side-nav/src/SideNavItem/SideNavItem.styles.ts
+++ b/packages/side-nav/src/SideNavItem/SideNavItem.styles.ts
@@ -60,7 +60,7 @@ export const baseStyle = css`
   }
 
   // Setup the active/focus wedge
-  &:before {
+  &::before {
     content: '';
     position: absolute;
     background-color: transparent;
@@ -101,7 +101,7 @@ export const activeBaseStyle = css`
   text-decoration: none;
 
   // The active wedge
-  &:before {
+  &::before {
     transform: scaleY(1);
   }
 `;
@@ -115,7 +115,7 @@ export const activeThemeStyle: Record<Theme, string> = {
       background-color: ${palette.green.light3};
     }
 
-    &:before {
+    &::before {
       background-color: ${palette.green.dark1};
     }
   `,
@@ -127,7 +127,7 @@ export const activeThemeStyle: Record<Theme, string> = {
       background-color: ${palette.green.dark3};
     }
 
-    &:before {
+    &::before {
       background-color: ${palette.green.base};
     }
   `,
@@ -152,7 +152,7 @@ export const focusedStyle = css`
     text-decoration: none;
 
     // The focus wedge
-    &:before {
+    &::before {
       transform: scaleY(1);
     }
   }
@@ -164,7 +164,7 @@ export const focusedThemeStyle: Record<Theme, string> = {
       color: ${palette.blue.dark2};
       background-color: ${palette.blue.light3};
 
-      &:before {
+      &::before {
         background-color: ${palette.blue.base};
       }
     }
@@ -174,7 +174,7 @@ export const focusedThemeStyle: Record<Theme, string> = {
       color: ${palette.blue.light3};
       background-color: ${palette.blue.dark3};
 
-      &:before {
+      &::before {
         background-color: ${palette.blue.light1};
       }
     }
@@ -183,7 +183,7 @@ export const focusedThemeStyle: Record<Theme, string> = {
 
 export const focusedDisabledStyle = css`
   &:focus {
-    &:before {
+    &::before {
       content: unset;
     }
   }

--- a/packages/stepper/src/InternalStep/InternalStep.styles.ts
+++ b/packages/stepper/src/InternalStep/InternalStep.styles.ts
@@ -11,7 +11,7 @@ export const baseStyles = css`
   flex-direction: column;
   align-items: center;
   padding-bottom: ${spacing[1]}px;
-  position: relative; // for the :after line
+  position: relative; // for the ::after line
 
   &:focus-visible {
     outline: none;
@@ -38,7 +38,7 @@ export const themeStyles: Record<Theme, string> = {
 };
 
 export const lineStyles = (iconSize: number, darkMode: boolean) => css`
-  &:after {
+  &::after {
     content: '';
     height: 1px;
     width: 100%;
@@ -52,12 +52,12 @@ export const lineStyles = (iconSize: number, darkMode: boolean) => css`
 
 export const completedLineStyles: Record<Theme, string> = {
   [Theme.Dark]: css`
-    &:after {
+    &::after {
       background-color: ${palette.green.base};
     }
   `,
   [Theme.Light]: css`
-    &:after {
+    &::after {
       background-color: ${palette.green.dark1};
     }
   `,

--- a/packages/table/src/TableHead/TableHead.styles.tsx
+++ b/packages/table/src/TableHead/TableHead.styles.tsx
@@ -25,7 +25,7 @@ export const getBaseStyles = (isSticky = false, theme: Theme) =>
         top: 0;
 
         .${tableClassName} & {
-          :after {
+          ::after {
             content: '';
             position: absolute;
             z-index: -1;
@@ -45,7 +45,7 @@ export const getBaseStyles = (isSticky = false, theme: Theme) =>
         }
 
         .${tableClassName}[data-is-sticky='true'] & {
-          :after {
+          ::after {
             opacity: 1;
           }
         }

--- a/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.styles.ts
+++ b/packages/table/src/useLeafyGreenTable/useLeafyGreenTable.styles.ts
@@ -9,7 +9,7 @@ export const disabledTableRowCheckStyles: Record<Theme, string> = {
       background-color: ${palette.gray.light2};
     }
     input[aria-checked='true'] + div {
-      &:before {
+      &::before {
         background-color: ${palette.gray.light1};
       }
       & path {
@@ -23,7 +23,7 @@ export const disabledTableRowCheckStyles: Record<Theme, string> = {
       background-color: ${palette.gray.dark2};
     }
     input[aria-checked='true'] + div {
-      &:before {
+      &::before {
         background-color: ${palette.gray.dark1};
       }
       & path {

--- a/packages/tabs/src/TabTitle/TabTitle.styles.ts
+++ b/packages/tabs/src/TabTitle/TabTitle.styles.ts
@@ -46,7 +46,7 @@ const baseStyles = css`
 
   // We create a pseudo element that's the width of the bolded text
   // This way there's no layout shift on hover when the text is bolded.
-  &:before {
+  &::before {
     content: attr(data-text);
     height: 0;
     font-weight: ${fontWeights.bold};
@@ -56,7 +56,7 @@ const baseStyles = css`
     pointer-events: none;
   }
 
-  &:after {
+  &::after {
     content: '';
     position: absolute;
     left: 0;
@@ -76,7 +76,7 @@ const baseStyles = css`
   }
 
   &:active:after {
-    &:after {
+    &::after {
       transform: scaleX(1);
     }
   }
@@ -108,7 +108,7 @@ const modeStyles: Record<Theme, ListTitleMode> = {
       &:hover {
         cursor: pointer;
         color: ${palette.gray.dark3};
-        &:after {
+        &::after {
           background-color: ${palette.gray.light2};
         }
       }
@@ -117,7 +117,7 @@ const modeStyles: Record<Theme, ListTitleMode> = {
       &:focus-visible {
         color: ${palette.blue.base};
 
-        &:after {
+        &::after {
           background-color: ${palette.blue.light1};
         }
       }
@@ -128,7 +128,7 @@ const modeStyles: Record<Theme, ListTitleMode> = {
         color: ${palette.green.dark2};
         font-weight: ${fontWeights.bold};
 
-        &:after {
+        &::after {
           transform: scaleX(1);
           background-color: ${palette.green.dark1};
         }
@@ -149,7 +149,7 @@ const modeStyles: Record<Theme, ListTitleMode> = {
         cursor: pointer;
         color: ${palette.white};
 
-        &:after {
+        &::after {
           background-color: ${palette.gray.dark2};
         }
       }
@@ -158,7 +158,7 @@ const modeStyles: Record<Theme, ListTitleMode> = {
       &:focus-visible {
         color: ${palette.blue.light1};
 
-        &:after {
+        &::after {
           background-color: ${palette.blue.light1};
         }
       }
@@ -169,7 +169,7 @@ const modeStyles: Record<Theme, ListTitleMode> = {
         color: ${palette.gray.light2};
         font-weight: ${fontWeights.bold};
 
-        &:after {
+        &::after {
           transform: scaleX(1);
           background-color: ${palette.green.dark1};
         }
@@ -189,7 +189,7 @@ const sizeStyles: Record<Size, string> = {
     line-height: ${typeScales.body1.lineHeight}px;
     height: ${SMALL_HEIGHT}px;
 
-    &:after {
+    &::after {
       height: 2px;
     }
   `,

--- a/packages/toggle/src/Toggle/styles.ts
+++ b/packages/toggle/src/Toggle/styles.ts
@@ -52,7 +52,7 @@ export const buttonBaseStyles = css`
   &[aria-checked='true'] {
     transition-delay: ${transitionDuration.default}ms;
 
-    &:before {
+    &::before {
       transform: scale(1);
       opacity: 1;
     }
@@ -60,7 +60,7 @@ export const buttonBaseStyles = css`
 
   // We're animating this pseudo-element in order to give the toggle groove
   // background an animation in and out.
-  &:before {
+  &::before {
     content: '';
     transition: ${transitionDuration.default}ms all ease-in-out;
     position: absolute;
@@ -91,8 +91,8 @@ export const sliderBaseStyles = css`
   justify-content: center;
   align-items: center;
 
-  &:before,
-  &:after {
+  &::before,
+  &::after {
     content: '';
     position: absolute;
     top: 0;
@@ -102,8 +102,8 @@ export const sliderBaseStyles = css`
   }
 
   ${sliderSelector.disabled} {
-    &:before,
-    &:after {
+    &::before,
+    &::after {
       content: none;
     }
   }
@@ -176,7 +176,7 @@ export const buttonThemeStyles: Record<Theme, string> = {
       border-color: ${palette.gray.light2};
     }
 
-    &:before {
+    &::before {
       background-color: ${palette.blue.base};
     }
 
@@ -206,7 +206,7 @@ export const buttonThemeStyles: Record<Theme, string> = {
       border-color: ${palette.gray.dark2};
     }
 
-    &:before {
+    &::before {
       background-color: ${palette.blue.light1};
     }
 


### PR DESCRIPTION
## ✍️ Proposed changes

Browsers accept both `:before` and `::before`, but the double colons distinguish pseudo-elements from pseudo-classes https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements

UI should remain unchanged, and this is purely a patch to remain consistent. Rather than publish new versions for a small change, we can leave the change to take place in the next versioning update for each package.

🎟 _Jira ticket:_ [Name of ticket](https://jira.mongodb.org/browse/[name-of-ticket])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
