### PR TITLE
refactor(DrawerWithToolbarWrapper): Fix overlay drawer flicker on open

### DIFF
--- a/packages/drawer/src/DrawerToolbarLayout/DrawerWithToolbarWrapper/DrawerWithToolbarWrapper.tsx
+++ b/packages/drawer/src/DrawerToolbarLayout/DrawerWithToolbarWrapper/DrawerWithToolbarWrapper.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, useEffect, useState } from 'react';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 
 import { useDrawerLayoutContext } from '../../DrawerLayout';
+import { useDrawerToolbarContext } from '../DrawerToolbarContext';
 
 import { getDrawerWithToolbarWrapperStyles } from './DrawerWithToolbarWrapper.styles';
 import { DrawerWithToolbarWrapperProps } from './DrawerWithToolbarWrapper.types';
@@ -20,7 +21,8 @@ export const DrawerWithToolbarWrapper = forwardRef<
 >(({ children, className }: DrawerWithToolbarWrapperProps, forwardedRef) => {
   const { theme } = useDarkMode();
   const [shouldAnimate, setShouldAnimate] = useState(false);
-  const { displayMode, isDrawerOpen, size } = useDrawerLayoutContext();
+  const { displayMode, size } = useDrawerLayoutContext();
+  const { isDrawerOpen } = useDrawerToolbarContext();
 
   useEffect(() => {
     if (isDrawerOpen) setShouldAnimate(true);


### PR DESCRIPTION
## ✍️ Proposed changes

<!-- Describe the big picture of your changes here and communicate why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

There were some changes to the layout components in the resizable work, which accidentally introduced a flicker to an overlay drawer. This change prevents that flicker from happening.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

Check out any Drawer/Toolbar/ overlay story and open the drawer. There should not be a flicker.

story with flicker: https://storybook.mongodb.design/?path=/story/sections-drawer-toolbar--overlay
story without flicker: https://642700aa3e49e32bdbf0b0fc-iaebwbrvoy.chromatic.com/?path=/story/sections-drawer-toolbar--overlay
