### PR TITLE
Fix default style (svg width/height) & css prop on promotions

### DIFF
--- a/.changeset/curvy-lines-tie.md
+++ b/.changeset/curvy-lines-tie.md
@@ -1,0 +1,5 @@
+---
+'@lg-chat/message': minor
+---
+
+Add `className` prop to `Message.Promotion` for custom styles

--- a/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
+++ b/chat/message/src/MessagePromotion/MessagePromotion.styles.ts
@@ -9,6 +9,9 @@ export const promotionContainerStyles = css`
   flex-direction: row;
   align-items: center;
   gap: 0px ${spacing[200]}px;
+  & div {
+    box-sizing: border-box;
+  }
 `;
 
 export const badgeStyles = css`
@@ -16,6 +19,6 @@ export const badgeStyles = css`
   flex-direction: row;
   justify-content: center;
 
-  width: ${BADGE_WIDTH}px;
-  height: ${BADGE_HEIGHT}px;
+  min-width: ${BADGE_WIDTH}px;
+  min-height: ${BADGE_HEIGHT}px;
 `;

--- a/chat/message/src/MessagePromotion/MessagePromotion.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotion.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Badge, { Variant } from '@leafygreen-ui/badge';
+import { cx } from '@leafygreen-ui/emotion';
 import Icon from '@leafygreen-ui/icon';
 import LeafyGreenProvider, {
   useDarkMode,
@@ -23,17 +24,16 @@ export function MessagePromotion({
   promotionUrl,
   onPromotionLinkClick,
   darkMode: darkModeProp,
+  className,
   ...rest
 }: MessagePromotionProps) {
   const { darkMode } = useDarkMode(darkModeProp);
   return (
     <LeafyGreenProvider darkMode={darkMode}>
-      <div className={promotionContainerStyles}>
-        <div>
-          <Badge variant={Variant.Green} className={badgeStyles}>
-            <Icon glyph="Award" />
-          </Badge>
-        </div>
+      <div className={cx(promotionContainerStyles, className)}>
+        <Badge variant={Variant.Green} className={badgeStyles}>
+          <Icon glyph="Award" />
+        </Badge>
         <Body as="span" {...rest}>
           {promotionText}
           <>

--- a/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
@@ -23,13 +23,14 @@ const meta: StoryMetaType<typeof MessagePromotion> = {
         className: [
           css`
             gap: 20px;
-              & div {
-                background-color: ${palette.blue.dark2};
-                border-color: white;
-                color: ${palette.blue.light2};
-              }
-            `,
-          undefined]
+            & div {
+              background-color: ${palette.blue.dark2};
+              border-color: white;
+              color: ${palette.blue.light2};
+            }
+          `,
+          undefined,
+        ],
       },
     },
   },

--- a/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
@@ -22,6 +22,7 @@ const meta: StoryMetaType<typeof MessagePromotion> = {
         promotionUrl: ['https://learn.mongodb.com/skills'],
         className: [
           css`
+            box-sizing: content-box;
             gap: 20px;
             & div {
               background-color: ${palette.blue.dark2};

--- a/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
+++ b/chat/message/src/MessagePromotion/MessagePromotions.stories.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { storybookArgTypes, StoryMetaType } from '@lg-tools/storybook-utils';
 import { StoryFn } from '@storybook/react';
 
+import { css } from '@leafygreen-ui/emotion';
+import { palette } from '@leafygreen-ui/palette';
+
 import { MessagePromotion, MessagePromotionProps } from '.';
 
 const meta: StoryMetaType<typeof MessagePromotion> = {
@@ -13,10 +16,20 @@ const meta: StoryMetaType<typeof MessagePromotion> = {
       combineArgs: {
         darkMode: [false, true],
         promotionText: [
-          'Challenge your knowledge by earning the Advanced Schema Design skill!',
-          'Challenge your knowledge by earning the Advanced Schema Design skill! This is a really really really really really really really really really really really really really really really really really  really really really really really really really really long copy text to test how the component handles long text content.',
+          'Challenge your knowledge and earn the Schema Design badge!',
+          'Challenge your knowledge by earning the Advanced Schema Design skill! This is a really really really really really really really really really long copy text to test how the component handles multiline text content.',
         ],
         promotionUrl: ['https://learn.mongodb.com/skills'],
+        className: [
+          css`
+            gap: 20px;
+              & div {
+                background-color: ${palette.blue.dark2};
+                border-color: white;
+                color: ${palette.blue.light2};
+              }
+            `,
+          undefined]
       },
     },
   },


### PR DESCRIPTION
## ✍️ Proposed changes

Fixes default style on Message.Promotion component. The style `box-sizing: border-box` was missing, causing the promotion badge size to be wrong when implemented on the MongoDB Assistant. On Storybook, `border-box` is set by default on all elements under the Story root element, so this issue was not caught previously.

I've also made it possible for users to pass in custom styles on the promotions with `className`, as it could be a helpful workaround for users if any similar issues arise.

I also updated the stories:
- Shortened the text in the promotion stories to potentially catch any future wrong-size issues.
- Added a story for the new `className` prop, passing different `box-sizing` on the promotion container.

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [*] I have added stories/tests that prove my fix is effective or that my feature works
- [*] I have added necessary documentation (if appropriate) _[unnecessary,  `HTMLElementProps<'div'>` is already documented in the readme]_
- [ ] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

* Review custom style generated story for MessagePromotion on Storybook for blue badge color, increased gap size.
* Review promotion badge elements in stories for Message & MessagePromotion on Storybook all have correct element size (36x24)
