### PR TITLE
[LG-5461] fix(button): `onClick` handler type inference

### DIFF
--- a/packages/button/src/Button/Button.spec.tsx
+++ b/packages/button/src/Button/Button.spec.tsx
@@ -265,6 +265,14 @@ describe('packages/button', () => {
       <Button onClick={() => {}} />;
     });
 
+    test('infers the onClick handler argument', () => {
+      <Button
+        onClick={event => {
+          event.preventDefault();
+        }}
+      />;
+    });
+
     test('accepts anchor tag attributes', () => {
       <Button href="http://mongodb.design" target="_blank" rel="noopener" />;
     });


### PR DESCRIPTION
## ✍️ Proposed changes

For now, I'm simply adding a failing test for context:

The failing test I added in that PR shows how the argument of callbacks passed to onClick of Button can no longer be inferred (it becomes implicit any), since it switched from `Box` to `InferredPolymorphic` (via [PR-2695](https://github.com/mongodb/leafygreen-ui/pull/2695))

<img width="531" height="180" alt="Screenshot of error in VS Code" src="https://github.com/user-attachments/assets/3f850816-bd38-4aac-884f-7bda817257ba" />


🎟 _Jira ticket:_ [LG-5461](https://jira.mongodb.org/browse/LG-5461)

## ✅ Checklist

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example will look as intended on the design website.

### For bug fixes, new features & breaking changes

- [x] I have added stories/tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

<!--
Provide concise, specific, and actionable testing steps based on the changes made. For bug fixes, include simple steps to reproduce the issue. For features, provide clear steps to verify the new functionality.
-->

TBD.
