### PR TITLE
[LG-5463] fix(code): fix language select rendering when displayName and language differ

### DIFF
--- a/.changeset/flat-carrots-change.md
+++ b/.changeset/flat-carrots-change.md
@@ -1,0 +1,29 @@
+---
+'@leafygreen-ui/code': patch
+---
+
+Fixes bug that prevented the language select from rendering if the `displayName` and `language` differed. 
+
+```tsx
+// languageOptions passed to `<Panel`>
+export const languageOptions = [
+  {
+    displayName: 'JavaScript',
+    language: 'javascript',
+  },
+  {
+    displayName: 'Python',
+    language: 'python',
+  },
+  {
+    displayName: 'macOS',
+    language: 'shell',
+  },
+];
+
+// This will render the language selector.
+<Code
+  language={languageOptions[2].language} // shell
+  panel={<Panel languageOptions={languageOptions} />} 
+/>
+```

--- a/packages/code/src/Code.stories.tsx
+++ b/packages/code/src/Code.stories.tsx
@@ -11,10 +11,8 @@ import { css } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 
-import {
-  languageOptions,
-  LanguageSwitcherWithPanelExample,
-} from './LanguageSwitcher/LanguageSwitcherExample';
+import { LanguageSwitcherWithPanelExample } from './LanguageSwitcher/LanguageSwitcherExample';
+import { languageOptions } from './testing/Code.testutils';
 import Code, {
   CodeProps,
   CopyButton,

--- a/packages/code/src/Code/Code.spec.tsx
+++ b/packages/code/src/Code/Code.spec.tsx
@@ -409,6 +409,74 @@ describe('packages/Code', () => {
           );
         }
       });
+
+      describe('when the language and displayName are the same', () => {
+        test('renders the language picker', () => {
+          const { getLanguageSwitcherUtils } = renderCode({
+            language: languageOptions[0].displayName,
+            panel: (
+              <Panel onChange={() => {}} languageOptions={languageOptions} />
+            ),
+          });
+          expect(getLanguageSwitcherUtils().getInput()).toBeDefined();
+        });
+
+        test('the language pickers display the displayName', () => {
+          const { getLanguageSwitcherUtils } = renderCode({
+            language: languageOptions[0].displayName,
+            panel: (
+              <Panel onChange={() => {}} languageOptions={languageOptions} />
+            ),
+          });
+          expect(getLanguageSwitcherUtils().getInput()).toHaveTextContent(
+            'JavaScript',
+          );
+        });
+
+        test('sets the correct language', () => {
+          const { getLanguage } = renderCode({
+            language: languageOptions[0].displayName,
+            panel: (
+              <Panel onChange={() => {}} languageOptions={languageOptions} />
+            ),
+          });
+          expect(getLanguage()).toBe('JavaScript');
+        });
+      });
+
+      describe('when the language and displayName are different', () => {
+        test('renders the language picker', () => {
+          const { getLanguageSwitcherUtils } = renderCode({
+            language: languageOptions[2].language, // language is shell. displayName is macOS
+            panel: (
+              <Panel onChange={() => {}} languageOptions={languageOptions} />
+            ),
+          });
+          expect(getLanguageSwitcherUtils().getInput()).toBeDefined();
+        });
+
+        test('the language pickers displays the displayName', () => {
+          const { getLanguageSwitcherUtils } = renderCode({
+            language: languageOptions[2].language, // language is shell. displayName is macOS
+            panel: (
+              <Panel onChange={() => {}} languageOptions={languageOptions} />
+            ),
+          });
+          expect(getLanguageSwitcherUtils().getInput()).toHaveTextContent(
+            'macOS',
+          );
+        });
+
+        test('sets the correct language', () => {
+          const { getLanguage } = renderCode({
+            language: languageOptions[2].language, // language is shell. displayName is macOS
+            panel: (
+              <Panel onChange={() => {}} languageOptions={languageOptions} />
+            ),
+          });
+          expect(getLanguage()).toBe('shell');
+        });
+      });
     });
 
     describe('custom action buttons', () => {
@@ -490,7 +558,7 @@ describe('packages/Code', () => {
       const { getLanguageSwitcherUtils } = renderCodeWithLanguageSwitcher({});
       const trigger = getLanguageSwitcherUtils().getInput();
       userEvent.click(trigger!);
-      expect(getLanguageSwitcherUtils().getOptions()).toHaveLength(2);
+      expect(getLanguageSwitcherUtils().getOptions()).toHaveLength(3);
     });
 
     test('options displayed in select are based on the languageOptions prop', () => {

--- a/packages/code/src/LanguageSwitcher/LanguageSwitcherExample.tsx
+++ b/packages/code/src/LanguageSwitcher/LanguageSwitcherExample.tsx
@@ -1,19 +1,9 @@
 import React, { useState } from 'react';
 
 import { LanguageOption } from '../Panel/Panel.types';
+import { languageOptions } from '../testing/Code.testutils';
 import { Language } from '../types';
 import Code, { Panel } from '..';
-
-export const languageOptions = [
-  {
-    displayName: 'JavaScript',
-    language: Language.JavaScript,
-  },
-  {
-    displayName: 'Python',
-    language: Language.Python,
-  },
-];
 
 const jsSnippet = `
 
@@ -34,9 +24,17 @@ print (greeting("World"))
 
 `;
 
+const shellSnippet = `
+
+#!/bin/sh
+echo "Hello world"
+
+`;
+
 const snippetMap = {
   [Language.JavaScript]: jsSnippet,
   [Language.Python]: pythonSnippet,
+  [Language.Shell]: shellSnippet,
 };
 
 export function LanguageSwitcherWithPanelExample({
@@ -61,7 +59,7 @@ export function LanguageSwitcherWithPanelExample({
   return (
     <Code
       {...rest}
-      language={language.displayName}
+      language={language.language}
       panel={
         <Panel
           languageOptions={languageOptions}
@@ -72,7 +70,7 @@ export function LanguageSwitcherWithPanelExample({
         />
       }
     >
-      {snippetMap[languageIndex as 'javascript' | 'python']}
+      {snippetMap[languageIndex as 'javascript' | 'python' | 'shell']}
     </Code>
   );
 }

--- a/packages/code/src/Panel/Panel.tsx
+++ b/packages/code/src/Panel/Panel.tsx
@@ -41,7 +41,7 @@ function Panel({
     showCustomActionButtons && !!filteredCustomActionIconButtons.length;
 
   const currentLanguage = languageOptions?.find(
-    option => option.displayName === language,
+    option => option.displayName === language || option.language === language,
   );
 
   const shouldRenderLanguageSwitcher =

--- a/packages/code/src/testing/Code.testutils.tsx
+++ b/packages/code/src/testing/Code.testutils.tsx
@@ -42,6 +42,10 @@ export const languageOptions = [
     displayName: 'Python',
     language: Language.Python,
   },
+  {
+    displayName: 'macOS',
+    language: Language.Shell,
+  },
 ];
 
 export const renderCode = (

--- a/packages/code/src/testing/getTestUtils.spec.tsx
+++ b/packages/code/src/testing/getTestUtils.spec.tsx
@@ -105,7 +105,7 @@ describe('packages/tabs/getTestUtils', () => {
             {},
           );
           userEvent.click(getLanguageSwitcherUtils().getInput()!);
-          expect(getLanguageSwitcherUtils().getOptions()).toHaveLength(2);
+          expect(getLanguageSwitcherUtils().getOptions()).toHaveLength(3);
         });
       });
 


### PR DESCRIPTION
## ✍️ Proposed changes

Fixes a bug in the Code component that prevented the language select from rendering when the `displayName` and `language` properties differed in the language options. The issue was in the Panel component's logic for finding the current language, which only matched against `displayName` but not against the `language` property itself.

The fix updates the language matching logic to check both `displayName` and `language` properties, enabling proper rendering of the language selector in cases where these values differ (e.g., displayName: "macOS", language: "shell").

🎟️ _Jira ticket:_ [LG-5463](https://jira.mongodb.org/browse/LG-5463)

## ✅ Checklist

- [x] I have added stories/tests that prove my fix is effective or that my feature works
- [x] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

### Story
View the `With Language Switcher` story

### Manually
1. Create a Code component with language options where `displayName` and `language` differ:
   ```tsx
   const languageOptions = [
     { displayName: 'macOS', language: 'shell' }
   ];
   ```
2. Set the Code component's language prop to the `language` value (not displayName):
   ```tsx
   <Code 
     language="shell" 
     panel={<Panel languageOptions={languageOptions} />} 
   />
   ```
3. Verify that the language selector renders and displays "macOS" as the selected option
4. Confirm that the syntax highlighting uses the correct language ("shell")
5. Run the new test cases added in `Code.spec.tsx` to verify the fix works for both matching and differing displayName/language scenarios