### PR TITLE
[LG-5489] fix(chart-card): fix header layout

### DIFF
--- a/.changeset/chart-card-import-layout-fixes.md
+++ b/.changeset/chart-card-import-layout-fixes.md
@@ -1,0 +1,5 @@
+---
+'@lg-charts/chart-card': patch
+---
+
+Adjusts grid layout for proper header positioning where the `title` takes up just the space it needs, and `headerContent` takes up the remainder of the header space.

--- a/charts/chart-card/src/ChartCard.stories.tsx
+++ b/charts/chart-card/src/ChartCard.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { ChartHeaderProps } from '@lg-charts/core';
 import { storybookArgTypes } from '@lg-tools/storybook-utils';
 import type { StoryObj } from '@storybook/react';
 
-import { HeaderProps } from '../Header/Header.types';
 import { ChartCard } from '..';
 
 export default {
@@ -64,7 +64,7 @@ export default {
 };
 
 interface ChartCardProps {
-  chartCardTitle: HeaderProps['title'];
+  chartCardTitle: ChartHeaderProps['title'];
   children: React.ReactNode;
   headerContent: React.ReactNode;
 }

--- a/charts/chart-card/src/ChartCard/ChartCard.styles.ts
+++ b/charts/chart-card/src/ChartCard/ChartCard.styles.ts
@@ -93,7 +93,7 @@ export const getHeaderStyles = ({
       height: 100%;
       padding: ${spacing[150]}px ${spacing[300]}px;
       display: grid;
-      grid-template-columns: 1fr auto;
+      grid-template-columns: auto 1fr;
       background: 'none';
     `,
     {


### PR DESCRIPTION
## ✍️ Proposed changes

This PR fixes import references and header layout issues in the ChartCard component. The changes update the component to use the correct `ChartHeaderProps` type from the core charts package instead of a local `HeaderProps` type, and adjusts the grid layout to properly position header elements.

[LG-5489](https://jira.mongodb.org/browse/LG-5489)

## ✅ Checklist

- [ ] I have added stories/tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

1. Navigate to the ChartCard Storybook stories
2. Verify that the component renders without TypeScript errors
3. Check that the header layout displays correctly with the title positioned on the left and additional content on the right
4. Confirm that all existing functionality remains intact