### PR TITLE
chore: The case of the missing changelogs

### DIFF
--- a/charts/chart-card/CHANGELOG.md
+++ b/charts/chart-card/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @lg-charts/chart-card
 
+## 1.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 1.0.4
 
 ### Patch Changes

--- a/charts/colors/CHANGELOG.md
+++ b/charts/colors/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @lg-charts/colors
 
+## 1.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+
 ## 1.0.3
 
 ### Patch Changes

--- a/charts/core/CHANGELOG.md
+++ b/charts/core/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @lg-charts/core
 
+## 2.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-charts/chart-card@1.0.5
+  - @lg-charts/colors@1.0.4
+  - @lg-charts/series-provider@1.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 2.0.2
 
 ### Patch Changes

--- a/charts/drag-provider/CHANGELOG.md
+++ b/charts/drag-provider/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @lg-charts/drag-provider
 
+## 1.0.8
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+  - @lg-charts/chart-card@1.0.5
+  - @lg-charts/core@2.0.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+
 ## 1.0.7
 
 ### Patch Changes

--- a/charts/legend/CHANGELOG.md
+++ b/charts/legend/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @lg-charts/legend
 
+## 1.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @lg-charts/series-provider@1.0.4
+  - @leafygreen-ui/checkbox@18.0.3
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 1.0.4
 
 ### Patch Changes

--- a/charts/series-provider/CHANGELOG.md
+++ b/charts/series-provider/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @lg-charts/series-provider
 
+## 1.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @lg-charts/colors@1.0.4
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+
 ## 1.0.3
 
 ### Patch Changes

--- a/chat/avatar/CHANGELOG.md
+++ b/chat/avatar/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @lg-chat/avatar
 
+## 7.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @leafygreen-ui/avatar@3.1.2
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 7.0.1
 
 ### Patch Changes

--- a/chat/chat-disclaimer/CHANGELOG.md
+++ b/chat/chat-disclaimer/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @lg-chat/chat-disclaimer
 
+## 5.0.0
+
+### Major Changes
+
+- a3dee88: Remove deprecated and unused `DisclaimerModal`
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/marketing-modal@8.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.8
 
 ### Patch Changes

--- a/chat/chat-window/CHANGELOG.md
+++ b/chat/chat-window/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @lg-chat/chat-window
 
+## 4.1.4
+
+### Patch Changes
+
+- b92bc72: [LG-5486](https://jira.mongodb.org/browse/LG-5486) add styles to `ChatWindow` to support wide screen UIs
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @lg-chat/title-bar@4.0.7
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 4.1.3
 
 ### Patch Changes

--- a/chat/fixed-chat-window/CHANGELOG.md
+++ b/chat/fixed-chat-window/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @lg-chat/fixed-chat-window
 
+## 4.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [b92bc72]
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @lg-chat/chat-window@4.1.4
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @lg-chat/title-bar@4.0.7
+  - @leafygreen-ui/avatar@3.1.2
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.5
 
 ### Patch Changes

--- a/chat/input-bar/CHANGELOG.md
+++ b/chat/input-bar/CHANGELOG.md
@@ -1,5 +1,34 @@
 # @lg-chat/input-bar
 
+## 10.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/banner@10.1.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @leafygreen-ui/avatar@3.1.2
+  - @leafygreen-ui/badge@10.1.2
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/input-option@4.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/search-input@6.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 10.0.3
 
 ### Patch Changes

--- a/chat/leafygreen-chat-provider/CHANGELOG.md
+++ b/chat/leafygreen-chat-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lg-chat/leafygreen-chat-provider
 
+## 5.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 5.0.1
 
 ### Patch Changes

--- a/chat/lg-markdown/CHANGELOG.md
+++ b/chat/lg-markdown/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @lg-chat/lg-markdown
 
+## 4.1.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/code@20.0.7
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.1.2
 
 ### Patch Changes

--- a/chat/message-actions/CHANGELOG.md
+++ b/chat/message-actions/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @lg-chat/message-actions
 
+## 1.1.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- a9eb172: Deprecate `MessageActions` and `MessageActionsProps`. Use `Message.Actions` from @lg-chat/message instead.
+- Updated dependencies [a9eb172]
+- Updated dependencies [a9eb172]
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @lg-chat/message@8.1.0
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @lg-chat/message-feedback@7.0.2
+  - @lg-chat/message-rating@5.0.2
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 1.1.1
 
 ### Patch Changes

--- a/chat/message-feed/CHANGELOG.md
+++ b/chat/message-feed/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @lg-chat/message-feed
 
+## 7.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [a9eb172]
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @lg-chat/message@8.1.0
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-chat/avatar@7.0.2
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @lg-chat/message-rating@5.0.2
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 7.0.1
 
 ### Patch Changes

--- a/chat/message-feedback/CHANGELOG.md
+++ b/chat/message-feedback/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @lg-chat/message-feedback
 
+## 7.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/text-area@12.0.3
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 7.0.1
 
 ### Patch Changes

--- a/chat/message-prompts/CHANGELOG.md
+++ b/chat/message-prompts/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @lg-chat/message-prompts
 
+## 4.0.5
+
+### Patch Changes
+
+- b92bc72: [LG-5485](https://jira.mongodb.org/browse/LG-5485) add max-width of 400px to `MessagePrompts`
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.4
 
 ### Patch Changes

--- a/chat/message-rating/CHANGELOG.md
+++ b/chat/message-rating/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @lg-chat/message-rating
 
+## 5.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 5.0.1
 
 ### Patch Changes

--- a/chat/message/CHANGELOG.md
+++ b/chat/message/CHANGELOG.md
@@ -1,5 +1,44 @@
 # @lg-chat/message
 
+## 8.1.0
+
+### Minor Changes
+
+- a9eb172: [LG-5437](https://jira.mongodb.org/browse/LG-5437): add expand/collapse functionality for `MessageLinks` and update to latest `@lg-chat/rich-links`
+- a9eb172: [LG-5437](https://jira.mongodb.org/browse/LG-5437): Enhanced Message component with compound components pattern. [Learn more about compound components here](https://github.com/mongodb/leafygreen-ui/blob/main/chat/message/README.md#compound-components)
+
+  - Migrated `MessageActions` from `@lg-chat/message-actions` into this package, now available as `Message.Actions`.
+  - Marked `MessageLinks` export as deprecated. Use `Message.Links` instead.
+  - Updated `Message.VerifiedBanner` to accept additional HTML props.
+
+### Patch Changes
+
+- a9eb172: [LG-5437](https://jira.mongodb.org/browse/LG-5437): update styles of verified answer banner
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [a9eb172]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/banner@10.1.0
+  - @lg-chat/rich-links@4.0.0
+  - @lg-chat/leafygreen-chat-provider@5.0.2
+  - @lg-chat/lg-markdown@4.1.3
+  - @lg-chat/message-feedback@7.0.2
+  - @lg-chat/message-rating@5.0.2
+  - @leafygreen-ui/avatar@3.1.2
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 8.0.1
 
 ### Patch Changes

--- a/chat/rich-links/CHANGELOG.md
+++ b/chat/rich-links/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @lg-chat/rich-links
 
+## 4.0.0
+
+### Major Changes
+
+- a9eb172: [LG-5437](https://jira.mongodb.org/browse/LG-5437)
+
+  #### Breaking Changes
+
+  - Removed `imageUrl` prop from `RichLink` component
+  - Updated `RichLink` to more compact styling
+
+  #### Non-breaking Changes
+
+  - Added `forwardRef` support to `RichLinksArea`
+  - Enhanced accessibility with `title` attribute on RichLink cards
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/card@13.0.5
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 3.1.2
 
 ### Patch Changes

--- a/chat/suggestions/CHANGELOG.md
+++ b/chat/suggestions/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @lg-chat/suggestions
 
+## 0.2.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/banner@10.1.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 0.2.2
 
 ### Patch Changes

--- a/chat/title-bar/CHANGELOG.md
+++ b/chat/title-bar/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @lg-chat/title-bar
 
+## 4.0.7
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @lg-chat/avatar@7.0.2
+  - @leafygreen-ui/badge@10.1.2
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.6
 
 ### Patch Changes

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @leafygreen-ui/a11y
 
+## 3.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+
 ## 3.0.3
 
 ### Patch Changes

--- a/packages/avatar/CHANGELOG.md
+++ b/packages/avatar/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/avatar
 
+## 3.1.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/logo@11.0.3
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 3.1.1
 
 ### Patch Changes

--- a/packages/badge/CHANGELOG.md
+++ b/packages/badge/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @leafygreen-ui/badge
 
+## 10.1.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 10.1.1
 
 ### Patch Changes

--- a/packages/banner/CHANGELOG.md
+++ b/packages/banner/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @leafygreen-ui/banner
 
+## 10.1.0
+
+### Minor Changes
+
+- a9eb172: Add and export `bannerChildrenContainerClassName` for customizing styles of `Banner` children container
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 10.0.5
 
 ### Patch Changes

--- a/packages/box/CHANGELOG.md
+++ b/packages/box/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @leafygreen-ui/box
 
+## 5.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 5.0.1
 
 ### Patch Changes

--- a/packages/button/CHANGELOG.md
+++ b/packages/button/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/button
 
+## 25.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/ripple@2.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 25.0.3
 
 ### Patch Changes

--- a/packages/callout/CHANGELOG.md
+++ b/packages/callout/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/callout
 
+## 12.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 12.0.4
 
 ### Patch Changes

--- a/packages/card/CHANGELOG.md
+++ b/packages/card/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/card
 
+## 13.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 13.0.4
 
 ### Patch Changes

--- a/packages/checkbox/CHANGELOG.md
+++ b/packages/checkbox/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/checkbox
 
+## 18.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 18.0.2
 
 ### Patch Changes

--- a/packages/chip/CHANGELOG.md
+++ b/packages/chip/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/chip
 
+## 4.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/inline-definition@9.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 4.0.4
 
 ### Patch Changes

--- a/packages/code/CHANGELOG.md
+++ b/packages/code/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @leafygreen-ui/code
 
+## 20.0.7
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/select@16.1.2
+  - @leafygreen-ui/skeleton-loader@3.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 20.0.6
 
 ### Patch Changes

--- a/packages/combobox/CHANGELOG.md
+++ b/packages/combobox/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @leafygreen-ui/combobox
 
+## 12.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/checkbox@18.0.3
+  - @leafygreen-ui/chip@4.0.5
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/input-option@4.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 12.0.5
 
 ### Patch Changes

--- a/packages/confirmation-modal/CHANGELOG.md
+++ b/packages/confirmation-modal/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @leafygreen-ui/confirmation-modal
 
+## 10.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/modal@20.0.2
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/text-input@16.0.3
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 10.0.1
 
 ### Patch Changes

--- a/packages/context-drawer/CHANGELOG.md
+++ b/packages/context-drawer/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @leafygreen-ui/context-drawer
 
+## 0.2.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/copyable/CHANGELOG.md
+++ b/packages/copyable/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @leafygreen-ui/copyable
 
+## 11.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+  - @leafygreen-ui/typography@22.1.2
+
 ## 11.0.5
 
 ### Patch Changes

--- a/packages/date-picker/CHANGELOG.md
+++ b/packages/date-picker/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @leafygreen-ui/date-picker
 
+## 4.0.7
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/date-utils@0.3.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/select@16.1.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.6
 
 ### Patch Changes

--- a/packages/date-utils/CHANGELOG.md
+++ b/packages/date-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @leafygreen-ui/date-utils
 
+## 0.3.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/descendants/CHANGELOG.md
+++ b/packages/descendants/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @leafygreen-ui/descendants
 
+## 3.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+
 ## 3.0.3
 
 ### Patch Changes

--- a/packages/drawer/CHANGELOG.md
+++ b/packages/drawer/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @leafygreen-ui/drawer
 
+## 5.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/resizable@0.1.2
+  - @leafygreen-ui/tabs@17.0.3
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/toolbar@1.0.5
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 5.0.2
 
 ### Patch Changes

--- a/packages/emotion/CHANGELOG.md
+++ b/packages/emotion/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @leafygreen-ui/emotion
 
+## 5.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 5.0.1
 
 ### Patch Changes

--- a/packages/empty-state/CHANGELOG.md
+++ b/packages/empty-state/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/empty-state
 
+## 3.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/badge@10.1.2
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 3.0.5
 
 ### Patch Changes

--- a/packages/expandable-card/CHANGELOG.md
+++ b/packages/expandable-card/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @leafygreen-ui/expandable-card
 
+## 5.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/card@13.0.5
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 5.0.4
 
 ### Patch Changes

--- a/packages/form-field/CHANGELOG.md
+++ b/packages/form-field/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/form-field
 
+## 4.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.2
 
 ### Patch Changes

--- a/packages/form-footer/CHANGELOG.md
+++ b/packages/form-footer/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @leafygreen-ui/form-footer
 
+## 9.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/banner@10.1.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/split-button@6.1.4
+
 ## 9.0.2
 
 ### Patch Changes

--- a/packages/gallery-indicator/CHANGELOG.md
+++ b/packages/gallery-indicator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/gallery-indicator
 
+## 3.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 3.0.2
 
 ### Patch Changes

--- a/packages/guide-cue/CHANGELOG.md
+++ b/packages/guide-cue/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @leafygreen-ui/guide-cue
 
+## 8.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tooltip@14.1.3
+  - @leafygreen-ui/typography@22.1.2
+
 ## 8.0.5
 
 ### Patch Changes

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @leafygreen-ui/hooks
 
+## 9.1.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 9.1.2
 
 ### Patch Changes

--- a/packages/icon-button/CHANGELOG.md
+++ b/packages/icon-button/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/icon-button
 
+## 17.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 17.0.4
 
 ### Patch Changes

--- a/packages/icon/CHANGELOG.md
+++ b/packages/icon/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @leafygreen-ui/icon
 
+## 14.5.0
+
+### Minor Changes
+
+- 5ef631a: ### New Features
+
+  - Adds "exports" field to package json
+  - Adds direct icon import pattern (e.g. `import CloudIcon from "@leafygreen-ui/icon/Cloud"`)
+  - Ensures backwards compatibility using "dist/\*" imports
+
+  ### Tooling
+
+  - Isolates build script from component TS project
+  - Updates individual icon build script to use the Rollup API directly
+  - Removes `postbuild` script. It's now redundant with the `"./dist/*"` exports field
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/emotion@5.0.2
+
 ## 14.4.1
 
 ### Patch Changes

--- a/packages/info-sprinkle/CHANGELOG.md
+++ b/packages/info-sprinkle/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/info-sprinkle
 
+## 5.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+
 ## 5.0.4
 
 ### Patch Changes

--- a/packages/inline-definition/CHANGELOG.md
+++ b/packages/inline-definition/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/inline-definition
 
+## 9.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+
 ## 9.0.4
 
 ### Patch Changes

--- a/packages/input-option/CHANGELOG.md
+++ b/packages/input-option/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/input-option
 
+## 4.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.4
 
 ### Patch Changes

--- a/packages/leafygreen-provider/CHANGELOG.md
+++ b/packages/leafygreen-provider/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @leafygreen-ui/leafygreen-provider
 
+## 5.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/hooks@9.1.3
+
 ## 5.0.3
 
 ### Patch Changes

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @leafygreen-ui/lib
 
+## 15.3.0
+
+### Minor Changes
+
+- a9eb172: Add `findChild` and `filterChildren` utils for compound component patterns.
+  - `findChild` finds a child component by a static property with support for styled components and fragments.
+  - `filterChildren` filters children by one or more static properties with support for styled components and fragments.
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 15.2.1
 
 ### Patch Changes

--- a/packages/loading-indicator/CHANGELOG.md
+++ b/packages/loading-indicator/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/loading-indicator
 
+## 4.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.4
 
 ### Patch Changes

--- a/packages/logo/CHANGELOG.md
+++ b/packages/logo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @leafygreen-ui/logo
 
+## 11.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/palette@5.0.2
+
 ## 11.0.2
 
 ### Patch Changes

--- a/packages/marketing-modal/CHANGELOG.md
+++ b/packages/marketing-modal/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/marketing-modal
 
+## 8.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/modal@20.0.2
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 8.0.1
 
 ### Patch Changes

--- a/packages/menu/CHANGELOG.md
+++ b/packages/menu/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @leafygreen-ui/menu
 
+## 32.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/descendants@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/input-option@4.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 32.0.1
 
 ### Patch Changes

--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @leafygreen-ui/modal
 
+## 20.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 20.0.1
 
 ### Patch Changes

--- a/packages/number-input/CHANGELOG.md
+++ b/packages/number-input/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @leafygreen-ui/number-input
 
+## 5.0.7
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/select@16.1.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+  - @leafygreen-ui/typography@22.1.2
+
 ## 5.0.6
 
 ### Patch Changes

--- a/packages/ordered-list/CHANGELOG.md
+++ b/packages/ordered-list/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/ordered-list
 
+## 3.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/descendants@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 3.0.4
 
 ### Patch Changes

--- a/packages/pagination/CHANGELOG.md
+++ b/packages/pagination/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @leafygreen-ui/pagination
 
+## 4.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/select@16.1.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 4.0.5
 
 ### Patch Changes

--- a/packages/palette/CHANGELOG.md
+++ b/packages/palette/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @leafygreen-ui/palette
 
+## 5.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 5.0.1
 
 ### Patch Changes

--- a/packages/password-input/CHANGELOG.md
+++ b/packages/password-input/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @leafygreen-ui/password-input
 
+## 5.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 5.0.2
 
 ### Patch Changes

--- a/packages/pipeline/CHANGELOG.md
+++ b/packages/pipeline/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/pipeline
 
+## 8.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+
 ## 8.0.3
 
 ### Patch Changes

--- a/packages/polymorphic/CHANGELOG.md
+++ b/packages/polymorphic/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @leafygreen-ui/polymorphic
 
+## 3.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+
 ## 3.0.3
 
 ### Patch Changes

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/popover
 
+## 14.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/portal@7.0.4
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 14.0.4
 
 ### Patch Changes

--- a/packages/portal/CHANGELOG.md
+++ b/packages/portal/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @leafygreen-ui/portal
 
+## 7.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/hooks@9.1.3
+
 ## 7.0.3
 
 ### Patch Changes

--- a/packages/preview-card/CHANGELOG.md
+++ b/packages/preview-card/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/preview-card
 
+## 0.2.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/progress-bar/CHANGELOG.md
+++ b/packages/progress-bar/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @leafygreen-ui/progress-bar
 
+## 1.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/radio-box-group/CHANGELOG.md
+++ b/packages/radio-box-group/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @leafygreen-ui/radio-box-group
 
+## 15.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 15.0.5
 
 ### Patch Changes

--- a/packages/radio-group/CHANGELOG.md
+++ b/packages/radio-group/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @leafygreen-ui/radio-group
 
+## 13.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 13.0.5
 
 ### Patch Changes

--- a/packages/resizable/CHANGELOG.md
+++ b/packages/resizable/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @leafygreen-ui/resizable
 
+## 0.1.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/palette@5.0.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/ripple/CHANGELOG.md
+++ b/packages/ripple/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @leafygreen-ui/ripple
 
+## 2.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/search-input/CHANGELOG.md
+++ b/packages/search-input/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @leafygreen-ui/search-input
 
+## 6.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/input-option@4.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 6.0.4
 
 ### Patch Changes

--- a/packages/section-nav/CHANGELOG.md
+++ b/packages/section-nav/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @leafygreen-ui/section-nav
 
+## 1.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/segmented-control/CHANGELOG.md
+++ b/packages/segmented-control/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @leafygreen-ui/segmented-control
 
+## 11.0.7
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 11.0.6
 
 ### Patch Changes

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @leafygreen-ui/select
 
+## 16.1.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/input-option@4.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 16.1.1
 
 ### Patch Changes

--- a/packages/side-nav/CHANGELOG.md
+++ b/packages/side-nav/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @leafygreen-ui/side-nav
 
+## 17.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/portal@7.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+  - @leafygreen-ui/typography@22.1.2
+
 ## 17.0.5
 
 ### Patch Changes

--- a/packages/skeleton-loader/CHANGELOG.md
+++ b/packages/skeleton-loader/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/skeleton-loader
 
+## 3.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/card@13.0.5
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 3.0.4
 
 ### Patch Changes

--- a/packages/split-button/CHANGELOG.md
+++ b/packages/split-button/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @leafygreen-ui/split-button
 
+## 6.1.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/button@25.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/menu@32.0.2
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 6.1.3
 
 ### Patch Changes

--- a/packages/stepper/CHANGELOG.md
+++ b/packages/stepper/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/stepper
 
+## 6.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+  - @leafygreen-ui/typography@22.1.2
+
 ## 6.0.4
 
 ### Patch Changes

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @leafygreen-ui/table
 
+## 15.1.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/checkbox@18.0.3
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 15.1.2
 
 ### Patch Changes

--- a/packages/tabs/CHANGELOG.md
+++ b/packages/tabs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @leafygreen-ui/tabs
 
+## 17.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/descendants@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 17.0.2
 
 ### Patch Changes

--- a/packages/testing-lib/CHANGELOG.md
+++ b/packages/testing-lib/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @leafygreen-ui/testing-lib
 
+## 0.8.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/text-area/CHANGELOG.md
+++ b/packages/text-area/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @leafygreen-ui/text-area
 
+## 12.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 12.0.2
 
 ### Patch Changes

--- a/packages/text-input/CHANGELOG.md
+++ b/packages/text-input/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/text-input
 
+## 16.0.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/form-field@4.0.3
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 16.0.2
 
 ### Patch Changes

--- a/packages/toast/CHANGELOG.md
+++ b/packages/toast/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @leafygreen-ui/toast
 
+## 8.0.6
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/portal@7.0.4
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 8.0.5
 
 ### Patch Changes

--- a/packages/toggle/CHANGELOG.md
+++ b/packages/toggle/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @leafygreen-ui/toggle
 
+## 12.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/a11y@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 12.0.4
 
 ### Patch Changes

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @leafygreen-ui/tokens
 
+## 3.2.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/palette@5.0.2
+
 ## 3.2.3
 
 ### Patch Changes

--- a/packages/toolbar/CHANGELOG.md
+++ b/packages/toolbar/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @leafygreen-ui/toolbar
 
+## 1.0.5
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/descendants@3.0.4
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/icon-button@17.0.5
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/tooltip@14.1.3
+  - @lg-tools/test-harnesses@0.3.4
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @leafygreen-ui/tooltip
 
+## 14.1.3
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/hooks@9.1.3
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/popover@14.0.5
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+
 ## 14.1.2
 
 ### Patch Changes

--- a/packages/typography/CHANGELOG.md
+++ b/packages/typography/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @leafygreen-ui/typography
 
+## 22.1.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [a9eb172]
+- Updated dependencies [5ef631a]
+- Updated dependencies [dc3299b]
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/icon@14.5.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/polymorphic@3.0.4
+  - @leafygreen-ui/tokens@3.2.4
+
 ## 22.1.1
 
 ### Patch Changes

--- a/tools/build/CHANGELOG.md
+++ b/tools/build/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lg-tools/build
 
+## 0.8.2
+
+### Patch Changes
+
+- dc3299b: Enables TS downleveling to 4.9.
+  Adds `lg-ts-downlevel` bin script
+
 ## 0.8.1
 
 ### Patch Changes

--- a/tools/codemods/CHANGELOG.md
+++ b/tools/codemods/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @lg-tools/codemods
 
+## 0.4.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/tools/lint/CHANGELOG.md
+++ b/tools/lint/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @lg-tools/lint
 
+## 3.0.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+  - @lg-tools/meta@0.6.2
+
 ## 3.0.1
 
 ### Patch Changes

--- a/tools/meta/CHANGELOG.md
+++ b/tools/meta/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @lg-tools/meta
 
+## 0.6.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+
 ## 0.6.1
 
 ### Patch Changes

--- a/tools/storybook-addon/CHANGELOG.md
+++ b/tools/storybook-addon/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @lg-tools/storybook-addon
 
+## 0.6.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+  - @leafygreen-ui/lib@15.3.0
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @leafygreen-ui/typography@22.1.2
+  - @lg-tools/meta@0.6.2
+  - @lg-tools/storybook-decorators@1.0.4
+  - @lg-tools/storybook-utils@0.3.2
+
 ## 0.6.1
 
 ### Patch Changes

--- a/tools/storybook-decorators/CHANGELOG.md
+++ b/tools/storybook-decorators/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @lg-tools/storybook-decorators
 
+## 1.0.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+- Updated dependencies [dc3299b]
+- Updated dependencies [a9eb172]
+- Updated dependencies [dc3299b]
+  - @lg-tools/build@0.8.2
+  - @leafygreen-ui/banner@10.1.0
+  - @leafygreen-ui/emotion@5.0.2
+  - @leafygreen-ui/leafygreen-provider@5.0.4
+  - @leafygreen-ui/palette@5.0.2
+  - @leafygreen-ui/tokens@3.2.4
+  - @lg-tools/storybook-utils@0.3.2
+
 ## 1.0.3
 
 ### Patch Changes

--- a/tools/storybook-utils/CHANGELOG.md
+++ b/tools/storybook-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lg-tools/storybook-utils
 
+## 0.3.2
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 0.3.1
 
 ### Patch Changes

--- a/tools/test-harnesses/CHANGELOG.md
+++ b/tools/test-harnesses/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @lg-tools/test-harnesses
 
+## 0.3.4
+
+### Patch Changes
+
+- dc3299b: Adds "exports" field to all packages
+  Enables TS downleveling to TS 4.9
+
 ## 0.3.3
 
 ### Patch Changes


### PR DESCRIPTION
[This release](https://github.com/mongodb/leafygreen-ui/pull/3108) updated the `package.json` files, and published the packages, but missed updating the changelog files.

## Why?
[This merge into main](https://github.com/mongodb/leafygreen-ui/actions/runs/17601183363/job/50004004337) had a broken `lint` package, which caused the `changeset version` script to fail silently. This has since been fixed in `main`

Related ticket to update CI: https://jira.mongodb.org/browse/LG-5521