### PR TITLE
Add message promotions to lg-chat

### DIFF
--- a/.changeset/dirty-monkeys-camp.md
+++ b/.changeset/dirty-monkeys-camp.md
@@ -1,0 +1,5 @@
+---
+'@lg-chat/message': minor
+---
+
+Adds section for promotional content to messages

--- a/.changeset/dirty-monkeys-camp.md
+++ b/.changeset/dirty-monkeys-camp.md
@@ -2,4 +2,4 @@
 '@lg-chat/message': minor
 ---
 
-Adds section for promotional content to messages
+Add `Message.Promotion` as `Message` subcomponent for promotional content

--- a/chat/message/README.md
+++ b/chat/message/README.md
@@ -155,31 +155,6 @@ const MessageWithLinks = () => {
 };
 ```
 
-### Message.VerifiedBanner
-
-```tsx
-import React from 'react';
-import {
-  LeafyGreenChatProvider,
-  Variant,
-} from '@lg-chat/leafygreen-chat-provider';
-import { Message } from '@lg-chat/message';
-
-const MessageWithVerifiedBanner = () => {
-  return (
-    <LeafyGreenChatProvider variant={Variant.Compact}>
-      <Message isSender={false} messageBody="Test message">
-        <Message.VerifiedBanner
-          verifier="MongoDB Staff"
-          verifiedAt={new Date('2024-03-24T16:20:00Z')}
-          learnMoreUrl="https://mongodb.com/docs"
-        />
-      </Message>
-    </LeafyGreenChatProvider>
-  );
-};
-```
-
 ### Message.Promotion
 
 ```tsx
@@ -200,6 +175,31 @@ const MessageWithPromotion = () => {
           promotionText="Go learn more about this skill!"
           promotionUrl="https://learn.mongodb.com/skills"
           onPromotionClick={handlePromotionClick}
+        />
+      </Message>
+    </LeafyGreenChatProvider>
+  );
+};
+```
+
+### Message.VerifiedBanner
+
+```tsx
+import React from 'react';
+import {
+  LeafyGreenChatProvider,
+  Variant,
+} from '@lg-chat/leafygreen-chat-provider';
+import { Message } from '@lg-chat/message';
+
+const MessageWithVerifiedBanner = () => {
+  return (
+    <LeafyGreenChatProvider variant={Variant.Compact}>
+      <Message isSender={false} messageBody="Test message">
+        <Message.VerifiedBanner
+          verifier="MongoDB Staff"
+          verifiedAt={new Date('2024-03-24T16:20:00Z')}
+          learnMoreUrl="https://mongodb.com/docs"
         />
       </Message>
     </LeafyGreenChatProvider>
@@ -250,20 +250,21 @@ const Example = () => {
   ];
 
   const handleLinkClick = () => console.log('Link clicked');
+  const handlePromotionClick = () => console.log('Promotion clicked');
 
   return (
     <LeafyGreenChatProvider variant={Variant.Compact}>
       <Message isSender={false} messageBody="Test message">
+        <Message.Promotion
+          promotionText="Go learn more about this skill!"
+          promotionUrl="https://learn.mongodb.com/skills"
+          onPromotionClick={handlePromotionClick}
+        />
         <Message.Actions
           onClickCopy={handleCopy}
           onClickRetry={handleRetry}
           onRatingChange={handleRatingChange}
           onSubmitFeedback={handleSubmitFeedback}
-        />
-        <Message.Promotion
-          promotionText="Go learn more about this skill!"
-          promotionUrl="https://learn.mongodb.com/skills"
-          onPromotionClick={() => console.log('Promotion clicked')}
         />
         <Message.VerifiedBanner
           verifier="MongoDB Staff"

--- a/chat/message/README.md
+++ b/chat/message/README.md
@@ -414,7 +414,6 @@ The `MessagePromotion` component displays promotional content with an award icon
 #### Rendering Behavior
 
 - If `promotionText` is empty or undefined, the component returns `null` and does not render anything
-- The component supports markdown content by default
 - If `promotionUrl` is provided, a "Learn More" link is displayed that opens in a new tab
 - If `promotionUrl` is not provided or is an empty string, no "Learn More" link is rendered
 - The component only renders in the `compact` variant when used as a compound component

--- a/chat/message/README.md
+++ b/chat/message/README.md
@@ -292,9 +292,9 @@ const Example = () => {
 | `markdownProps`                   | [`LGMarkdownProps`](https://github.com/mongodb/leafygreen-ui/tree/main/chat/lg-markdown#properties) | Props passed to the internal ReactMarkdown instance                               |                                                                                                                           |
 | `messageBody`                     | `string`                                                                                            | Message body text passed to LGMarkdown                                            |                                                                                                                           |
 | `onLinkClick`                     | `({ children: string; imageUrl?: string }) => void`                                                 | A callback function that is called when the link is clicked.                      |                                                                                                                           |
-| `onPromotionClick`                | `() => void`                                                                                        | Callback function for when promotional content is clicked           |                                                                                                                           |
-| `promotion`                       | `string`                                                                                            | Text to render as promotional content on the message            |                                                                                                                           |
-| `promotionUrl`                    | `string`                                                                                            | URL for the promotion to link the "Learn more" to                |                                                                                                                           |
+| `onPromotionClick`                | `() => void`                                                                                        | Callback function for when promotional content is clicked                         |                                                                                                                           |
+| `promotion`                       | `string`                                                                                            | Text to render as promotional content on the message                              |                                                                                                                           |
+| `promotionUrl`                    | `string`                                                                                            | URL for the promotion to link the "Learn more" to                                 |                                                                                                                           |
 | `sourceType`                      | `'markdown' \| 'text'`                                                                              | Determines the rendering method of the message                                    |                                                                                                                           |
 | `verified`                        | `{ verifier?: string; verifiedAt?: Date; learnMoreUrl?: string; }`                                  | Sets if an answer is "verified" and controls the content of the message banner.   |                                                                                                                           |
 | `...`                             | `HTMLElementProps<'div'>`                                                                           | Props spread on the root element                                                  |                                                                                                                           |
@@ -323,14 +323,14 @@ const Example = () => {
 
 ### Message.Promotion
 
-| Prop                                 | Type                              | Description                                                   | Default     |
-| ------------------------------------ | --------------------------------- | ------------------------------------------------------------- | ----------- |
-| `promotionText`                      | `string`                          | Promotion text content.                                       |             |
-| `promotionUrl` _(optional)_          | `string`                          | Promotion URL for the "Learn More" link.                      |             |
-| `baseFontSize` _(optional)_          | `BaseFontSize`                    | Base font size.                                               |             |
-| `onPromotionClick` _(optional)_      | `() => void`                      | Promotion onClick callback handler.                           |             |
-| `markdownProps` _(optional)_         | `Omit<LGMarkdownProps, 'children'>` | Props passed to the internal ReactMarkdown instance.         |             |
-| `...`                                | `HTMLElementProps<'div'>`         | Props spread on the root element                              |             |
+| Prop                            | Type                                | Description                                          | Default |
+| ------------------------------- | ----------------------------------- | ---------------------------------------------------- | ------- |
+| `promotionText`                 | `string`                            | Promotion text content.                              |         |
+| `promotionUrl` _(optional)_     | `string`                            | Promotion URL for the "Learn More" link.             |         |
+| `baseFontSize` _(optional)_     | `BaseFontSize`                      | Base font size.                                      |         |
+| `onPromotionClick` _(optional)_ | `() => void`                        | Promotion onClick callback handler.                  |         |
+| `markdownProps` _(optional)_    | `Omit<LGMarkdownProps, 'children'>` | Props passed to the internal ReactMarkdown instance. |         |
+| `...`                           | `HTMLElementProps<'div'>`           | Props spread on the root element                     |         |
 
 ### Message.VerifiedBanner
 

--- a/chat/message/README.md
+++ b/chat/message/README.md
@@ -61,7 +61,7 @@ return (
 
 ### Compound Components
 
-The `Message` component uses a compound component pattern, allowing you to compose different parts of a message using subcomponents like `Message.Actions`, `Message.Links`, and `Message.VerifiedBanner`.
+The `Message` component uses a compound component pattern, allowing you to compose different parts of a message using subcomponents like `Message.Actions`, `Message.Links`, `Message.Promotion`, and `Message.VerifiedBanner`.
 
 **Note 1:** All compound components only render in the `compact` variant.  
 **Note 2:** The layout and order of compound components are enforced by the `Message` component itself. Even if you change the order of subcomponents in your JSX, they will be rendered in the correct, intended order within the message bubble. This ensures consistent UI and accessibility regardless of how you compose your message children.
@@ -180,6 +180,33 @@ const MessageWithVerifiedBanner = () => {
 };
 ```
 
+### Message.Promotion
+
+```tsx
+import React from 'react';
+import {
+  LeafyGreenChatProvider,
+  Variant,
+} from '@lg-chat/leafygreen-chat-provider';
+import { Message } from '@lg-chat/message';
+
+const MessageWithPromotion = () => {
+  const handlePromotionClick = () => console.log('Promotion clicked');
+
+  return (
+    <LeafyGreenChatProvider variant={Variant.Compact}>
+      <Message isSender={false} messageBody="Test message">
+        <Message.Promotion
+          promotionText="Go learn more about this skill!"
+          promotionUrl="https://learn.mongodb.com/skills"
+          onPromotionClick={handlePromotionClick}
+        />
+      </Message>
+    </LeafyGreenChatProvider>
+  );
+};
+```
+
 ### Complete Example with All Subcomponents
 
 ```tsx
@@ -233,6 +260,11 @@ const Example = () => {
           onRatingChange={handleRatingChange}
           onSubmitFeedback={handleSubmitFeedback}
         />
+        <Message.Promotion
+          promotionText="Go learn more about this skill!"
+          promotionUrl="https://learn.mongodb.com/skills"
+          onPromotionClick={() => console.log('Promotion clicked')}
+        />
         <Message.VerifiedBanner
           verifier="MongoDB Staff"
           verifiedAt={new Date('2024-03-24T16:20:00Z')}
@@ -260,6 +292,9 @@ const Example = () => {
 | `markdownProps`                   | [`LGMarkdownProps`](https://github.com/mongodb/leafygreen-ui/tree/main/chat/lg-markdown#properties) | Props passed to the internal ReactMarkdown instance                               |                                                                                                                           |
 | `messageBody`                     | `string`                                                                                            | Message body text passed to LGMarkdown                                            |                                                                                                                           |
 | `onLinkClick`                     | `({ children: string; imageUrl?: string }) => void`                                                 | A callback function that is called when the link is clicked.                      |                                                                                                                           |
+| `onPromotionClick`                | `() => void`                                                                                        | Callback function for when promotional content is clicked           |                                                                                                                           |
+| `promotion`                       | `string`                                                                                            | Text to render as promotional content on the message            |                                                                                                                           |
+| `promotionUrl`                    | `string`                                                                                            | URL for the promotion to link the "Learn more" to                |                                                                                                                           |
 | `sourceType`                      | `'markdown' \| 'text'`                                                                              | Determines the rendering method of the message                                    |                                                                                                                           |
 | `verified`                        | `{ verifier?: string; verifiedAt?: Date; learnMoreUrl?: string; }`                                  | Sets if an answer is "verified" and controls the content of the message banner.   |                                                                                                                           |
 | `...`                             | `HTMLElementProps<'div'>`                                                                           | Props spread on the root element                                                  |                                                                                                                           |
@@ -285,6 +320,17 @@ const Example = () => {
 | `links`                    | `Array<RichLinkProps>`           | An array of link data to render in the links section.        |                       |
 | `onLinkClick` _(optional)_ | `({ children: string }) => void` | A callback function that is called when any link is clicked. |                       |
 | `...`                      | `HTMLElementProps<'div'>`        | Props spread on the root element                             |                       |
+
+### Message.Promotion
+
+| Prop                                 | Type                              | Description                                                   | Default     |
+| ------------------------------------ | --------------------------------- | ------------------------------------------------------------- | ----------- |
+| `promotionText`                      | `string`                          | Promotion text content.                                       |             |
+| `promotionUrl` _(optional)_          | `string`                          | Promotion URL for the "Learn More" link.                      |             |
+| `baseFontSize` _(optional)_          | `BaseFontSize`                    | Base font size.                                               |             |
+| `onPromotionClick` _(optional)_      | `() => void`                      | Promotion onClick callback handler.                           |             |
+| `markdownProps` _(optional)_         | `Omit<LGMarkdownProps, 'children'>` | Props passed to the internal ReactMarkdown instance.         |             |
+| `...`                                | `HTMLElementProps<'div'>`         | Props spread on the root element                              |             |
 
 ### Message.VerifiedBanner
 
@@ -360,6 +406,22 @@ The `MessageLinks` component provides an expandable/collapsible section for disp
 The component manages its own internal state for:
 
 - Expansion state: Controls whether the links section is expanded or collapsed
+
+### Message.Promotion
+
+The `MessagePromotion` component displays promotional content with an award icon and optional "Learn More" link.
+
+#### Rendering Behavior
+
+- If `promotionText` is empty or undefined, the component returns `null` and does not render anything
+- The component supports markdown content by default
+- If `promotionUrl` is provided, a "Learn More" link is displayed that opens in a new tab
+- If `promotionUrl` is not provided or is an empty string, no "Learn More" link is rendered
+- The component only renders in the `compact` variant when used as a compound component
+
+#### Callback Behavior
+
+- The `onPromotionClick` callback is triggered when clicking the "Learn More" link
 
 ### Message.VerifiedBanner
 

--- a/chat/message/src/Message.stories.tsx
+++ b/chat/message/src/Message.stories.tsx
@@ -282,6 +282,15 @@ export const WithMessageLinksExpanded: StoryObj<MessageStoryProps> = {
   },
 };
 
+export const WithPromotion: StoryObj<MessageStoryProps> = {
+  render: Template,
+  args: {
+    isSender: false,
+    messageBody: ASSISTANT_TEXT,
+    promotion: "Want to learn more? Go to the Skills homepage!",
+  },
+};
+
 export const WithAllSubComponents: StoryObj<MessageStoryProps> = {
   render: Template,
   args: {
@@ -294,6 +303,7 @@ export const WithAllSubComponents: StoryObj<MessageStoryProps> = {
     ),
     isSender: false,
     messageBody: ASSISTANT_TEXT,
+    promotion: "This response includes promotional content",
   },
 };
 

--- a/chat/message/src/Message.stories.tsx
+++ b/chat/message/src/Message.stories.tsx
@@ -121,23 +121,22 @@ const getLinksChild = () => (
 const getPromotionsChild = () => (
   <Message.Promotion
     promotionText="Go learn more about this skill!"
-    promotionUrl='https://learn.mongodb.com/skills'
+    promotionUrl="https://learn.mongodb.com/skills"
     // eslint-disable-next-line no-console
     onPromotionClick={() => console.log('Promotion clicked')}
   />
-
-)
+);
 
 const getAllSpaciousArgs = () => {
   return {
-    promotion: "Go learn more about this skill!",
-    promotionUrl: "https://learn.mongodb.com/skills",
+    promotion: 'Go learn more about this skill!',
+    promotionUrl: 'https://learn.mongodb.com/skills',
     // eslint-disable-next-line no-console
     onPromotionClick: () => console.log('Promotion clicked'),
     verified: {
-      verifier: "MongoDB Staff",
+      verifier: 'MongoDB Staff',
       verifiedAt: new Date('2023-08-24T16:20:00Z'),
-      learnMoreUrl: "https://mongodb.com/docs",
+      learnMoreUrl: 'https://mongodb.com/docs',
     },
     links: [
       {
@@ -172,8 +171,8 @@ const getAllSpaciousArgs = () => {
       },
     ],
     linksHeading: 'Related Resources',
-  }
-}
+  };
+};
 
 const meta: StoryMetaType<typeof Message> = {
   title: 'Composition/Chat/Message',

--- a/chat/message/src/Message.stories.tsx
+++ b/chat/message/src/Message.stories.tsx
@@ -127,53 +127,6 @@ const getPromotionsChild = () => (
   />
 );
 
-const getAllSpaciousArgs = () => {
-  return {
-    promotion: 'Go learn more about this skill!',
-    promotionUrl: 'https://learn.mongodb.com/skills',
-    // eslint-disable-next-line no-console
-    onPromotionClick: () => console.log('Promotion clicked'),
-    verified: {
-      verifier: 'MongoDB Staff',
-      verifiedAt: new Date('2023-08-24T16:20:00Z'),
-      learnMoreUrl: 'https://mongodb.com/docs',
-    },
-    links: [
-      {
-        href: 'https://mongodb.design',
-        children: 'LeafyGreen UI',
-        variant: 'Website',
-      },
-      {
-        href: 'https://mongodb.github.io/leafygreen-ui/?path=/docs/overview-introduction--docs',
-        children: 'LeafyGreen UI Docs',
-        variant: 'Docs',
-      },
-      {
-        href: 'https://learn.mongodb.com/',
-        children: 'MongoDB University',
-        variant: 'Learn',
-      },
-      {
-        href: 'https://mongodb.com/docs',
-        children: 'MongoDB Docs',
-        variant: 'Docs',
-      },
-      {
-        href: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-        children: 'Rick Astley - Never Gonna Give You Up',
-        variant: 'Video',
-      },
-      {
-        href: 'https://mongodb.com/',
-        children: 'MongoDB Homepage',
-        variant: 'Website',
-      },
-    ],
-    linksHeading: 'Related Resources',
-  };
-};
-
 const meta: StoryMetaType<typeof Message> = {
   title: 'Composition/Chat/Message',
   component: Message,
@@ -347,7 +300,7 @@ export const WithPromotion: StoryObj<MessageStoryProps> = {
   },
 };
 
-export const CompactWithAllSubComponents: StoryObj<MessageStoryProps> = {
+export const WithAllSubComponents: StoryObj<MessageStoryProps> = {
   render: Template,
   args: {
     variant: Variant.Compact,
@@ -361,16 +314,6 @@ export const CompactWithAllSubComponents: StoryObj<MessageStoryProps> = {
     ),
     isSender: false,
     messageBody: ASSISTANT_TEXT,
-  },
-};
-
-export const SpaciousWithAllSubComponents: StoryObj<MessageStoryProps> = {
-  render: Template,
-  args: {
-    variant: Variant.Spacious,
-    isSender: false,
-    messageBody: ASSISTANT_TEXT,
-    ...getAllSpaciousArgs(),
   },
 };
 

--- a/chat/message/src/Message.stories.tsx
+++ b/chat/message/src/Message.stories.tsx
@@ -118,6 +118,56 @@ const getLinksChild = () => (
   />
 );
 
+const getPromotionsChild = () => (
+  <Message.Promotion
+    promotionText="This response includes promotional content"
+  />
+)
+
+const getAllSpaciousArgs = () => {
+  return {
+    promotion: "This response includes [promotional content](www.google.com)",
+    verified: {
+      verifier: "MongoDB Staff",
+      verifiedAt: new Date('2023-08-24T16:20:00Z'),
+      learnMoreUrl: "https://mongodb.com/docs",
+    },
+    links: [
+      {
+        href: 'https://mongodb.design',
+        children: 'LeafyGreen UI',
+        variant: 'Website',
+      },
+      {
+        href: 'https://mongodb.github.io/leafygreen-ui/?path=/docs/overview-introduction--docs',
+        children: 'LeafyGreen UI Docs',
+        variant: 'Docs',
+      },
+      {
+        href: 'https://learn.mongodb.com/',
+        children: 'MongoDB University',
+        variant: 'Learn',
+      },
+      {
+        href: 'https://mongodb.com/docs',
+        children: 'MongoDB Docs',
+        variant: 'Docs',
+      },
+      {
+        href: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        children: 'Rick Astley - Never Gonna Give You Up',
+        variant: 'Video',
+      },
+      {
+        href: 'https://mongodb.com/',
+        children: 'MongoDB Homepage',
+        variant: 'Website',
+      },
+    ],
+    linksHeading: 'Related Resources',
+  }
+}
+
 const meta: StoryMetaType<typeof Message> = {
   title: 'Composition/Chat/Message',
   component: Message,
@@ -285,25 +335,37 @@ export const WithMessageLinksExpanded: StoryObj<MessageStoryProps> = {
 export const WithPromotion: StoryObj<MessageStoryProps> = {
   render: Template,
   args: {
+    children: getPromotionsChild(),
     isSender: false,
     messageBody: ASSISTANT_TEXT,
     promotion: "Want to learn more? Go to the Skills homepage!",
   },
 };
 
-export const WithAllSubComponents: StoryObj<MessageStoryProps> = {
+export const CompactWithAllSubComponents: StoryObj<MessageStoryProps> = {
   render: Template,
   args: {
+    variant: Variant.Compact,
     children: (
       <>
         {getActionsChild()}
         {getLinksChild()}
+        {getPromotionsChild()}
         {getVerifiedBannerChild()}
       </>
     ),
     isSender: false,
     messageBody: ASSISTANT_TEXT,
-    promotion: "This response includes promotional content",
+  },
+};
+
+export const SpaciousWithAllSubComponents: StoryObj<MessageStoryProps> = {
+  render: Template,
+  args: {
+    variant: Variant.Spacious,
+    isSender: false,
+    messageBody: ASSISTANT_TEXT,
+    ...getAllSpaciousArgs(),
   },
 };
 

--- a/chat/message/src/Message.stories.tsx
+++ b/chat/message/src/Message.stories.tsx
@@ -338,7 +338,6 @@ export const WithPromotion: StoryObj<MessageStoryProps> = {
     children: getPromotionsChild(),
     isSender: false,
     messageBody: ASSISTANT_TEXT,
-    promotion: "Want to learn more? Go to the Skills homepage!",
   },
 };
 

--- a/chat/message/src/Message.stories.tsx
+++ b/chat/message/src/Message.stories.tsx
@@ -120,13 +120,20 @@ const getLinksChild = () => (
 
 const getPromotionsChild = () => (
   <Message.Promotion
-    promotionText="This response includes promotional content"
+    promotionText="Go learn more about this skill!"
+    promotionUrl='https://learn.mongodb.com/skills'
+    // eslint-disable-next-line no-console
+    onPromotionClick={() => console.log('Promotion clicked')}
   />
+
 )
 
 const getAllSpaciousArgs = () => {
   return {
-    promotion: "This response includes [promotional content](www.google.com)",
+    promotion: "Go learn more about this skill!",
+    promotionUrl: "https://learn.mongodb.com/skills",
+    // eslint-disable-next-line no-console
+    onPromotionClick: () => console.log('Promotion clicked'),
     verified: {
       verifier: "MongoDB Staff",
       verifiedAt: new Date('2023-08-24T16:20:00Z'),

--- a/chat/message/src/Message/CompactMessage.tsx
+++ b/chat/message/src/Message/CompactMessage.tsx
@@ -43,7 +43,10 @@ export const CompactMessage = forwardRef<HTMLDivElement, MessageProps>(
       MessageSubcomponentProperty.VerifiedBanner,
     );
     const links = findChild(children, MessageSubcomponentProperty.Links);
-    const promotion = findChild(children, MessageSubcomponentProperty.Promotion);
+    const promotion = findChild(
+      children,
+      MessageSubcomponentProperty.Promotion,
+    );
 
     // Filter out subcomponents from children
     const remainingChildren = filterChildren(

--- a/chat/message/src/Message/CompactMessage.tsx
+++ b/chat/message/src/Message/CompactMessage.tsx
@@ -43,6 +43,7 @@ export const CompactMessage = forwardRef<HTMLDivElement, MessageProps>(
       MessageSubcomponentProperty.VerifiedBanner,
     );
     const links = findChild(children, MessageSubcomponentProperty.Links);
+    const promotion = findChild(children, MessageSubcomponentProperty.Promotion);
 
     // Filter out subcomponents from children
     const remainingChildren = filterChildren(
@@ -80,6 +81,7 @@ export const CompactMessage = forwardRef<HTMLDivElement, MessageProps>(
           >
             {messageBody ?? ''}
           </MessageContent>
+          {promotion}
           {actions}
           {verifiedBanner}
           {links}

--- a/chat/message/src/Message/Message.tsx
+++ b/chat/message/src/Message/Message.tsx
@@ -14,11 +14,13 @@ import { MessageActions } from '../MessageActions';
 import { MessageVerifiedBanner } from '../MessageBanner';
 import { MessageContext } from '../MessageContext';
 import { MessageLinks } from '../MessageLinks';
+import { MessagePromotion } from '../MessagePromotion';
 
 import { CompactMessage } from './CompactMessage';
 import {
   ActionsType,
   LinksType,
+  PromotionType,
   type MessageProps,
   type VerifiedBannerType,
 } from './Message.types';
@@ -102,8 +104,6 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
 
 BaseMessage.displayName = 'Message';
 
-// These are just FUNCTIONS. NOT instanced here
-// Name tag the FUNCTIONS (not the instances) so we can easily use findChild to get the instances of them
 const Actions = MessageActions as ActionsType;
 Actions[MessageSubcomponentProperty.Actions] = true;
 
@@ -113,8 +113,12 @@ Links[MessageSubcomponentProperty.Links] = true;
 const VerifiedBanner = MessageVerifiedBanner as VerifiedBannerType;
 VerifiedBanner[MessageSubcomponentProperty.VerifiedBanner] = true;
 
+const Promotion = MessagePromotion as PromotionType;
+Promotion[MessageSubcomponentProperty.Promotion] = true;
+
 export const Message = Object.assign(BaseMessage, {
   Actions,
   Links,
   VerifiedBanner,
+  Promotion,
 });

--- a/chat/message/src/Message/Message.tsx
+++ b/chat/message/src/Message/Message.tsx
@@ -26,7 +26,6 @@ import {
 } from './Message.types';
 import { SpaciousMessage } from './SpaciousMessage';
 
-// Builds the base message, can be either compact or spacious
 const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
   (
     {
@@ -36,9 +35,6 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
       children,
       componentOverrides,
       darkMode: darkModeProp,
-      promotion,
-      promotionUrl,
-      onPromotionClick,
       links,
       linksHeading,
       onLinkClick,
@@ -87,9 +83,6 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
               avatar={avatar}
               baseFontSize={baseFontSize}
               componentOverrides={componentOverrides}
-              promotion={promotion}
-              promotionUrl={promotionUrl}
-              onPromotionClick={onPromotionClick}
               links={links}
               linksHeading={linksHeading}
               onLinkClick={onLinkClick}

--- a/chat/message/src/Message/Message.tsx
+++ b/chat/message/src/Message/Message.tsx
@@ -21,7 +21,7 @@ import {
   ActionsType,
   LinksType,
   type MessageProps,
-  PromotionType,
+  type PromotionType,
   type VerifiedBannerType,
 } from './Message.types';
 import { SpaciousMessage } from './SpaciousMessage';

--- a/chat/message/src/Message/Message.tsx
+++ b/chat/message/src/Message/Message.tsx
@@ -24,6 +24,7 @@ import {
 } from './Message.types';
 import { SpaciousMessage } from './SpaciousMessage';
 
+// Builds the base message, can be either compact or spacious
 const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
   (
     {
@@ -33,6 +34,7 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
       children,
       componentOverrides,
       darkMode: darkModeProp,
+      promotion,
       links,
       linksHeading,
       onLinkClick,
@@ -81,6 +83,7 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
               avatar={avatar}
               baseFontSize={baseFontSize}
               componentOverrides={componentOverrides}
+              promotion={promotion}
               links={links}
               linksHeading={linksHeading}
               onLinkClick={onLinkClick}
@@ -99,6 +102,8 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
 
 BaseMessage.displayName = 'Message';
 
+// These are just FUNCTIONS. NOT instanced here
+// Name tag the FUNCTIONS (not the instances) so we can easily use findChild to get the instances of them
 const Actions = MessageActions as ActionsType;
 Actions[MessageSubcomponentProperty.Actions] = true;
 

--- a/chat/message/src/Message/Message.tsx
+++ b/chat/message/src/Message/Message.tsx
@@ -20,8 +20,8 @@ import { CompactMessage } from './CompactMessage';
 import {
   ActionsType,
   LinksType,
-  PromotionType,
   type MessageProps,
+  PromotionType,
   type VerifiedBannerType,
 } from './Message.types';
 import { SpaciousMessage } from './SpaciousMessage';
@@ -37,6 +37,8 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
       componentOverrides,
       darkMode: darkModeProp,
       promotion,
+      promotionUrl,
+      onPromotionClick,
       links,
       linksHeading,
       onLinkClick,
@@ -86,6 +88,8 @@ const BaseMessage = forwardRef<HTMLDivElement, MessageProps>(
               baseFontSize={baseFontSize}
               componentOverrides={componentOverrides}
               promotion={promotion}
+              promotionUrl={promotionUrl}
+              onPromotionClick={onPromotionClick}
               links={links}
               linksHeading={linksHeading}
               onLinkClick={onLinkClick}

--- a/chat/message/src/Message/Message.types.ts
+++ b/chat/message/src/Message/Message.types.ts
@@ -25,7 +25,6 @@ export interface ComponentOverrides {
   MessageContainer?: (props: MessageContainerProps) => JSX.Element;
   MessageContent?: (props: MessageContentProps) => JSX.Element;
   MessageLinks?: (props: MessageLinksProps) => JSX.Element;
-  MessagePromotion?: (props: MessagePromotionProps) => JSX.Element;
 }
 
 export interface MessageProps
@@ -67,24 +66,6 @@ export interface MessageProps
    * @default true
    */
   isSender?: boolean;
-
-  /**
-   * Text to render as promotional content on the message.
-   * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
-   */
-  promotion?: string;
-
-  /**
-   * URL for the promotion to link the "Learn more" to.
-   * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
-   */
-  promotionUrl?: string;
-
-  /**
-   * Callback function for when promotional content is clicked.
-   * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
-   */
-  onPromotionClick?: () => void; // TODO - Update the handler type
 
   /**
    * A list of links to render as rich links for the message.

--- a/chat/message/src/Message/Message.types.ts
+++ b/chat/message/src/Message/Message.types.ts
@@ -75,6 +75,12 @@ export interface MessageProps
   promotion?: string;
 
   /**
+   * URL for the promotion to link the "Learn more" to.
+   * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
+   */
+  promotionUrl?: string;
+
+  /**
    * Callback function for when promotional content is clicked.
    * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
    */

--- a/chat/message/src/Message/Message.types.ts
+++ b/chat/message/src/Message/Message.types.ts
@@ -75,6 +75,12 @@ export interface MessageProps
   promotion?: string;
 
   /**
+   * Callback function for when promotional content is clicked.
+   * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
+   */
+  onPromotionClick?: () => void; // TODO - Update the handler type
+
+  /**
    * A list of links to render as rich links for the message.
    * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
    */
@@ -117,3 +123,7 @@ export type VerifiedBannerType =
   ForwardRefExoticComponent<MessageVerifiedBannerProps> & {
     isLGMessageVerifiedBanner?: boolean;
   };
+
+export type PromotionType = ForwardRefExoticComponent<MessagePromotionProps> & {
+  isLGMessagePromotion?: boolean;
+};

--- a/chat/message/src/Message/Message.types.ts
+++ b/chat/message/src/Message/Message.types.ts
@@ -12,6 +12,7 @@ import {
 import { type MessageContainerProps } from '../MessageContainer';
 import { type MessageContentProps } from '../MessageContent';
 import { type MessageLinksProps } from '../MessageLinks';
+import { type MessagePromotionProps } from '../MessagePromotion';
 
 export const Align = {
   Right: 'right',
@@ -24,6 +25,7 @@ export interface ComponentOverrides {
   MessageContainer?: (props: MessageContainerProps) => JSX.Element;
   MessageContent?: (props: MessageContentProps) => JSX.Element;
   MessageLinks?: (props: MessageLinksProps) => JSX.Element;
+  MessagePromotion?: (props: MessagePromotionProps) => JSX.Element;
 }
 
 export interface MessageProps
@@ -65,6 +67,12 @@ export interface MessageProps
    * @default true
    */
   isSender?: boolean;
+
+  /**
+   * Text to render as promotional content on the message.
+   * @remarks This prop is only considered when the parent `LeafyGreenChatProvider` has `variant="spacious"`.
+   */
+  promotion?: string;
 
   /**
    * A list of links to render as rich links for the message.

--- a/chat/message/src/Message/SpaciousMessage.tsx
+++ b/chat/message/src/Message/SpaciousMessage.tsx
@@ -13,7 +13,6 @@ import {
 } from '../MessageContainer';
 import { MessageContent } from '../MessageContent';
 import { MessageLinks } from '../MessageLinks';
-import { MessagePromotion } from '../MessagePromotion/MessagePromotion';
 
 import { Align, type MessageProps } from './Message.types';
 import {
@@ -35,9 +34,6 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
       className,
       componentOverrides,
       isSender = true,
-      promotion,
-      promotionUrl,
-      onPromotionClick,
       links,
       linksHeading,
       markdownProps,
@@ -134,16 +130,6 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
             >
               {messageBody ?? ''}
             </Polymorph>
-            {promotion && promotionUrl ? (
-              <Polymorph
-                as={componentOverrides?.MessagePromotion ?? MessagePromotion}
-                promotionText={promotion}
-                promotionUrl={promotionUrl}
-                baseFontSize={baseFontSize}
-                onPromotionClick={onPromotionClick}
-                {...markdownProps}
-              />
-            ) : null}
             {links ? (
               <Polymorph
                 as={componentOverrides?.MessageLinks ?? MessageLinks}

--- a/chat/message/src/Message/SpaciousMessage.tsx
+++ b/chat/message/src/Message/SpaciousMessage.tsx
@@ -36,6 +36,7 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
       componentOverrides,
       isSender = true,
       promotion,
+      promotionUrl,
       onPromotionClick,
       links,
       linksHeading,
@@ -133,10 +134,11 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
             >
               {messageBody ?? ''}
             </Polymorph>
-            {promotion ? (
+            {promotion && promotionUrl ? (
               <Polymorph
                 as={componentOverrides?.MessagePromotion ?? MessagePromotion}
                 promotionText={promotion}
+                promotionUrl={promotionUrl}
                 baseFontSize={baseFontSize}
                 onPromotionClick={onPromotionClick}
                 {...markdownProps}

--- a/chat/message/src/Message/SpaciousMessage.tsx
+++ b/chat/message/src/Message/SpaciousMessage.tsx
@@ -36,6 +36,7 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
       componentOverrides,
       isSender = true,
       promotion,
+      onPromotionClick,
       links,
       linksHeading,
       markdownProps,
@@ -137,7 +138,7 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
                 as={componentOverrides?.MessagePromotion ?? MessagePromotion}
                 promotionText={promotion}
                 baseFontSize={baseFontSize}
-                onLinkClick={() => {}} // TODO: implement proper callback
+                onPromotionClick={onPromotionClick}
                 {...markdownProps}
               />
             ) : null}

--- a/chat/message/src/Message/SpaciousMessage.tsx
+++ b/chat/message/src/Message/SpaciousMessage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../MessageContainer';
 import { MessageContent } from '../MessageContent';
 import { MessageLinks } from '../MessageLinks';
+import { MessagePromotion } from '../MessagePromotion/MessagePromotion';
 
 import { Align, type MessageProps } from './Message.types';
 import {
@@ -34,6 +35,7 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
       className,
       componentOverrides,
       isSender = true,
+      promotion,
       links,
       linksHeading,
       markdownProps,
@@ -130,6 +132,15 @@ export const SpaciousMessage = forwardRef<HTMLDivElement, MessageProps>(
             >
               {messageBody ?? ''}
             </Polymorph>
+            {promotion ? (
+              <Polymorph
+                as={componentOverrides?.MessagePromotion ?? MessagePromotion}
+                promotionText={promotion}
+                baseFontSize={baseFontSize}
+                onLinkClick={() => {}} // TODO: implement proper callback
+                {...markdownProps}
+              />
+            ) : null}
             {links ? (
               <Polymorph
                 as={componentOverrides?.MessageLinks ?? MessageLinks}

--- a/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
@@ -104,7 +104,7 @@ describe('MessagePromotion', () => {
         onPromotionClick: mockOnClick,
       });
 
-      const learnMoreLink = screen.getByText("Learn More");
+      const learnMoreLink = screen.getByText('Learn More');
       await userEvent.click(learnMoreLink);
 
       expect(mockOnClick).toHaveBeenCalledTimes(1);

--- a/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
@@ -17,7 +17,11 @@ const defaultProps: MessagePromotionProps = {
 
 const renderMessagePromotion = (props: Partial<MessagePromotionProps> = {}) => {
   const { container } = render(
-    <MessagePromotion data-testid="message-promotion" {...defaultProps} {...props} />
+    <MessagePromotion
+      data-testid="message-promotion"
+      {...defaultProps}
+      {...props}
+    />,
   );
   return { container };
 };
@@ -41,7 +45,7 @@ describe('MessagePromotion', () => {
       expect(svg).toHaveAttribute('height', '16');
     });
 
-    test('renders promotion text', () => {
+    test('renders promotion text & link', () => {
       const promotionText = 'This is a test promotion message';
       renderMessagePromotion({
         promotionText,
@@ -49,14 +53,10 @@ describe('MessagePromotion', () => {
       });
 
       expect(screen.getByText(promotionText)).toBeInTheDocument();
+      expect(screen.getByText('Learn More')).toBeInTheDocument();
     });
 
-    test('renders learn more link', () => {
-      renderMessagePromotion();
-      expect(screen.getByText("Learn more")).toBeInTheDocument();
-    });
-
-    test('renders text but not external link when no URL', () => {
+    test('renders text but not external link when no URL provided', () => {
       const promotionText = 'This is a test promotion message';
       renderMessagePromotion({
         promotionText,
@@ -64,7 +64,34 @@ describe('MessagePromotion', () => {
       });
 
       expect(screen.getByText(promotionText)).toBeInTheDocument();
-      expect(screen.queryByText("Learn more")).not.toBeInTheDocument();
+      expect(screen.queryByText('Learn More')).not.toBeInTheDocument();
+    });
+
+    test('renders text but not external link when URL is empty string', () => {
+      renderMessagePromotion({
+        ...defaultProps,
+        promotionUrl: '',
+      });
+
+      expect(screen.queryByText('Learn More')).not.toBeInTheDocument();
+    });
+
+    test('if promotion text is empty, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        ...defaultProps,
+        promotionText: '',
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('if promotion text is undefined, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        ...defaultProps,
+        promotionText: undefined,
+      });
+
+      expect(container.firstChild).toBeNull();
     });
   });
 
@@ -90,44 +117,6 @@ describe('MessagePromotion', () => {
           onPromotionClick: undefined,
         });
       }).not.toThrow();
-    });
-  });
-
-  describe('edge cases', () => {
-    test('if promotion text is empty, does not render anything', () => {
-      const { container } = renderMessagePromotion({
-        ...defaultProps,
-        promotionText: '',
-      });
-
-      expect(container.firstChild).toBeNull();
-    });
-
-    test('if promotion text is undefined, does not render anything', () => {
-      const { container } = renderMessagePromotion({
-        ...defaultProps,
-        promotionText: undefined,
-      });
-
-      expect(container.firstChild).toBeNull();
-    });
-
-    test('if promotion url is empty, does not render anything', () => {
-      const { container } = renderMessagePromotion({
-        ...defaultProps,
-        promotionUrl: '',
-      });
-
-      expect(container.firstChild).toBeNull();
-    });
-
-    test('if promotion url is undefined, does not render anything', () => {
-      const { container } = renderMessagePromotion({
-        ...defaultProps,
-        promotionUrl: undefined,
-      });
-
-      expect(container.firstChild).toBeNull();
     });
   });
 });

--- a/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
@@ -9,15 +9,15 @@ jest.mock('@lg-chat/lg-markdown', () => ({
   LGMarkdown: jest.fn(({ children }) => <div>{children}</div>),
 }));
 
-const renderMessagePromotion = (props: Partial<MessagePromotionProps> = {}) => {
-  const defaultProps: MessagePromotionProps = {
-    promotionText: 'This is a test promotion message',
-    baseFontSize: 16,
-    ...props,
-  };
+const defaultProps: MessagePromotionProps = {
+  promotionText: 'Go learn a new skill!',
+  promotionUrl: 'https://learn.mongodb.com/skills',
+  baseFontSize: 16,
+};
 
+const renderMessagePromotion = (props: Partial<MessagePromotionProps> = {}) => {
   const { container } = render(
-    <MessagePromotion data-testid="message-promotion" {...defaultProps} />
+    <MessagePromotion data-testid="message-promotion" {...defaultProps} {...props} />
   );
   return { container };
 };
@@ -25,9 +25,7 @@ const renderMessagePromotion = (props: Partial<MessagePromotionProps> = {}) => {
 describe('MessagePromotion', () => {
   describe('a11y', () => {
     test('does not have basic accessibility issues', async () => {
-      const { container } = renderMessagePromotion({
-        promotionText: 'Test promotion text',
-      });
+      const { container } = renderMessagePromotion();
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
@@ -35,9 +33,7 @@ describe('MessagePromotion', () => {
 
   describe('rendering', () => {
     test('renders SVG icon at 16x16 size', () => {
-      renderMessagePromotion({
-        promotionText: 'Test promotion',
-      });
+      renderMessagePromotion();
 
       const svg = document.querySelector('svg');
       expect(svg).toBeInTheDocument();
@@ -49,9 +45,26 @@ describe('MessagePromotion', () => {
       const promotionText = 'This is a test promotion message';
       renderMessagePromotion({
         promotionText,
+        promotionUrl: 'https://learn.mongodb.com/skills',
       });
 
       expect(screen.getByText(promotionText)).toBeInTheDocument();
+    });
+
+    test('renders learn more link', () => {
+      renderMessagePromotion();
+      expect(screen.getByText("Learn more")).toBeInTheDocument();
+    });
+
+    test('renders text but not external link when no URL', () => {
+      const promotionText = 'This is a test promotion message';
+      renderMessagePromotion({
+        promotionText,
+        promotionUrl: undefined,
+      });
+
+      expect(screen.getByText(promotionText)).toBeInTheDocument();
+      expect(screen.queryByText("Learn more")).not.toBeInTheDocument();
     });
   });
 
@@ -60,7 +73,7 @@ describe('MessagePromotion', () => {
       const mockOnClick = jest.fn();
 
       renderMessagePromotion({
-        promotionText: 'Clickable promotion',
+        ...defaultProps,
         onPromotionClick: mockOnClick,
       });
 
@@ -73,7 +86,7 @@ describe('MessagePromotion', () => {
     test('onPromotionClick is not required', () => {
       expect(() => {
         renderMessagePromotion({
-          promotionText: 'Test promotion without click handler',
+          ...defaultProps,
           onPromotionClick: undefined,
         });
       }).not.toThrow();
@@ -83,15 +96,8 @@ describe('MessagePromotion', () => {
   describe('edge cases', () => {
     test('if promotion text is empty, does not render anything', () => {
       const { container } = renderMessagePromotion({
+        ...defaultProps,
         promotionText: '',
-      });
-
-      expect(container.firstChild).toBeNull();
-    });
-
-    test('if promotion text is null, does not render anything', () => {
-      const { container } = renderMessagePromotion({
-        promotionText: null as any,
       });
 
       expect(container.firstChild).toBeNull();
@@ -99,7 +105,26 @@ describe('MessagePromotion', () => {
 
     test('if promotion text is undefined, does not render anything', () => {
       const { container } = renderMessagePromotion({
-        promotionText: undefined as any,
+        ...defaultProps,
+        promotionText: undefined,
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('if promotion url is empty, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        ...defaultProps,
+        promotionUrl: '',
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('if promotion url is undefined, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        ...defaultProps,
+        promotionUrl: undefined,
       });
 
       expect(container.firstChild).toBeNull();

--- a/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import { MessagePromotion, type MessagePromotionProps } from '.';
+
+jest.mock('@lg-chat/lg-markdown', () => ({
+  LGMarkdown: jest.fn(({ children }) => <div>{children}</div>),
+}));
+
+const renderMessagePromotion = (props: Partial<MessagePromotionProps> = {}) => {
+  const defaultProps: MessagePromotionProps = {
+    promotionText: 'This is a test promotion message',
+    baseFontSize: 16,
+    ...props,
+  };
+
+  const { container } = render(
+    <MessagePromotion data-testid="message-promotion" {...defaultProps} />
+  );
+  return { container };
+};
+
+describe('MessagePromotion', () => {
+  describe('a11y', () => {
+    test('does not have basic accessibility issues', async () => {
+      const { container } = renderMessagePromotion({
+        promotionText: 'Test promotion text',
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('rendering', () => {
+    test('renders SVG icon at 16x16 size', () => {
+      renderMessagePromotion({
+        promotionText: 'Test promotion',
+      });
+
+      const svg = document.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute('width', '16');
+      expect(svg).toHaveAttribute('height', '16');
+    });
+
+    test('renders promotion text', () => {
+      const promotionText = 'This is a test promotion message';
+      renderMessagePromotion({
+        promotionText,
+      });
+
+      expect(screen.getByText(promotionText)).toBeInTheDocument();
+    });
+  });
+
+  describe('callback handling', () => {
+    test('onPromotionClick is called when promotion element is clicked', async () => {
+      const mockOnClick = jest.fn();
+
+      renderMessagePromotion({
+        promotionText: 'Clickable promotion',
+        onPromotionClick: mockOnClick,
+      });
+
+      const promotion = screen.getByTestId('message-promotion');
+      await userEvent.click(promotion);
+
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('onPromotionClick is not required', () => {
+      expect(() => {
+        renderMessagePromotion({
+          promotionText: 'Test promotion without click handler',
+          onPromotionClick: undefined,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('edge cases', () => {
+    test('if promotion text is empty, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        promotionText: '',
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('if promotion text is null, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        promotionText: null as any,
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    test('if promotion text is undefined, does not render anything', () => {
+      const { container } = renderMessagePromotion({
+        promotionText: undefined as any,
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.spec.tsx
@@ -104,8 +104,8 @@ describe('MessagePromotion', () => {
         onPromotionClick: mockOnClick,
       });
 
-      const promotion = screen.getByTestId('message-promotion');
-      await userEvent.click(promotion);
+      const learnMoreLink = screen.getByText("Learn More");
+      await userEvent.click(learnMoreLink);
 
       expect(mockOnClick).toHaveBeenCalledTimes(1);
     });

--- a/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
@@ -1,0 +1,46 @@
+
+import { css } from '@leafygreen-ui/emotion';
+import { palette } from '@leafygreen-ui/palette';
+import { BaseFontSize, spacing, typeScales } from '@leafygreen-ui/tokens';
+
+// TODO - Darkmode style(s)?
+
+// const fontStyles: Record<BaseFontSize, string> = {
+//   [BaseFontSize.Body1]: css`
+//     font-size: ${typeScales.body1.fontSize}px;
+//     line-height: ${typeScales.body1.lineHeight}px;
+//   `,
+//   [BaseFontSize.Body2]: css`
+//     font-size: ${typeScales.body2.fontSize}px;
+//     line-height: ${typeScales.body2.lineHeight}px;
+//   `,
+// };
+
+// export const getTextStyles = (baseFontSize: BaseFontSize) => fontStyles[baseFontSize];
+
+export const containerStyles = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
+export const iconStyles = css`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  
+  padding: 4px 10px;
+  width: ${spacing[900]}px;
+  height: ${spacing[600]}px; 
+
+  margin-right: ${spacing[200]}px;
+  
+  border-radius: ${spacing[600]}px;
+  border: 1px solid ${palette.green.light2};
+  background-color: ${palette.green.light3};
+
+  & svg {
+    color: ${palette.green.dark2};
+  }
+`

--- a/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
@@ -1,22 +1,7 @@
 
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
-import { BaseFontSize, spacing, typeScales } from '@leafygreen-ui/tokens';
-
-// TODO - Darkmode style(s)?
-
-// const fontStyles: Record<BaseFontSize, string> = {
-//   [BaseFontSize.Body1]: css`
-//     font-size: ${typeScales.body1.fontSize}px;
-//     line-height: ${typeScales.body1.lineHeight}px;
-//   `,
-//   [BaseFontSize.Body2]: css`
-//     font-size: ${typeScales.body2.fontSize}px;
-//     line-height: ${typeScales.body2.lineHeight}px;
-//   `,
-// };
-
-// export const getTextStyles = (baseFontSize: BaseFontSize) => fontStyles[baseFontSize];
+import { spacing } from '@leafygreen-ui/tokens';
 
 export const containerStyles = css`
   display: flex;
@@ -29,11 +14,10 @@ export const iconStyles = css`
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: center;
   
-  padding: 4px 10px;
   width: ${spacing[900]}px;
   height: ${spacing[600]}px; 
-
   margin-right: ${spacing[200]}px;
   
   border-radius: ${spacing[600]}px;

--- a/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
@@ -1,4 +1,3 @@
-
 import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { spacing } from '@leafygreen-ui/tokens';
@@ -7,6 +6,7 @@ export const containerStyles = css`
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin: ${spacing[200]}px 0 0 0;
 `
 
 export const iconStyles = css`
@@ -28,3 +28,8 @@ export const iconStyles = css`
     color: ${palette.green.dark2};
   }
 `
+
+export const learnMoreStyles = css`
+  display: inline;
+  color: inherit;
+`;

--- a/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
@@ -2,24 +2,24 @@ import { css } from '@leafygreen-ui/emotion';
 import { palette } from '@leafygreen-ui/palette';
 import { spacing } from '@leafygreen-ui/tokens';
 
-export const containerStyles = css`
+export const promotionContainerStyles = css`
   display: flex;
   flex-direction: row;
   align-items: center;
   margin: ${spacing[200]}px 0 0 0;
-`
+`;
 
-export const iconStyles = css`
+export const promotionIconStyles = css`
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  
+
   width: ${spacing[900]}px;
-  height: ${spacing[600]}px; 
+  height: ${spacing[600]}px;
   margin-right: ${spacing[200]}px;
-  
+
   border-radius: ${spacing[600]}px;
   border: 1px solid ${palette.green.light2};
   background-color: ${palette.green.light3};
@@ -27,9 +27,9 @@ export const iconStyles = css`
   & svg {
     color: ${palette.green.dark2};
   }
-`
+`;
 
-export const learnMoreStyles = css`
+export const promotionLearnMoreStyles = css`
   display: inline;
   color: inherit;
 `;

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -1,23 +1,17 @@
 import React from 'react';
 
 import Icon from '@leafygreen-ui/icon';
+import { Disclaimer, Link } from '@leafygreen-ui/typography';
 
 import { MessageContent } from '../MessageContent';
-import { type MessagePromotionProps } from './MessagePromotion.types';
-import { containerStyles, iconStyles } from './MessagePromotion.styles';
 
-// Open markdown link in new tab
-function MarkdownLinkRenderer(props: any) {
-  return (
-    <a href={props.href} target="_blank" rel="noreferrer">
-      {props.children}
-    </a>
-  );
-}
+import { containerStyles, iconStyles, learnMoreStyles } from './MessagePromotion.styles';
+import { type MessagePromotionProps } from './MessagePromotion.types';
 
 export function MessagePromotion({
   baseFontSize,
   promotionText,
+  promotionUrl,
   onPromotionClick,
   promotionContentType = "markdown",
   markdownProps,
@@ -27,6 +21,7 @@ export function MessagePromotion({
   if (!promotionText) {
     return null;
   }
+
   return (
     <div className={containerStyles}>
       <div className={iconStyles} >
@@ -36,13 +31,23 @@ export function MessagePromotion({
       </div>
       <MessageContent
         baseFontSize={baseFontSize}
-        markdownProps={{ ...markdownProps, components: { a: MarkdownLinkRenderer } }}
+        markdownProps={{ ...markdownProps}}
         sourceType={promotionContentType}
         onClick={onPromotionClick}
         {...rest}
       >
         {promotionText}
       </MessageContent>
+      { promotionUrl ? (
+        <Disclaimer className={learnMoreStyles}>
+          {promotionUrl && (
+            <>
+              {' '}
+              <Link href={promotionUrl} onClick={onPromotionClick}>Learn More</Link>
+            </>
+          )}
+        </Disclaimer>
+      ) : null}
     </div>
   )
 }

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -32,12 +32,20 @@ export function MessagePromotion({
       <div className={promotionIconStyles}>
         <Icon glyph="Award" />
       </div>
-      <Body className={promotionLearnMoreStyles} baseFontSize={baseFontSize} {...rest}>
+      <Body
+        className={promotionLearnMoreStyles}
+        baseFontSize={baseFontSize}
+        {...rest}
+      >
         {promotionText}
         {promotionUrl && (
           <>
             {' '}
-            <Link href={promotionUrl} onClick={onPromotionClick} baseFontSize={baseFontSize}>
+            <Link
+              href={promotionUrl}
+              onClick={onPromotionClick}
+              baseFontSize={baseFontSize}
+            >
               Learn More
             </Link>
           </>

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -9,7 +9,7 @@ import { containerStyles, iconStyles } from './MessagePromotion.styles';
 export function MessagePromotion({
   baseFontSize,
   promotionText,
-  onLinkClick,   // TODO figure out link click callback.
+  onPromotionClick,   // TODO figure out link click callback.
   markdownProps,
   ...rest
 }: MessagePromotionProps) {

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -6,10 +6,20 @@ import { MessageContent } from '../MessageContent';
 import { type MessagePromotionProps } from './MessagePromotion.types';
 import { containerStyles, iconStyles } from './MessagePromotion.styles';
 
+// Open markdown link in new tab
+function MarkdownLinkRenderer(props: any) {
+  return (
+    <a href={props.href} target="_blank" rel="noreferrer">
+      {props.children}
+    </a>
+  );
+}
+
 export function MessagePromotion({
   baseFontSize,
   promotionText,
-  onPromotionClick,   // TODO figure out link click callback.
+  onPromotionClick,
+  promotionContentType = "markdown",
   markdownProps,
   ...rest
 }: MessagePromotionProps) {
@@ -26,8 +36,9 @@ export function MessagePromotion({
       </div>
       <MessageContent
         baseFontSize={baseFontSize}
-        markdownProps={markdownProps}
-        sourceType="markdown"   // TODO Add a sourceType param to MessagePromotion
+        markdownProps={{ ...markdownProps, components: { a: MarkdownLinkRenderer } }}
+        sourceType={promotionContentType}
+        onClick={onPromotionClick}
         {...rest}
       >
         {promotionText}

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
 import Icon from '@leafygreen-ui/icon';
-import { Disclaimer, Link } from '@leafygreen-ui/typography';
-
-import { MessageContent } from '../MessageContent';
+import { Body, Link } from '@leafygreen-ui/typography';
 
 import {
   promotionContainerStyles,
@@ -13,10 +11,8 @@ import {
 import { type MessagePromotionProps } from './MessagePromotion.types';
 
 /**
- * MessagePromotion component renders promotional content with an award icon and optional "Learn More" link.
- * It integrates with the MessageContent component to support markdown rendering of promotional text.
+ * Renders promotional content with an award icon and optional "Learn More" link.
  *
- * @param props - Component properties
  * @returns The rendered promotional message component, or null if no promotionText is provided
  */
 export function MessagePromotion({
@@ -24,7 +20,6 @@ export function MessagePromotion({
   promotionText,
   promotionUrl,
   onPromotionClick,
-  promotionContentType = 'markdown',
   markdownProps,
   ...rest
 }: MessagePromotionProps) {
@@ -37,27 +32,17 @@ export function MessagePromotion({
       <div className={promotionIconStyles}>
         <Icon glyph="Award" />
       </div>
-      <MessageContent
-        baseFontSize={baseFontSize}
-        markdownProps={{ ...markdownProps }}
-        sourceType={promotionContentType}
-        onClick={onPromotionClick}
-        {...rest}
-      >
+      <Body className={promotionLearnMoreStyles} baseFontSize={baseFontSize} {...rest}>
         {promotionText}
-      </MessageContent>
-      {promotionUrl ? (
-        <Disclaimer className={promotionLearnMoreStyles}>
-          {promotionUrl && (
-            <>
-              {' '}
-              <Link href={promotionUrl} onClick={onPromotionClick}>
-                Learn More
-              </Link>
-            </>
-          )}
-        </Disclaimer>
-      ) : null}
+        {promotionUrl && (
+          <>
+            {' '}
+            <Link href={promotionUrl} onClick={onPromotionClick} baseFontSize={baseFontSize}>
+              Learn More
+            </Link>
+          </>
+        )}
+      </Body>
     </div>
   );
 }

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Icon from '@leafygreen-ui/icon';
+
+import { MessageContent } from '../MessageContent';
+import { type MessagePromotionProps } from './MessagePromotion.types';
+import { containerStyles, iconStyles } from './MessagePromotion.styles';
+
+export function MessagePromotion({
+  baseFontSize,
+  promotionText,
+  onLinkClick,   // TODO figure out link click callback.
+  markdownProps,
+  ...rest
+}: MessagePromotionProps) {
+
+  if (!promotionText) {
+    return null;
+  }
+  return (
+    <div className={containerStyles}>
+      <div className={iconStyles} >
+        <Icon
+          glyph="Award"
+        />
+      </div>
+      <MessageContent
+        baseFontSize={baseFontSize}
+        markdownProps={markdownProps}
+        sourceType="markdown"   // TODO Add a sourceType param to MessagePromotion
+        {...rest}
+      >
+        {promotionText}
+      </MessageContent>
+    </div>
+  )
+}

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -5,49 +5,59 @@ import { Disclaimer, Link } from '@leafygreen-ui/typography';
 
 import { MessageContent } from '../MessageContent';
 
-import { containerStyles, iconStyles, learnMoreStyles } from './MessagePromotion.styles';
+import {
+  promotionContainerStyles,
+  promotionIconStyles,
+  promotionLearnMoreStyles,
+} from './MessagePromotion.styles';
 import { type MessagePromotionProps } from './MessagePromotion.types';
 
+/**
+ * MessagePromotion component renders promotional content with an award icon and optional "Learn More" link.
+ * It integrates with the MessageContent component to support markdown rendering of promotional text.
+ *
+ * @param props - Component properties
+ * @returns The rendered promotional message component, or null if no promotionText is provided
+ */
 export function MessagePromotion({
   baseFontSize,
   promotionText,
   promotionUrl,
   onPromotionClick,
-  promotionContentType = "markdown",
+  promotionContentType = 'markdown',
   markdownProps,
   ...rest
 }: MessagePromotionProps) {
-
   if (!promotionText) {
     return null;
   }
 
   return (
-    <div className={containerStyles}>
-      <div className={iconStyles} >
-        <Icon
-          glyph="Award"
-        />
+    <div className={promotionContainerStyles}>
+      <div className={promotionIconStyles}>
+        <Icon glyph="Award" />
       </div>
       <MessageContent
         baseFontSize={baseFontSize}
-        markdownProps={{ ...markdownProps}}
+        markdownProps={{ ...markdownProps }}
         sourceType={promotionContentType}
         onClick={onPromotionClick}
         {...rest}
       >
         {promotionText}
       </MessageContent>
-      { promotionUrl ? (
-        <Disclaimer className={learnMoreStyles}>
+      {promotionUrl ? (
+        <Disclaimer className={promotionLearnMoreStyles}>
           {promotionUrl && (
             <>
               {' '}
-              <Link href={promotionUrl} onClick={onPromotionClick}>Learn More</Link>
+              <Link href={promotionUrl} onClick={onPromotionClick}>
+                Learn More
+              </Link>
             </>
           )}
         </Disclaimer>
       ) : null}
     </div>
-  )
+  );
 }

--- a/chat/message/src/MessagePromotion/MessagePromotion.types.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.types.ts
@@ -1,6 +1,8 @@
 import { LGMarkdownProps } from '@lg-chat/lg-markdown';
+
 import { HTMLElementProps } from '@leafygreen-ui/lib';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
+
 import { type MessageSourceType } from "../MessageContent"
 
 export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'children'> {
@@ -8,6 +10,11 @@ export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'ch
    * Promotion text content.
    */
   promotionText: string;
+
+  /**
+   * Promotion URL.
+   */
+  promotionUrl: string;
 
   /**
    * Base font size.
@@ -25,7 +32,7 @@ export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'ch
    * @returns void
    */
   onPromotionClick?: () => void;  // TODO - figure out inps
-  
+
   /**
    * Props passed to the internal ReactMarkdown instance
    */

--- a/chat/message/src/MessagePromotion/MessagePromotion.types.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.types.ts
@@ -4,8 +4,8 @@ import { HTMLElementProps } from '@leafygreen-ui/lib';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
 
 export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'children'> {
-  promotionText?: string;
-  baseFontSize: BaseFontSize;
-  onLinkClick: () => void;  // TODO - figure out inps
+  promotionText: string;
+  baseFontSize?: BaseFontSize;
+  onPromotionClick?: () => void;  // TODO - figure out inps
   markdownProps?: Omit<LGMarkdownProps, 'children'>;
 }

--- a/chat/message/src/MessagePromotion/MessagePromotion.types.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.types.ts
@@ -1,11 +1,33 @@
 import { LGMarkdownProps } from '@lg-chat/lg-markdown';
-
 import { HTMLElementProps } from '@leafygreen-ui/lib';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
+import { type MessageSourceType } from "../MessageContent"
 
 export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'children'> {
+  /**
+   * Promotion text content.
+   */
   promotionText: string;
+
+  /**
+   * Base font size.
+   */
   baseFontSize?: BaseFontSize;
+
+  /**
+   * Promotion text content rendering method.
+   * @default MessageSourceType.Markdown
+   */
+  promotionContentType?: MessageSourceType;
+
+  /**
+   * Promotion onClick callback handler
+   * @returns void
+   */
   onPromotionClick?: () => void;  // TODO - figure out inps
+  
+  /**
+   * Props passed to the internal ReactMarkdown instance
+   */
   markdownProps?: Omit<LGMarkdownProps, 'children'>;
 }

--- a/chat/message/src/MessagePromotion/MessagePromotion.types.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.types.ts
@@ -1,0 +1,11 @@
+import { LGMarkdownProps } from '@lg-chat/lg-markdown';
+
+import { HTMLElementProps } from '@leafygreen-ui/lib';
+import { BaseFontSize } from '@leafygreen-ui/tokens';
+
+export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'children'> {
+  promotionText?: string;
+  baseFontSize: BaseFontSize;
+  onLinkClick: () => void;  // TODO - figure out inps
+  markdownProps?: Omit<LGMarkdownProps, 'children'>;
+}

--- a/chat/message/src/MessagePromotion/MessagePromotion.types.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.types.ts
@@ -3,9 +3,10 @@ import { LGMarkdownProps } from '@lg-chat/lg-markdown';
 import { HTMLElementProps } from '@leafygreen-ui/lib';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
 
-import { type MessageSourceType } from "../MessageContent"
+import { type MessageSourceType } from '../MessageContent';
 
-export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'children'> {
+export interface MessagePromotionProps
+  extends Omit<HTMLElementProps<'div'>, 'children'> {
   /**
    * Promotion text content.
    */
@@ -14,7 +15,7 @@ export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'ch
   /**
    * Promotion URL.
    */
-  promotionUrl: string;
+  promotionUrl?: string;
 
   /**
    * Base font size.
@@ -29,9 +30,8 @@ export interface MessagePromotionProps extends Omit<HTMLElementProps<'div'>, 'ch
 
   /**
    * Promotion onClick callback handler
-   * @returns void
    */
-  onPromotionClick?: () => void;  // TODO - figure out inps
+  onPromotionClick?: () => void;
 
   /**
    * Props passed to the internal ReactMarkdown instance

--- a/chat/message/src/MessagePromotion/MessagePromotion.types.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.types.ts
@@ -3,8 +3,6 @@ import { LGMarkdownProps } from '@lg-chat/lg-markdown';
 import { HTMLElementProps } from '@leafygreen-ui/lib';
 import { BaseFontSize } from '@leafygreen-ui/tokens';
 
-import { type MessageSourceType } from '../MessageContent';
-
 export interface MessagePromotionProps
   extends Omit<HTMLElementProps<'div'>, 'children'> {
   /**
@@ -21,12 +19,6 @@ export interface MessagePromotionProps
    * Base font size.
    */
   baseFontSize?: BaseFontSize;
-
-  /**
-   * Promotion text content rendering method.
-   * @default MessageSourceType.Markdown
-   */
-  promotionContentType?: MessageSourceType;
 
   /**
    * Promotion onClick callback handler

--- a/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
@@ -17,15 +17,16 @@ const meta: StoryMetaType<typeof MessagePromotion> = {
 
 export default meta;
 
-const Template: StoryFn<MessagePromotionProps> = (props) => (
-  React.createElement(MessagePromotion, props)
-);
+const Template: StoryFn<MessagePromotionProps> = props =>
+  React.createElement(MessagePromotion, props);
 
 export const WithPromotionTextAndUrl = {
   render: Template,
   args: {
-    promotionText: 'Challenge your knowledge by earning the Advanced Schema Design skill! ',
-    promotionUrl: 'https://learn.mongodb.com/courses/advanced-schema-patterns-and-antipatterns',
+    promotionText:
+      'Challenge your knowledge by earning the Advanced Schema Design skill! ',
+    promotionUrl:
+      'https://learn.mongodb.com/courses/advanced-schema-patterns-and-antipatterns',
     // eslint-disable-next-line no-console
     onPromotionClick: () => console.log('Promotion clicked'),
   },
@@ -34,14 +35,16 @@ export const WithPromotionTextAndUrl = {
 export const WithPromotionTextOnly = {
   render: Template,
   args: {
-    promotionText: 'Challenge your knowledge by earning the Advanced Schema Design skill! ',
+    promotionText:
+      'Challenge your knowledge by earning the Advanced Schema Design skill! ',
   },
 };
 
 export const WithLongPromotionTextAndUrl = {
   render: Template,
   args: {
-    promotionText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+    promotionText:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
     promotionUrl: 'https://learn.mongodb.com/skills',
     // eslint-disable-next-line no-console
     onPromotionClick: () => console.log('Promotion clicked'),

--- a/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { StoryMetaType } from '@lg-tools/storybook-utils';
+import { StoryFn } from '@storybook/react';
+
+import { MessagePromotion, MessagePromotionProps } from '.';
+
+const meta: StoryMetaType<typeof MessagePromotion> = {
+  title: 'Composition/Chat/MessagePromotion',
+  component: MessagePromotion,
+  args: {
+    baseFontSize: 13,
+  },
+  parameters: {
+    default: 'WithPromotionTextAndUrl',
+  },
+};
+
+export default meta;
+
+const Template: StoryFn<MessagePromotionProps> = (props) => (
+  React.createElement(MessagePromotion, props)
+);
+
+export const WithPromotionTextAndUrl = {
+  render: Template,
+  args: {
+    promotionText: 'Challenge your knowledge by earning the Advanced Schema Design skill! ',
+    promotionUrl: 'https://learn.mongodb.com/courses/advanced-schema-patterns-and-antipatterns',
+    // eslint-disable-next-line no-console
+    onPromotionClick: () => console.log('Promotion clicked'),
+  },
+};
+
+export const WithPromotionTextOnly = {
+  render: Template,
+  args: {
+    promotionText: 'Challenge your knowledge by earning the Advanced Schema Design skill! ',
+  },
+};
+
+export const WithLongPromotionTextAndUrl = {
+  render: Template,
+  args: {
+    promotionText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+    promotionUrl: 'https://learn.mongodb.com/skills',
+    // eslint-disable-next-line no-console
+    onPromotionClick: () => console.log('Promotion clicked'),
+  },
+};

--- a/chat/message/src/MessagePromotion/index.ts
+++ b/chat/message/src/MessagePromotion/index.ts
@@ -1,0 +1,2 @@
+export { MessagePromotion } from './MessagePromotion';
+export { type MessagePromotionProps } from './MessagePromotion.types';

--- a/chat/message/src/constants.ts
+++ b/chat/message/src/constants.ts
@@ -6,6 +6,7 @@ export const MessageSubcomponentProperty = {
   Actions: 'isLGMessageActions',
   VerifiedBanner: 'isLGMessageVerifiedBanner',
   Links: 'isLGMessageLinks',
+  Promotion: 'isLGMessagePromotion',
 } as const;
 
 /**

--- a/chat/message/src/index.ts
+++ b/chat/message/src/index.ts
@@ -32,3 +32,5 @@ export {
   MessageLinks,
   type MessageLinksProps,
 } from './MessageLinks';
+export { MessagePromotion } from './MessagePromotion/MessagePromotion';
+export { type MessagePromotionProps } from './MessagePromotion/MessagePromotion.types';


### PR DESCRIPTION
## ✍️ Proposed changes

Adds a promoted content section to lg-chat messages. This will be used by the MongoDB AI Assistant to promote skills during conversations.

🎟 _Jira ticket:_ [EAI-1318](https://jira.mongodb.org/browse/EAI-1318])

[Figma](https://www.figma.com/design/qZxxWKLt7kWMcWbZfvt6vK/EXPO-5323-Skills-in-Atlas-and-Chat?node-id=2726-10013) 

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added stories/tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

1. Links open in new tab
      - Using storybook, click promotion links and verify they open in new tab
2. Keyboard navigation
    - Again on storybook, test keyboard navigation highlights the promotion's "Learn more" link using tab button

