### PR TITLE
fix(CodeEditor): fix initial version number

### DIFF
--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leafygreen-ui/code-editor",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "LeafyGreen UI Kit Code Editor",
   "main": "./dist/umd/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
## ✍️ Proposed changes
The initial `code-editor` package was versioned at `0.1.0` on accident. This bumps it down to `0.0.0`.