### PR TITLE
chore(vscode) adds default .svg editor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,13 +12,12 @@
   "eslint.lintTask.enable": true,
   "eslint.format.enable": true,
   "eslint.runtime": "node",
-  "eslint.workingDirectories": [
-    "./"
-  ],
+  "eslint.workingDirectories": ["./"],
   "typescript.preferences.importModuleSpecifier": "project-relative",
-  "cSpell.words": [
-    "leafygreen"
-  ],
+  "cSpell.words": ["leafygreen"],
+  "workbench.editorAssociations": {
+    "*.svg": "default"
+  },
   "githubPullRequests.pullRequestDescription": "Copilot",
   "github.copilot.chat.codeGeneration.instructions": [
     {


### PR DESCRIPTION
At some point VSCode (and Cursor) started opening `.svg` files in the image preview. 
IMO we should set the default back to text editor (done here)

(if others disagree, I can close this ticket and just update my user settings)