### PR TITLE
feat(side-nav): add new SideNav component scaffold

### DIFF
--- a/chat/side-nav/README.md
+++ b/chat/side-nav/README.md
@@ -1,0 +1,25 @@
+# Side Nav
+
+![npm (scoped)](https://img.shields.io/npm/v/@leafygreen-ui/side-nav.svg)
+
+#### [View on MongoDB.design](https://www.mongodb.design/component/side-nav/live-example/)
+
+## Installation
+
+### PNPM
+
+```shell
+pnpm add @leafygreen-ui/side-nav
+```
+
+### Yarn
+
+```shell
+yarn add @leafygreen-ui/side-nav
+```
+
+### NPM
+
+```shell
+npm install @leafygreen-ui/side-nav
+```

--- a/chat/side-nav/package.json
+++ b/chat/side-nav/package.json
@@ -1,0 +1,43 @@
+  
+{
+  "name": "@lg-chat/side-nav",
+  "version": "0.1.0",
+  "description": "LeafyGreen UI Kit Side Nav",
+  "main": "./dist/umd/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": {
+      "require": "./dist/umd/index.js",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./testing": {
+      "require": "./dist/umd/testing/index.js",
+      "import": "./dist/esm/testing/index.js",
+      "types": "./dist/types/testing/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "lg-build bundle",
+    "tsc": "lg-build tsc",
+    "docs": "lg-build docs"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@leafygreen-ui/emotion": "workspace:^",
+    "@leafygreen-ui/lib": "workspace:^",
+    "@lg-tools/test-harnesses": "workspace:^"
+  },
+  "homepage": "https://github.com/mongodb/leafygreen-ui/tree/main/packages/side-nav",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mongodb/leafygreen-ui"
+  },
+  "bugs": {
+    "url": "https://jira.mongodb.org/projects/LG/summary"
+  }
+}

--- a/chat/side-nav/src/SideNav.stories.tsx
+++ b/chat/side-nav/src/SideNav.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+
+import { SideNav } from '.';
+
+export default {
+  title: 'Components/SideNav',
+  component: SideNav,
+};
+
+const Template: StoryFn<typeof SideNav> = props => <SideNav {...props} />;
+
+export const Basic = Template.bind({});

--- a/chat/side-nav/src/SideNav/SideNav.spec.tsx
+++ b/chat/side-nav/src/SideNav/SideNav.spec.tsx
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { SideNav } from '.';
+
+describe('packages/side-nav', () => {
+  test('condition', () => {});
+});

--- a/chat/side-nav/src/SideNav/SideNav.styles.ts
+++ b/chat/side-nav/src/SideNav/SideNav.styles.ts
@@ -1,0 +1,3 @@
+import { css } from '@leafygreen-ui/emotion';
+
+export const baseStyles = css``;

--- a/chat/side-nav/src/SideNav/SideNav.tsx
+++ b/chat/side-nav/src/SideNav/SideNav.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { SideNavProps } from './SideNav.types';
+
+export const SideNav = (props: SideNavProps) => {
+  return <div {...props}>your content here</div>;
+};
+
+SideNav.displayName = 'SideNav';

--- a/chat/side-nav/src/SideNav/SideNav.types.ts
+++ b/chat/side-nav/src/SideNav/SideNav.types.ts
@@ -1,0 +1,1 @@
+export interface SideNavProps {}

--- a/chat/side-nav/src/SideNav/index.ts
+++ b/chat/side-nav/src/SideNav/index.ts
@@ -1,0 +1,2 @@
+export { SideNav } from './SideNav';
+export { type SideNavProps } from './SideNav.types';

--- a/chat/side-nav/src/index.ts
+++ b/chat/side-nav/src/index.ts
@@ -1,0 +1,1 @@
+export { SideNav, type SideNavProps } from './SideNav';

--- a/chat/side-nav/src/testing/getTestUtils.spec.tsx
+++ b/chat/side-nav/src/testing/getTestUtils.spec.tsx
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { SideNav } from '.';
+
+describe('packages/side-nav/getTestUtils', () => {
+  test('condition', () => {});
+});

--- a/chat/side-nav/src/testing/getTestUtils.tsx
+++ b/chat/side-nav/src/testing/getTestUtils.tsx
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { findByLgId, getByLgId, queryByLgId } from '@lg-tools/test-harnesses';
+
+import { LgIdString } from '@leafygreen-ui/lib';
+
+import { DEFAULT_LGID_ROOT, getLgIds } from '../utils/getLgIds';
+
+import { TestUtilsReturnType } from './getTestUtils.types';
+
+export const getTestUtils = (
+  lgId: LgIdString = DEFAULT_LGID_ROOT,
+): TestUtilsReturnType => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const lgIds = getLgIds(lgId);
+
+  return {};
+};

--- a/chat/side-nav/src/testing/getTestUtils.types.ts
+++ b/chat/side-nav/src/testing/getTestUtils.types.ts
@@ -1,0 +1,1 @@
+export interface TestUtilsReturnType {}

--- a/chat/side-nav/src/testing/index.ts
+++ b/chat/side-nav/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { getTestUtils } from './getTestUtils';
+export { type TestUtilsReturnType } from './getTestUtils.types';

--- a/chat/side-nav/src/utils/getLgIds.ts
+++ b/chat/side-nav/src/utils/getLgIds.ts
@@ -1,0 +1,12 @@
+import { LgIdString } from '@leafygreen-ui/lib';
+
+export const DEFAULT_LGID_ROOT = 'lg-side_nav';
+
+export const getLgIds = (root: LgIdString = DEFAULT_LGID_ROOT) => {
+  const ids = {
+    root,
+  } as const;
+  return ids;
+};
+
+export type GetLgIdsReturnType = ReturnType<typeof getLgIds>;

--- a/chat/side-nav/tsconfig.json
+++ b/chat/side-nav/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@lg-tools/build/config/package.tsconfig.json",
+   "compilerOptions": {
+    "paths": {
+      "@leafygreen-ui/icon/dist/*": ["../../packages/icon/src/generated/*"],
+      "@leafygreen-ui/*": ["../../packages/*/src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.spec.*", "**/*.stories.*"],
+  "references": [
+    {
+      "path": "../../packages/emotion"
+    },
+    {
+      "path": "../../packages/lib"
+    },
+    {
+      "path": "../../tools/test-harnesses"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,18 @@ importers:
         specifier: workspace:^
         version: link:../../tools/build
 
+  chat/side-nav:
+    dependencies:
+      '@leafygreen-ui/emotion':
+        specifier: workspace:^
+        version: link:../../packages/emotion
+      '@leafygreen-ui/lib':
+        specifier: workspace:^
+        version: link:../../packages/lib
+      '@lg-tools/test-harnesses':
+        specifier: workspace:^
+        version: link:../../tools/test-harnesses
+
   chat/suggestions:
     dependencies:
       '@leafygreen-ui/banner':
@@ -1985,7 +1997,7 @@ importers:
         version: 4.16.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)
+        version: 10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)
       xml2json:
         specifier: ^0.12.0
         version: 0.12.0
@@ -4051,10 +4063,10 @@ importers:
         version: 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@storybook/react':
         specifier: 8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)
       '@storybook/react-webpack5':
         specifier: 8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)
       '@storybook/test':
         specifier: 8.6.12
         version: 8.6.12(storybook@8.6.14(prettier@2.8.8))
@@ -4063,7 +4075,7 @@ importers:
         version: 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@svgr/webpack':
         specifier: 8.0.1
-        version: 8.0.1(typescript@6.0.0-dev.20250822)
+        version: 8.0.1(typescript@6.0.0-dev.20250827)
       assert:
         specifier: ^2.1.0
         version: 2.1.0
@@ -4105,7 +4117,7 @@ importers:
         version: 18.3.1
       react-docgen-typescript:
         specifier: 2.2.2
-        version: 2.2.2(typescript@6.0.0-dev.20250822)
+        version: 2.2.2(typescript@6.0.0-dev.20250827)
       react-dom:
         specifier: ^17.0.0 || ^18.0.0
         version: 18.3.1(react@18.3.1)
@@ -4256,7 +4268,7 @@ importers:
         version: 11.1.1
       jest:
         specifier: 29.6.2
-        version: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+        version: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
       jest-axe:
         specifier: 8.0.0
         version: 8.0.0
@@ -10851,8 +10863,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20250822:
-    resolution: {integrity: sha512-omHezTVn6vg+B/eFHkIzUGFvlbbkJdsdmdBohcsw8NMLyKOhKRMinE9aLu8f0EALT4R2YS41xak2KinK74/6Xg==}
+  typescript@6.0.0-dev.20250827:
+    resolution: {integrity: sha512-TNrtA9r9AMgInuUMAV5hVTQWClBfvG+HWhIanl7ZO8GWSwjzL9mRgauvwzMfXpdwoAR1h+XC5zSj9WbbGGOtxg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -13401,7 +13413,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))':
+  '@jest/core@29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -13415,7 +13427,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13472,7 +13484,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -13486,7 +13498,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+      jest-config: 29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -14017,7 +14029,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)':
+  '@storybook/builder-webpack5@8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)':
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@types/semver': 7.7.0
@@ -14027,7 +14039,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.11.0(webpack@5.88.0(esbuild@0.25.8))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@6.0.0-dev.20250822)(webpack@5.88.0(esbuild@0.25.8))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@6.0.0-dev.20250827)(webpack@5.88.0(esbuild@0.25.8))
       html-webpack-plugin: 5.6.3(webpack@5.88.0(esbuild@0.25.8))
       magic-string: 0.30.17
       path-browserify: 1.0.1
@@ -14045,7 +14057,7 @@ snapshots:
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -14129,11 +14141,11 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@2.8.8)
 
-  '@storybook/preset-react-webpack@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)':
+  '@storybook/preset-react-webpack@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)':
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.14(prettier@2.8.8))
-      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.0-dev.20250822)(webpack@5.88.0(esbuild@0.25.8))
+      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.0-dev.20250827)(webpack@5.88.0(esbuild@0.25.8))
       '@types/semver': 7.7.0
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -14146,7 +14158,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       webpack: 5.88.0(esbuild@0.25.8)
     optionalDependencies:
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
     transitivePeerDependencies:
       - '@storybook/test'
       - '@swc/core'
@@ -14159,16 +14171,16 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@2.8.8)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.0-dev.20250822)(webpack@5.88.0(esbuild@0.25.8))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.0-dev.20250827)(webpack@5.88.0(esbuild@0.25.8))':
     dependencies:
       debug: 4.4.1
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.8
-      react-docgen-typescript: 2.2.2(typescript@6.0.0-dev.20250822)
+      react-docgen-typescript: 2.2.2(typescript@6.0.0-dev.20250827)
       tslib: 2.8.1
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
       webpack: 5.88.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - supports-color
@@ -14179,16 +14191,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.14(prettier@2.8.8)
 
-  '@storybook/react-webpack5@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)':
+  '@storybook/react-webpack5@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)
-      '@storybook/preset-react-webpack': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)
-      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)
+      '@storybook/builder-webpack5': 8.6.12(esbuild@0.25.8)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)
+      '@storybook/preset-react-webpack': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(esbuild@0.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)
+      '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.14(prettier@2.8.8)
     optionalDependencies:
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
     transitivePeerDependencies:
       - '@rspack/core'
       - '@storybook/test'
@@ -14213,7 +14225,7 @@ snapshots:
       '@storybook/test': 8.6.12(storybook@8.6.14(prettier@2.8.8))
       typescript: 5.8.3
 
-  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250822)':
+  '@storybook/react@8.6.12(@storybook/test@8.6.12(storybook@8.6.14(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@2.8.8))(typescript@6.0.0-dev.20250827)':
     dependencies:
       '@storybook/components': 8.6.12(storybook@8.6.14(prettier@2.8.8))
       '@storybook/global': 5.0.0
@@ -14226,7 +14238,7 @@ snapshots:
       storybook: 8.6.14(prettier@2.8.8)
     optionalDependencies:
       '@storybook/test': 8.6.12(storybook@8.6.14(prettier@2.8.8))
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
 
   '@storybook/test@8.5.3(storybook@8.6.14(prettier@2.8.8))':
     dependencies:
@@ -14392,12 +14404,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.0.0(typescript@6.0.0-dev.20250822)':
+  '@svgr/core@8.0.0(typescript@6.0.0-dev.20250827)':
     dependencies:
       '@babel/core': 7.24.3
       '@svgr/babel-preset': 8.0.0(@babel/core@7.24.3)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@6.0.0-dev.20250822)
+      cosmiconfig: 8.3.6(typescript@6.0.0-dev.20250827)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -14442,11 +14454,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250822))':
+  '@svgr/plugin-jsx@8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250827))':
     dependencies:
       '@babel/core': 7.24.3
       '@svgr/babel-preset': 8.0.0(@babel/core@7.24.3)
-      '@svgr/core': 8.0.0(typescript@6.0.0-dev.20250822)
+      '@svgr/core': 8.0.0(typescript@6.0.0-dev.20250827)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -14477,10 +14489,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/plugin-svgo@8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250822))(typescript@6.0.0-dev.20250822)':
+  '@svgr/plugin-svgo@8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250827))(typescript@6.0.0-dev.20250827)':
     dependencies:
-      '@svgr/core': 8.0.0(typescript@6.0.0-dev.20250822)
-      cosmiconfig: 8.3.6(typescript@6.0.0-dev.20250822)
+      '@svgr/core': 8.0.0(typescript@6.0.0-dev.20250827)
+      cosmiconfig: 8.3.6(typescript@6.0.0-dev.20250827)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -14511,16 +14523,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/webpack@8.0.1(typescript@6.0.0-dev.20250822)':
+  '@svgr/webpack@8.0.1(typescript@6.0.0-dev.20250827)':
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.24.3)
       '@babel/preset-env': 7.24.3(@babel/core@7.24.3)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.3)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.3)
-      '@svgr/core': 8.0.0(typescript@6.0.0-dev.20250822)
-      '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250822))
-      '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250822))(typescript@6.0.0-dev.20250822)
+      '@svgr/core': 8.0.0(typescript@6.0.0-dev.20250827)
+      '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250827))
+      '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0(typescript@6.0.0-dev.20250827))(typescript@6.0.0-dev.20250827)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15826,14 +15838,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  cosmiconfig@8.3.6(typescript@6.0.0-dev.20250822):
+  cosmiconfig@8.3.6(typescript@6.0.0-dev.20250827):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
 
   create-ecdh@4.0.4:
     dependencies:
@@ -16211,7 +16223,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
 
   dunder-proto@1.0.1:
     dependencies:
@@ -16833,7 +16845,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@6.0.0-dev.20250822)(webpack@5.88.0(esbuild@0.25.8)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@6.0.0-dev.20250827)(webpack@5.88.0(esbuild@0.25.8)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -16847,7 +16859,7 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.7.2
       tapable: 2.2.2
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
       webpack: 5.88.0(esbuild@0.25.8)
 
   form-data@2.5.5:
@@ -17564,16 +17576,16 @@ snapshots:
       - ts-node
     optional: true
 
-  jest-cli@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)):
+  jest-cli@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.2.0
-      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+      jest-config: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       prompts: 2.4.2
@@ -17616,7 +17628,7 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-config@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)):
+  jest-config@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
@@ -17642,7 +17654,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)
+      ts-node: 10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17679,7 +17691,7 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-config@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)):
+  jest-config@29.7.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
@@ -17705,7 +17717,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)
+      ts-node: 10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17973,12 +17985,12 @@ snapshots:
       - ts-node
     optional: true
 
-  jest@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822)):
+  jest@29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827)):
     dependencies:
-      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+      '@jest/core': 29.6.2(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822))
+      jest-cli: 29.6.2(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19259,9 +19271,9 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  react-docgen-typescript@2.2.2(typescript@6.0.0-dev.20250822):
+  react-docgen-typescript@2.2.2(typescript@6.0.0-dev.20250827):
     dependencies:
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
 
   react-docgen@7.1.1:
     dependencies:
@@ -20195,7 +20207,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250822):
+  ts-node@10.9.2(@types/node@20.19.9)(typescript@6.0.0-dev.20250827):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -20209,7 +20221,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 6.0.0-dev.20250822
+      typescript: 6.0.0-dev.20250827
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -20321,7 +20333,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@6.0.0-dev.20250822: {}
+  typescript@6.0.0-dev.20250827: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
## ✍️ Proposed changes

This PR introduces a new `SideNav` component scaffold in the `chat/` directory. The component includes all the necessary boilerplate files and structure to get started with development, including TypeScript types, styles, tests, Storybook stories, and testing utilities.

The scaffold provides:
- Basic component structure with TypeScript support
- Storybook integration for component documentation
- Test setup with React Testing Library
- Testing utilities with LG ID support
- Proper package configuration and dependencies

This is the foundational work for implementing the SideNav component functionality.

🎟️ _Jira ticket:_ N/A

## ✅ Checklist

- [x] I have added my new package to the global tsconfig
- [x] I have added my new package to the Table of Contents on the global README
- [x] I have verified the Live Example will look as intended on the design website.

## 🧪 How to test changes

1. **Verify component scaffold:**
   - Navigate to the `chat/side-nav` directory
   - Run `pnpm build` to ensure the component builds successfully
   - Check that all TypeScript types compile without errors

2. **Test Storybook integration:**
   - Start Storybook and navigate to "Components/SideNav"
   - Verify the Basic story renders the placeholder content
   - Confirm no console errors appear

3. **Validate package structure:**
   - Check that the package.json exports are correctly configured
   - Verify the testing utilities are properly structured
   - Ensure all necessary dependencies are included

4. **Run tests:**
   - Execute the test suite for the side-nav component
   - Confirm placeholder tests pass without issues