### PR TITLE
[LG-5516] chore/bug(CodeEditor): Fixed darkmode in storybook and shortcuts table styling

### DIFF
--- a/packages/code-editor/src/CodeEditor.stories.tsx
+++ b/packages/code-editor/src/CodeEditor.stories.tsx
@@ -22,6 +22,7 @@ import * as StandaloneModule from 'prettier/standalone';
 import { css } from '@leafygreen-ui/emotion';
 // @ts-ignore LG icons don't currently support TS
 import CloudIcon from '@leafygreen-ui/icon/dist/Cloud';
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import Modal from '@leafygreen-ui/modal';
 
 import { CopyButtonAppearance } from './CodeEditor/CodeEditor.types';
@@ -89,16 +90,17 @@ const meta: StoryMetaType<typeof CodeEditor> = {
     },
   },
   decorators: [
-    StoryFn => (
-      <div
-        className={css`
-          width: 100vw;
-          height: 100vh;
-          padding: 0;
-        `}
-      >
-        <StoryFn />
-      </div>
+    (Story: StoryFn, context) => (
+      <LeafyGreenProvider darkMode={context?.args.darkMode}>
+        <div
+          className={css`
+            width: 100vw;
+            padding: 0;
+          `}
+        >
+          <Story />
+        </div>
+      </LeafyGreenProvider>
     ),
   ],
   args: {

--- a/packages/code-editor/src/ShortcutTable/ShortcutTable.styles.ts
+++ b/packages/code-editor/src/ShortcutTable/ShortcutTable.styles.ts
@@ -3,12 +3,14 @@ import { spacing } from '@leafygreen-ui/tokens';
 
 const TABLE_WIDTH = '282px';
 const ROW_PADDING = spacing[300];
+const CONTAINER_MARGIN_TOP = spacing[1000] - ROW_PADDING; // Account for the padding on the first row
 
 export const TableContainerStyles = css`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  margin-top: ${CONTAINER_MARGIN_TOP}px;
 `;
 
 export const TableStyles = css`
@@ -20,7 +22,6 @@ export const TableStyles = css`
   }
 
   td {
-    display: inline-block;
     vertical-align: top;
 
     &:first-child {
@@ -32,11 +33,6 @@ export const TableStyles = css`
       text-align: right;
     }
   }
-`;
-
-export const HeadingStyles = css`
-  margin-bottom: ${spacing[1000] -
-  ROW_PADDING}px; // Account for the padding on the first row
 `;
 
 export const PlusSignStyles = css`

--- a/packages/code-editor/src/ShortcutTable/ShortcutTable.tsx
+++ b/packages/code-editor/src/ShortcutTable/ShortcutTable.tsx
@@ -4,16 +4,21 @@ import Badge from '@leafygreen-ui/badge';
 import { Disclaimer, H3 } from '@leafygreen-ui/typography';
 
 import {
-  HeadingStyles,
   PlusSignStyles,
   TableContainerStyles,
   TableStyles,
 } from './ShortcutTable.styles';
 
+const PlusSign = () => (
+  <div className={PlusSignStyles}>
+    <Disclaimer>+</Disclaimer>
+  </div>
+);
+
 export function ShortcutTable({ className }: { className?: string }) {
   return (
     <div className={className}>
-      <H3 className={HeadingStyles}>Code Editor Shortcuts</H3>
+      <H3>Code Editor Shortcuts</H3>
       <div className={TableContainerStyles}>
         <table className={TableStyles}>
           <tbody>
@@ -36,7 +41,7 @@ export function ShortcutTable({ className }: { className?: string }) {
             <tr>
               <td>
                 <Badge variant="lightgray">⌘/CTRL</Badge>
-                <Disclaimer className={PlusSignStyles}>+</Disclaimer>
+                <PlusSign />
                 <Badge variant="lightgray">F</Badge>
               </td>
               <td>
@@ -46,7 +51,7 @@ export function ShortcutTable({ className }: { className?: string }) {
             <tr>
               <td>
                 <Badge variant="lightgray">⌘/CTRL</Badge>
-                <Disclaimer className={PlusSignStyles}>+</Disclaimer>
+                <PlusSign />
                 <Badge variant="lightgray">Z</Badge>
               </td>
               <td>
@@ -56,9 +61,9 @@ export function ShortcutTable({ className }: { className?: string }) {
             <tr>
               <td>
                 <Badge variant="lightgray">⌘/CTRL</Badge>
-                <Disclaimer className={PlusSignStyles}>+</Disclaimer>
+                <PlusSign />
                 <Badge variant="lightgray">SHIFT</Badge>
-                <Disclaimer className={PlusSignStyles}>+</Disclaimer>
+                <PlusSign />
                 <Badge variant="lightgray">Z</Badge>
               </td>
               <td>


### PR DESCRIPTION
## ✍️ Proposed changes
- Adds `LeafyGreenProvider` to storybook so dark mode works as expected
- Fixes display of disclaimer plus signs in the shortcuts table

🎟 _Jira ticket:_ [LG-5516](https://jira.mongodb.org/browse/LG-5516)

## 🧪 How to test changes
- View storybook

## Screenshots
### Before
<img width="1120" height="464" alt="Screenshot 2025-09-15 at 2 30 41 PM" src="https://github.com/user-attachments/assets/6f4c7330-f32b-447e-9e20-75feb258d2a8" />
<img width="703" height="422" alt="Screenshot 2025-09-15 at 2 31 01 PM" src="https://github.com/user-attachments/assets/4e24fe86-5a71-4bd8-a754-8dddbb38916c" />

### After
<img width="1137" height="280" alt="Screenshot 2025-09-15 at 2 30 51 PM" src="https://github.com/user-attachments/assets/d15eee91-bfdc-4a67-a94e-31cd0f6a8f31" />
<img width="671" height="397" alt="Screenshot 2025-09-15 at 2 31 12 PM" src="https://github.com/user-attachments/assets/0757e0ff-bc63-4cf1-b94a-a45f512bc772" />

