### PR TITLE
[LG-5593] fix(modal) revert change in order of `data-testid` and `...rest` in `ModalView`

### DIFF
--- a/packages/confirmation-modal/src/ConfirmationModal/ConfirmationModal.spec.tsx
+++ b/packages/confirmation-modal/src/ConfirmationModal/ConfirmationModal.spec.tsx
@@ -507,6 +507,20 @@ describe('packages/confirmation-modal', () => {
       const modal = getByTestId('my-modal');
       expect(modal).toBeInTheDocument();
     });
+
+    it('propagates to the buttons', () => {
+      const { getByTestId } = renderModal({
+        open: true,
+        confirmButtonProps: { 'data-testid': 'my-confirm-btn' },
+        cancelButtonProps: { 'data-testid': 'my-cancel-btn' },
+      });
+
+      const confirmButton = getByTestId('my-confirm-btn');
+      expect(confirmButton).toBeInTheDocument();
+
+      const cancelButton = getByTestId('my-cancel-btn');
+      expect(cancelButton).toBeInTheDocument();
+    });
   });
 
   // eslint-disable-next-line jest/no-disabled-tests

--- a/packages/confirmation-modal/src/ConfirmationModal/ConfirmationModal.spec.tsx
+++ b/packages/confirmation-modal/src/ConfirmationModal/ConfirmationModal.spec.tsx
@@ -497,6 +497,18 @@ describe('packages/confirmation-modal', () => {
     });
   });
 
+  describe('testid attribute', () => {
+    it('propagates to the dom element', () => {
+      const { getByTestId } = renderModal({
+        open: true,
+        'data-testid': 'my-modal',
+      });
+
+      const modal = getByTestId('my-modal');
+      expect(modal).toBeInTheDocument();
+    });
+  });
+
   // eslint-disable-next-line jest/no-disabled-tests
   test.skip('types behave as expected', () => {
     <>

--- a/packages/confirmation-modal/src/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/confirmation-modal/src/ConfirmationModal/ConfirmationModal.tsx
@@ -134,8 +134,8 @@ export const ConfirmationModal = forwardRef<
         </div>
         <Footer>
           <Button
-            {...confirmButtonProps}
             data-testid={lgIds.confirm}
+            {...confirmButtonProps}
             disabled={!confirmEnabled || isConfirmDisabled}
             className={cx(buttonStyle, confirmButtonProps?.className)}
             variant={variant}
@@ -145,10 +145,10 @@ export const ConfirmationModal = forwardRef<
             {buttonText || confirmButtonProps?.children || 'Confirm'}
           </Button>
           <Button
+            data-testid={lgIds.cancel}
             {...cancelButtonProps}
             onClick={handleCancel}
             className={cx(buttonStyle, cancelButtonProps?.className)}
-            data-testid={lgIds.cancel}
           >
             Cancel
           </Button>

--- a/packages/lib/src/LgIdProps/index.ts
+++ b/packages/lib/src/LgIdProps/index.ts
@@ -10,4 +10,9 @@ export interface LgIdProps {
    * LG test id passed to the component wrapper.
    */
   ['data-lgid']?: LgIdString;
+
+  /**
+   * An additional test id passed to the component wrapper, meant for use by consumers of the library.
+   */
+  ['data-testid']?: string;
 }

--- a/packages/modal/src/Modal/Modal.spec.tsx
+++ b/packages/modal/src/Modal/Modal.spec.tsx
@@ -260,6 +260,18 @@ describe('packages/modal', () => {
       expect(modal).not.toBeVisible();
     });
   });
+
+  describe('testid attribute', () => {
+    it('propagates to the dom element', () => {
+      const { getByTestId } = renderModal({
+        open: true,
+        'data-testid': 'my-modal',
+      });
+
+      const modal = getByTestId('my-modal');
+      expect(modal).toBeInTheDocument();
+    });
+  });
 });
 
 async function expectElementToNotBeRemoved(element: HTMLElement) {

--- a/packages/modal/src/Modal/ModalView.tsx
+++ b/packages/modal/src/Modal/ModalView.tsx
@@ -90,11 +90,11 @@ const ModalView = React.forwardRef<HTMLDialogElement, ModalProps>(
         }}
       >
         <dialog
+          data-testid={lgIds.root}
+          data-lgid={lgIds.root}
           {...rest}
           ref={dialogRef}
           id={id}
-          data-testid={lgIds.root}
-          data-lgid={lgIds.root}
           className={getDialogStyles({
             backdropClassName,
             className,


### PR DESCRIPTION
## ✍️ Proposed changes

Merging this PR will:
- Propagate `data-testid` through the `ConfirmationModal` and `Modal` components.

🎟 _Jira ticket:_ [LG-5593](https://jira.mongodb.org/browse/LG-5593)

## ✅ Checklist

### For new components

- [ ] I have added my new package to the global tsconfig
- [ ] I have added my new package to the Table of Contents on the global README
- [ ] I have verified the Live Example will look as intended on the design website.

### For bug fixes, new features & breaking changes

- [ ] I have added stories/tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

<!--
Provide concise, specific, and actionable testing steps based on the changes made. For bug fixes, include simple steps to reproduce the issue. For features, provide clear steps to verify the new functionality.
-->
