### PR TITLE
LG-4817: `useResizeObserver` hook

### DIFF
--- a/.changeset/dark-dancers-wave.md
+++ b/.changeset/dark-dancers-wave.md
@@ -1,0 +1,7 @@
+---
+'@lg-chat/leafygreen-chat-provider': minor
+'@leafygreen-ui/hooks': minor
+---
+
+- Introduces a new hook (`useResizeObserver`) provided natively by `@leafygreen-ui/hooks`.
+- Updates `@lg-chat/leafygreen-chat-provider` to use the native `useResizeObserver` hook.

--- a/chat/leafygreen-chat-provider/package.json
+++ b/chat/leafygreen-chat-provider/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "dependencies": {
-    "use-resize-observer": "^9.1.0"
+    "@leafygreen-ui/hooks": "workspace:^"
   },
   "devDependencies": {
     "@lg-tools/build": "workspace:^"

--- a/chat/leafygreen-chat-provider/src/LeafyGreenChatProvider/LeafyGreenChatProvider.tsx
+++ b/chat/leafygreen-chat-provider/src/LeafyGreenChatProvider/LeafyGreenChatProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
-import useResizeObserver from 'use-resize-observer';
+
+import { useResizeObserver } from '@leafygreen-ui/hooks';
 
 import {
   LeafyGreenChatContextProps,

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -83,6 +83,36 @@ const lastTimeContentElMutated = useMutationObserver(
 | `callback` | `function`             | Callback function to execute inside of MutationObserver instance.                                                                                  |         |
 | `enabled`  | `boolean`              | Determines whether the event handler is attached or not.                                                                                           | `true`  |
 
+## useResizeObserver
+
+### Example
+
+```js
+import { useResizeObserver } from '@leafygreen-ui/hooks';
+
+const MyComponent = () => {
+  const { ref, size } = useResizeObserver(
+    onResize: ({ width }) => {
+      doSomethingWith(width)
+    }
+  );
+
+  return (
+    <div ref={ref}>
+      Width: {size.width}, Height: {size.height}
+    </div>
+  );
+};
+```
+
+### Properties
+
+| Prop       | Type                                                | Description                                                                             | Default |
+| ---------- | --------------------------------------------------- | --------------------------------------------------------------------------------------- | ------- |
+| `target`   | `React.RefObject<T> \| T \| null \| undefined`      | Optional React ref object pointing to the target element, or the target element itself. |         |
+| `onResize` | `(size: { width: number, height: number }) => void` | Optional function to call when the size of the target element changes.                  |         |
+| `disabled` | `boolean`                                           | Determines whether the event handler is disabled or not.                                | `false` |
+
 ## useViewportSize
 
 Hook to subscribe to changes in viewport size

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -16,6 +16,7 @@ export { default as useMutationObserver } from './useMutationObserver';
 export { default as useObjectDependency } from './useObjectDependency';
 export { default as usePoller } from './usePoller';
 export { default as usePrevious } from './usePrevious';
+export { useResizeObserver } from './useResizeObserver';
 export { default as useSsrCheck } from './useSsrCheck';
 export { useStateRef } from './useStateRef';
 export { default as useValidation } from './useValidation';

--- a/packages/hooks/src/useResizeObserver/index.ts
+++ b/packages/hooks/src/useResizeObserver/index.ts
@@ -1,0 +1,1 @@
+export { useResizeObserver } from './useResizeObserver';

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.spec.tsx
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.spec.tsx
@@ -1,0 +1,85 @@
+import { useRef } from 'react';
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import { useResizeObserver } from './useResizeObserver';
+
+function MockComponent({
+  disabled = false,
+  onResize,
+}: {
+  disabled?: boolean;
+  onResize: jest.Mock;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useResizeObserver(ref, onResize, disabled);
+
+  return (
+    <div data-testid="mock-element" ref={ref}>
+      My little div
+    </div>
+  );
+}
+
+describe('useResizeObserver', () => {
+  const observeMock = jest.fn();
+  const unobserveMock = jest.fn();
+  const disconnectMock = jest.fn();
+
+  let resizeCallback: ResizeObserverCallback;
+
+  beforeAll(() => {
+    // override global ResizeObserver class
+    global.ResizeObserver = jest.fn(callback => {
+      resizeCallback = callback;
+      return {
+        observe: observeMock,
+        unobserve: unobserveMock,
+        disconnect: disconnectMock,
+      };
+    });
+  });
+
+  beforeEach(() => {
+    observeMock.mockClear();
+    unobserveMock.mockClear();
+    disconnectMock.mockClear();
+  });
+
+  test('observes the target element', () => {
+    const { getByTestId } = render(<MockComponent onResize={jest.fn()} />);
+
+    const targetElem = getByTestId('mock-element');
+    expect(observeMock).toHaveBeenCalledWith(targetElem);
+  });
+
+  test('calls the provided callback when a size change is observed', () => {
+    const onResize = jest.fn();
+    render(<MockComponent onResize={onResize} />);
+
+    const resizeObserverEntry = {
+      contentRect: { width: 100, height: 200 },
+    } as ResizeObserverEntry;
+
+    // simulate ResizeObserver triggering callback
+    act(() => {
+      resizeCallback([resizeObserverEntry], new ResizeObserver(() => {}));
+    });
+
+    expect(onResize).toHaveBeenCalled();
+  });
+
+  test('disconnects observer on unmount', () => {
+    const { unmount } = render(<MockComponent onResize={jest.fn()} />);
+
+    unmount();
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+
+  test('does not observe if disabled', () => {
+    render(<MockComponent disabled={true} onResize={jest.fn()} />);
+
+    expect(observeMock).not.toHaveBeenCalled();
+    expect(disconnectMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.spec.tsx
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.spec.tsx
@@ -17,7 +17,7 @@ function MockComponent({
 
   const { ref, size } = useResizeObserver({
     target: usesControlledRef ? controlledRef : undefined,
-    callback: onResize,
+    onResize,
     disabled,
   });
 

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+/**
+ * Hook to observe changes in the size of a DOM element and fire a callback.
+ * @param target React ref object pointing to the target element.
+ * @param callback Function to call when the size of the target element changes.
+ * @param disabled Determines whether or not the hook should run, defaults to false.
+ */
+export const useResizeObserver = <T extends HTMLElement>(
+  target: HTMLElement | React.RefObject<T> | null,
+  callback: (entry: ResizeObserverEntry) => void,
+  disabled = false,
+) => {
+  const [size, setSize] = useState<Size>();
+
+  useEffect(() => {
+    if (disabled || !target) {
+      return;
+    }
+
+    const targetElem = target instanceof HTMLElement ? target : target.current;
+
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setSize({ width, height });
+
+        callback(entry);
+      }
+    });
+
+    if (targetElem) {
+      observer.observe(targetElem);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [target, callback, disabled]);
+
+  return size;
+};

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.ts
@@ -9,7 +9,7 @@ interface UseResizeObserverProps<T extends HTMLElement = HTMLElement> {
   /** Optional React ref object pointing to the target element or the target element itself. */
   target?: React.RefObject<T> | T | null | undefined;
   /** Function to call when the size of the target element changes. */
-  onResize?: (entry: ResizeObserverEntry) => void;
+  onResize?: (size: Size) => void;
   /** Determines whether or not the hook should run, defaults to false. */
   disabled?: boolean;
 }
@@ -54,7 +54,7 @@ export const useResizeObserver = <T extends HTMLElement>({
         setSize({ width, height });
 
         if (onResize) {
-          onResize(entry);
+          onResize({ width, height });
         }
       }
     });

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.ts
@@ -1,36 +1,61 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface Size {
   width: number;
   height: number;
 }
 
+interface UseResizeObserverProps<T extends HTMLElement = HTMLElement> {
+  /** Optional React ref object pointing to the target element or the target element itself. */
+  target?: React.RefObject<T> | T | null | undefined;
+  /** Function to call when the size of the target element changes. */
+  callback?: (entry: ResizeObserverEntry) => void;
+  /** Determines whether or not the hook should run, defaults to false. */
+  disabled?: boolean;
+}
+
+interface UseResizeObserverReturnType<T extends HTMLElement = HTMLElement> {
+  /** Ref to attach to the target element if no target is provided. */
+  ref?: React.RefObject<T>;
+  /** Current size of the target element, undefined if not observed or disabled. */
+  size?: Size;
+}
+
 /**
  * Hook to observe changes in the size of a DOM element and fire a callback.
- * @param target React ref object pointing to the target element.
- * @param callback Function to call when the size of the target element changes.
- * @param disabled Determines whether or not the hook should run, defaults to false.
  */
-export const useResizeObserver = <T extends HTMLElement>(
-  target: HTMLElement | React.RefObject<T> | null,
-  callback: (entry: ResizeObserverEntry) => void,
+export const useResizeObserver = <T extends HTMLElement>({
+  target,
+  callback,
   disabled = false,
-) => {
+}: UseResizeObserverProps<T>): UseResizeObserverReturnType<T> => {
+  const internalTargetRef = useRef<T>(null);
+
   const [size, setSize] = useState<Size>();
 
   useEffect(() => {
-    if (disabled || !target) {
+    if (disabled) {
       return;
     }
 
-    const targetElem = target instanceof HTMLElement ? target : target.current;
+    const targetElem = target
+      ? target instanceof HTMLElement
+        ? target
+        : target.current
+      : internalTargetRef.current;
+
+    if (!targetElem) {
+      return;
+    }
 
     const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
         setSize({ width, height });
 
-        callback(entry);
+        if (callback) {
+          callback(entry);
+        }
       }
     });
 
@@ -43,5 +68,8 @@ export const useResizeObserver = <T extends HTMLElement>(
     };
   }, [target, callback, disabled]);
 
-  return size;
+  return {
+    ref: target ? undefined : internalTargetRef,
+    size,
+  };
 };

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.ts
@@ -6,7 +6,7 @@ interface Size {
 }
 
 interface UseResizeObserverProps<T extends HTMLElement = HTMLElement> {
-  /** Optional React ref object pointing to the target element or the target element itself. */
+  /** Optional React ref object pointing to the target element, or the target element itself. */
   target?: React.RefObject<T> | T | null | undefined;
   /** Function to call when the size of the target element changes. */
   onResize?: (size: Size) => void;

--- a/packages/hooks/src/useResizeObserver/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver/useResizeObserver.ts
@@ -9,7 +9,7 @@ interface UseResizeObserverProps<T extends HTMLElement = HTMLElement> {
   /** Optional React ref object pointing to the target element or the target element itself. */
   target?: React.RefObject<T> | T | null | undefined;
   /** Function to call when the size of the target element changes. */
-  callback?: (entry: ResizeObserverEntry) => void;
+  onResize?: (entry: ResizeObserverEntry) => void;
   /** Determines whether or not the hook should run, defaults to false. */
   disabled?: boolean;
 }
@@ -22,11 +22,11 @@ interface UseResizeObserverReturnType<T extends HTMLElement = HTMLElement> {
 }
 
 /**
- * Hook to observe changes in the size of a DOM element and fire a callback.
+ * Hook to observe changes in the size of a DOM element and fire a onResize.
  */
 export const useResizeObserver = <T extends HTMLElement>({
   target,
-  callback,
+  onResize,
   disabled = false,
 }: UseResizeObserverProps<T>): UseResizeObserverReturnType<T> => {
   const internalTargetRef = useRef<T>(null);
@@ -53,8 +53,8 @@ export const useResizeObserver = <T extends HTMLElement>({
         const { width, height } = entry.contentRect;
         setSize({ width, height });
 
-        if (callback) {
-          callback(entry);
+        if (onResize) {
+          onResize(entry);
         }
       }
     });
@@ -66,7 +66,7 @@ export const useResizeObserver = <T extends HTMLElement>({
     return () => {
       observer.disconnect();
     };
-  }, [target, callback, disabled]);
+  }, [target, onResize, disabled]);
 
   return {
     ref: target ? undefined : internalTargetRef,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,9 +547,9 @@ importers:
 
   chat/leafygreen-chat-provider:
     dependencies:
-      use-resize-observer:
-        specifier: ^9.1.0
-        version: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@leafygreen-ui/hooks':
+        specifier: workspace:^
+        version: link:../../packages/hooks
     devDependencies:
       '@lg-tools/build':
         specifier: workspace:^
@@ -1921,7 +1921,7 @@ importers:
         version: 11.1.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)
+        version: 10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)
       xml2json:
         specifier: ^0.12.0
         version: 0.12.0
@@ -3938,10 +3938,10 @@ importers:
         version: 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@storybook/react':
         specifier: 8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)
       '@storybook/react-webpack5':
         specifier: 8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)
       '@storybook/test':
         specifier: 8.6.12
         version: 8.6.12(storybook@8.6.14(prettier@2.8.8))
@@ -3950,7 +3950,7 @@ importers:
         version: 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@svgr/webpack':
         specifier: 8.0.1
-        version: 8.0.1(typescript@5.9.0-dev.20250725)
+        version: 8.0.1(typescript@5.9.0-dev.20250729)
       assert:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3992,7 +3992,7 @@ importers:
         version: 18.3.1
       react-docgen-typescript:
         specifier: 2.2.2
-        version: 2.2.2(typescript@5.9.0-dev.20250725)
+        version: 2.2.2(typescript@5.9.0-dev.20250729)
       react-dom:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.1(react@18.3.1)
@@ -4143,7 +4143,7 @@ importers:
         version: 11.1.1
       jest:
         specifier: 29.6.2
-        version: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+        version: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
       jest-axe:
         specifier: 8.0.0
         version: 8.0.0
@@ -5470,9 +5470,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
-  '@juggle/resize-observer@3.4.0':
-    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -10764,8 +10761,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.0-dev.20250725:
-    resolution: {integrity: sha512-iCfSsyPg1NMRP2ythXNvkljHbmMTppyUUZSnnD4DwGxKEn2GJwz0nBByLOJNbAeYggqo+/zgraMry9U+BZgJMw==}
+  typescript@5.9.0-dev.20250729:
+    resolution: {integrity: sha512-+tqV9F9lsLD6c/vZ+ZqJim/uVsEPmwmgE+Ib9VFyoR9Ibw0uDWx6rDN4hO5PaL6MJP/8eVJTfags7B4BdbW7Dg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10900,12 +10897,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  use-resize-observer@9.1.0:
-    resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
-    peerDependencies:
-      react: 16.8.0 - 18
-      react-dom: 16.8.0 - 18
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -13343,7 +13334,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))':
+  '@jest/core@29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -13357,7 +13348,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13414,7 +13405,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -13428,7 +13419,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13590,8 +13581,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
-
-  '@juggle/resize-observer@3.4.0': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -13957,7 +13946,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)':
+  '@storybook/builder-webpack5@8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)':
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@types/semver': 7.7.0
@@ -13967,7 +13956,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.11.0(webpack@5.88.0(esbuild@0.25.8))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.0-dev.20250725)(webpack@5.88.0(esbuild@0.25.8))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.0-dev.20250729)(webpack@5.88.0(esbuild@0.25.8))
       html-webpack-plugin: 5.6.3(webpack@5.88.0(esbuild@0.25.8))
       magic-string: 0.30.17
       path-browserify: 1.0.1
@@ -13985,7 +13974,7 @@ snapshots:
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -14069,11 +14058,11 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@2.8.8)
 
-  '@storybook/preset-react-webpack@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)':
+  '@storybook/preset-react-webpack@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)':
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.14(prettier@2.8.8))
-      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250725)(webpack@5.88.0(esbuild@0.25.8))
+      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250729)(webpack@5.88.0(esbuild@0.25.8))
       '@types/semver': 7.7.0
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -14086,7 +14075,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       webpack: 5.88.0(esbuild@0.25.8)
     optionalDependencies:
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
     transitivePeerDependencies:
       - '@storybook/test'
       - '@swc/core'
@@ -14099,16 +14088,16 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@2.8.8)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250725)(webpack@5.88.0(esbuild@0.25.8))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.0-dev.20250729)(webpack@5.88.0(esbuild@0.25.8))':
     dependencies:
       debug: 4.4.1
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.8
-      react-docgen-typescript: 2.2.2(typescript@5.9.0-dev.20250725)
+      react-docgen-typescript: 2.2.2(typescript@5.9.0-dev.20250729)
       tslib: 2.8.1
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
       webpack: 5.88.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - supports-color
@@ -14119,16 +14108,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.14(prettier@2.8.8)
 
-  '@storybook/react-webpack5@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)':
+  '@storybook/react-webpack5@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)
-      '@storybook/preset-react-webpack': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)
-      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)
+      '@storybook/builder-webpack5': 8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)
+      '@storybook/preset-react-webpack': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)
+      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.14(prettier@2.8.8)
     optionalDependencies:
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
     transitivePeerDependencies:
       - '@rspack/core'
       - '@storybook/test'
@@ -14153,7 +14142,7 @@ snapshots:
       '@storybook/test': 8.6.12(storybook@8.6.14(prettier@2.8.8))
       typescript: 5.8.3
 
-  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250725)':
+  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@5.9.0-dev.20250729)':
     dependencies:
       '@storybook/components': 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@storybook/global': 5.0.0
@@ -14166,7 +14155,7 @@ snapshots:
       storybook: 8.6.14(prettier@2.8.8)
     optionalDependencies:
       '@storybook/test': 8.6.12(storybook@8.6.14(prettier@2.8.8))
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
 
   '@storybook/test@8.5.3(storybook@8.6.14(prettier@2.8.8))':
     dependencies:
@@ -14332,12 +14321,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.0.0(typescript@5.9.0-dev.20250725)':
+  '@svgr/core@8.0.0(typescript@5.9.0-dev.20250729)':
     dependencies:
       '@babel/core': 7.24.3
       '@svgr/babel-preset': 8.0.0(@babel/core@7.24.3)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250725)
+      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250729)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -14382,11 +14371,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250725))':
+  '@svgr/plugin-jsx@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250729))':
     dependencies:
       '@babel/core': 7.24.3
       '@svgr/babel-preset': 8.0.0(@babel/core@7.24.3)
-      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250725)
+      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250729)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -14417,10 +14406,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/plugin-svgo@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250725))(typescript@5.9.0-dev.20250725)':
+  '@svgr/plugin-svgo@8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250729))(typescript@5.9.0-dev.20250729)':
     dependencies:
-      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250725)
-      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250725)
+      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250729)
+      cosmiconfig: 8.3.6(typescript@5.9.0-dev.20250729)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -14451,16 +14440,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/webpack@8.0.1(typescript@5.9.0-dev.20250725)':
+  '@svgr/webpack@8.0.1(typescript@5.9.0-dev.20250729)':
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.24.3)
       '@babel/preset-env': 7.24.3(@babel/core@7.24.3)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.3)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.3)
-      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250725)
-      '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250725))
-      '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250725))(typescript@5.9.0-dev.20250725)
+      '@svgr/core': 8.0.0(typescript@5.9.0-dev.20250729)
+      '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250729))
+      '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0(typescript@5.9.0-dev.20250729))(typescript@5.9.0-dev.20250729)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15758,14 +15747,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  cosmiconfig@8.3.6(typescript@5.9.0-dev.20250725):
+  cosmiconfig@8.3.6(typescript@5.9.0-dev.20250729):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
 
   create-ecdh@4.0.4:
     dependencies:
@@ -16145,7 +16134,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
 
   dunder-proto@1.0.1:
     dependencies:
@@ -16763,7 +16752,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.0-dev.20250725)(webpack@5.88.0(esbuild@0.25.8)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.0-dev.20250729)(webpack@5.88.0(esbuild@0.25.8)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -16777,7 +16766,7 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.7.2
       tapable: 2.2.2
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
       webpack: 5.88.0(esbuild@0.25.8)
 
   form-data@2.5.5:
@@ -17461,16 +17450,16 @@ snapshots:
       - ts-node
     optional: true
 
-  jest-cli@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)):
+  jest-cli@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.2.0
-      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       prompts: 2.4.2
@@ -17513,7 +17502,7 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-config@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)):
+  jest-config@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
@@ -17539,7 +17528,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)
+      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17576,7 +17565,7 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-config@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)):
+  jest-config@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
@@ -17602,7 +17591,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)
+      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17870,12 +17859,12 @@ snapshots:
       - ts-node
     optional: true
 
-  jest@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725)):
+  jest@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729)):
     dependencies:
-      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725))
+      jest-cli: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19261,9 +19250,9 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  react-docgen-typescript@2.2.2(typescript@5.9.0-dev.20250725):
+  react-docgen-typescript@2.2.2(typescript@5.9.0-dev.20250729):
     dependencies:
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
 
   react-docgen@7.1.1:
     dependencies:
@@ -20203,7 +20192,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250725):
+  ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.0-dev.20250729):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -20217,7 +20206,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.0-dev.20250725
+      typescript: 5.9.0-dev.20250729
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -20329,7 +20318,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.0-dev.20250725: {}
+  typescript@5.9.0-dev.20250729: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -20477,12 +20466,6 @@ snapshots:
       use-isomorphic-layout-effect: 1.2.1(@types/react@18.2.23)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.2.23
-
-  use-resize-observer@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@juggle/resize-observer': 3.4.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## ✍️ Proposed changes

- introduce a new internal `useResizeObserver` hook for lightweight and fewer dependencies
- replace existing 3rd party usages of `use-resize-observer` package

🎟 _Jira ticket:_ [LG-4817](https://jira.mongodb.org/browse/[LG-4817])

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example looks as intended on the design website.

## 🧪 How to test changes

<!--
Explain or give steps of how to test your changes manually. Be as specific as you can – this will help the reviewer effectively and efficiently test and approve your changes. For bug fixes, this can often simply be the steps that you used to reproduce the bug.
-->
