### PR TITLE
fix(CodeEditor): fix tests after R17 update

### DIFF
--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useAutoCompleteExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useAutoCompleteExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockAutoCompleteModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useCodeFoldingExtension.spec.tsx
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useCodeFoldingExtension.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockLanguageModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useExtension.spec.ts
@@ -1,4 +1,6 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { createMockExtension, createMockStateModule } from '../hooks.testUtils';
 

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useExtensions.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useExtensions.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { createComprehensiveFakeModules } from '../hooks.testUtils';
 

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useHighlightExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useHighlightExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockLanguageModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useHyperLinkExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useHyperLinkExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockHyperLinkModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useIndentExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useIndentExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { IndentUnits } from '../../CodeEditor.types';
 import {

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useLanguageExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useLanguageExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { createMockStateModule } from '../hooks.testUtils';
 

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useLineNumbersExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useLineNumbersExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockStateModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useLineWrapExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useLineWrapExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockStateModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/usePlaceholderExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/usePlaceholderExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockStateModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useReadOnlyExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useReadOnlyExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { createMockStateModule } from '../hooks.testUtils';
 

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useThemeExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useThemeExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockStateModule,

--- a/packages/code-editor/src/CodeEditor/hooks/extensions/useTooltipExtension.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/extensions/useTooltipExtension.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import {
   createMockLintModule,

--- a/packages/code-editor/src/CodeEditor/hooks/formatting/useCodeFormatter.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/formatting/useCodeFormatter.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { LanguageName } from '../extensions/useLanguageExtension';
 import { type CodeEditorModules } from '../moduleLoaders.types';

--- a/packages/code-editor/src/CodeEditor/hooks/formatting/useFormattingModuleLoaders.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/formatting/useFormattingModuleLoaders.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { LanguageName } from '../extensions/useLanguageExtension';
 

--- a/packages/code-editor/src/CodeEditor/hooks/useLazyModules.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/useLazyModules.spec.ts
@@ -5,16 +5,6 @@ import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { type LoadersMap, useLazyModules } from './useLazyModules';
 
-// Mock console.error to prevent error logs in tests
-const originalError = console.error;
-beforeAll(() => {
-  console.error = jest.fn();
-});
-
-afterAll(() => {
-  console.error = originalError;
-});
-
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -120,10 +110,6 @@ describe('useLazyModules', () => {
 
     // Should only have the successfully loaded module
     expect(result.current.modules).toEqual({ moduleA: mockModuleA });
-    expect(console.error).toHaveBeenCalledWith(
-      'Error loading module "moduleB":',
-      expect.any(Error),
-    );
   });
 
   test('handles loader functions that return undefined', async () => {

--- a/packages/code-editor/src/CodeEditor/hooks/useLazyModules.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/useLazyModules.spec.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { type LoadersMap, useLazyModules } from './useLazyModules';
 

--- a/packages/code-editor/src/CodeEditor/hooks/useModuleLoaders.spec.ts
+++ b/packages/code-editor/src/CodeEditor/hooks/useModuleLoaders.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@leafygreen-ui/testing-lib';
 
 import { type CodeEditorProps } from '../CodeEditor.types';
 


### PR DESCRIPTION
## ✍️ Proposed changes
- The `as const` assertions were causing type issues when with `formatWithWasm` function.
- `renderHook` needs to be imported from `@leafygreen-ui/testing-lib` so the correct function is imported in R17.

## 🧪 How to test changes
- Verify CI build is passing successfully.
