### PR TITLE
[LG-5600] feat(input-bar): add onClickStop prop and update button disabled logic

### DIFF
--- a/.changeset/large-lands-worry.md
+++ b/.changeset/large-lands-worry.md
@@ -1,0 +1,8 @@
+---
+'@lg-chat/input-bar': minor
+---
+
+[LG-5600](https://jira.mongodb.org/browse/LG-5600)
+Fix send button disabled logic: the send button now remains enabled during loading state (even with empty message body) to allow users to stop the request. The `disabled` and `disableSend` props still take precedence.
+
+Add `onClickStopButton` prop to handle stop actions during loading state. When triggered, the previous message body is restored to the input field (similar to error state behavior).

--- a/chat/input-bar/README.md
+++ b/chat/input-bar/README.md
@@ -39,7 +39,7 @@ const Example = () => {
     // Simulate API call
   };
 
-  const handleClickStop = () => {
+  const handleClickStopButton = () => {
     console.log('Stopping request');
     setState(State.Unset);
     // Cancel your API request here
@@ -49,7 +49,7 @@ const Example = () => {
     <LeafyGreenChatProvider variant={Variant.Compact}>
       <InputBar
         onMessageSend={handleMessageSend}
-        onClickStop={handleClickStop}
+        onClickStopButton={handleClickStopButton}
         state={state}
         errorMessage="Failed to send message. Please try again."
       />
@@ -60,21 +60,21 @@ const Example = () => {
 
 ## Properties
 
-| Prop                          | Type                                           | Description                                                                                                | Default |
-| ----------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------- |
-| `badgeText`                   | `string`                                       | Determines the text inside the rendered Badge                                                              |         |
-| `darkMode`                    | `boolean`                                      | Determines if the component will render in dark mode                                                       | `false` |
-| `disabled`                    | `boolean`                                      | Determines whether the user can interact with the InputBar                                                 | `false` |
-| `disableSend`                 | `boolean`                                      | When defined as `true`, disables the send action and button                                                |         |
-| `errorMessage`                | `ReactNode`                                    | Custom error message to display when `state='error'`                                                       |         |
-| `onClickStop`                 | `() => void`                                   | Callback fired when the stop button is clicked during a loading state. Restores the previous message body. |         |
-| `onMessageSend`               | `(messageBody: string, e?: FormEvent) => void` | Callback fired when the user sends a message.                                                              |         |
-| `shouldRenderGradient`        | `boolean`                                      | Toggles the gradient animation around the input                                                            | `true`  |
-| `shouldRenderHotkeyIndicator` | `boolean`                                      | Toggles the hotkey indicator on the right side of the input                                                | `false` |
-| `textareaProps`               | `TextareaAutosizeProps`                        | Props passed to the TextareaAutosize component.                                                            |         |
-| `textareaRef`                 | `RefObject<HTMLTextAreaElement>`               | Ref object to access the textarea element directly                                                         |         |
-| `state`                       | `'unset' \| 'error' \| 'loading'`              | The current state of the InputBar.                                                                         |         |
-| `...`                         | `HTMLElementProps<'form'>`                     | Props spread on the root element                                                                           |         |
+| Prop                          | Type                                           | Description                                                                                                                                 | Default |
+| ----------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `badgeText`                   | `string`                                       | Determines the text inside the rendered Badge                                                                                               |         |
+| `darkMode`                    | `boolean`                                      | Determines if the component will render in dark mode                                                                                        | `false` |
+| `disabled`                    | `boolean`                                      | Determines whether the user can interact with the InputBar                                                                                  | `false` |
+| `disableSend`                 | `boolean`                                      | When defined as `true`, disables the send action and button                                                                                 |         |
+| `errorMessage`                | `ReactNode`                                    | Custom error message to display when `state='error'`                                                                                        |         |
+| `onClickStopButton`           | `() => void`                                   | Callback fired when the stop button is clicked during a loading state. Restores the previous message body. Only applies in compact variant. |         |
+| `onMessageSend`               | `(messageBody: string, e?: FormEvent) => void` | Callback fired when the user sends a message.                                                                                               |         |
+| `shouldRenderGradient`        | `boolean`                                      | Toggles the gradient animation around the input                                                                                             | `true`  |
+| `shouldRenderHotkeyIndicator` | `boolean`                                      | Toggles the hotkey indicator on the right side of the input                                                                                 | `false` |
+| `textareaProps`               | `TextareaAutosizeProps`                        | Props passed to the TextareaAutosize component.                                                                                             |         |
+| `textareaRef`                 | `RefObject<HTMLTextAreaElement>`               | Ref object to access the textarea element directly                                                                                          |         |
+| `state`                       | `'unset' \| 'error' \| 'loading'`              | The current state of the InputBar.                                                                                                          |         |
+| `...`                         | `HTMLElementProps<'form'>`                     | Props spread on the root element                                                                                                            |         |
 
 ## TextareaAutosizeProps
 

--- a/chat/input-bar/src/InputBar/InputBar.spec.tsx
+++ b/chat/input-bar/src/InputBar/InputBar.spec.tsx
@@ -385,31 +385,39 @@ describe('packages/input-bar', () => {
     });
   });
 
-  describe('onClickStop', () => {
-    test('enables send button during loading state even with empty message', () => {
+  describe('onClickStopButton', () => {
+    test('renders stop button during loading state', () => {
       renderInputBar({ state: State.Loading });
 
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
-      expect(sendButton).not.toHaveAttribute('aria-disabled', 'true');
+      const stopButton = screen.getByRole('button', { name: 'Stop message' });
+      expect(stopButton).toBeInTheDocument();
+      expect(stopButton).not.toHaveAttribute('aria-disabled', 'true');
     });
 
-    test('calls onClickStop when button is clicked during loading state', () => {
-      const onClickStop = jest.fn();
-      renderInputBar({ state: State.Loading, onClickStop });
+    test('does not render send button during loading state', () => {
+      renderInputBar({ state: State.Loading });
 
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
-      userEvent.click(sendButton);
+      const sendButton = screen.queryByRole('button', { name: 'Send message' });
+      expect(sendButton).not.toBeInTheDocument();
+    });
 
-      expect(onClickStop).toHaveBeenCalledTimes(1);
+    test('calls onClickStopButton when button is clicked during loading state', () => {
+      const onClickStopButton = jest.fn();
+      renderInputBar({ state: State.Loading, onClickStopButton });
+
+      const stopButton = screen.getByRole('button', { name: 'Stop message' });
+      userEvent.click(stopButton);
+
+      expect(onClickStopButton).toHaveBeenCalledTimes(1);
     });
 
     test('restores previous message when stop is clicked in uncontrolled mode', () => {
-      const onClickStop = jest.fn();
+      const onClickStopButton = jest.fn();
       const onMessageSend = jest.fn();
-      const { rerender } = renderInputBar({ onClickStop, onMessageSend });
+      const { rerender } = renderInputBar({ onClickStopButton, onMessageSend });
 
       const textarea = screen.getByRole('textbox');
-      let sendButton = screen.getByRole('button', { name: 'Send message' });
+      const sendButton = screen.getByRole('button', { name: 'Send message' });
 
       userEvent.type(textarea, TEST_INPUT_TEXT);
       expect(textarea).toHaveValue(TEST_INPUT_TEXT);
@@ -422,60 +430,68 @@ describe('packages/input-bar', () => {
         <LeafyGreenChatProvider variant={Variant.Compact}>
           <InputBar
             state={State.Loading}
-            onClickStop={onClickStop}
+            onClickStopButton={onClickStopButton}
             onMessageSend={onMessageSend}
           />
         </LeafyGreenChatProvider>,
       );
 
-      sendButton = screen.getByRole('button', { name: 'Send message' });
+      const stopButton = screen.getByRole('button', { name: 'Stop message' });
 
-      userEvent.click(sendButton);
+      userEvent.click(stopButton);
 
-      expect(onClickStop).toHaveBeenCalledTimes(1);
+      expect(onClickStopButton).toHaveBeenCalledTimes(1);
       expect(textarea).toHaveValue(TEST_INPUT_TEXT);
     });
 
     test('does not call onMessageSend when stopping during loading state', () => {
       const onMessageSend = jest.fn();
-      const onClickStop = jest.fn();
+      const onClickStopButton = jest.fn();
 
       renderInputBar({
         state: State.Loading,
         onMessageSend,
-        onClickStop,
+        onClickStopButton,
         textareaProps: { value: TEST_INPUT_TEXT },
       });
 
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
-      userEvent.click(sendButton);
+      const stopButton = screen.getByRole('button', { name: 'Stop message' });
+      userEvent.click(stopButton);
 
-      expect(onClickStop).toHaveBeenCalledTimes(1);
+      expect(onClickStopButton).toHaveBeenCalledTimes(1);
       expect(onMessageSend).not.toHaveBeenCalled();
     });
 
     test('disabled prop takes precedence over loading state', () => {
-      const onClickStop = jest.fn();
-      renderInputBar({ state: State.Loading, disabled: true, onClickStop });
+      const onClickStopButton = jest.fn();
+      renderInputBar({
+        state: State.Loading,
+        disabled: true,
+        onClickStopButton,
+      });
 
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
-      expect(sendButton).toHaveAttribute('aria-disabled', 'true');
+      const stopButton = screen.getByRole('button', { name: 'Stop message' });
+      expect(stopButton).toHaveAttribute('aria-disabled', 'true');
     });
 
     test('disableSend prop takes precedence over loading state', () => {
-      const onClickStop = jest.fn();
-      renderInputBar({ state: State.Loading, disableSend: true, onClickStop });
+      const onClickStopButton = jest.fn();
+      renderInputBar({
+        state: State.Loading,
+        disableSend: true,
+        onClickStopButton,
+      });
 
-      const sendButton = screen.getByRole('button', { name: 'Send message' });
-      expect(sendButton).toHaveAttribute('aria-disabled', 'true');
+      const stopButton = screen.getByRole('button', { name: 'Stop message' });
+      expect(stopButton).toHaveAttribute('aria-disabled', 'true');
     });
 
-    test('does not call onClickStop if not in loading state', () => {
-      const onClickStop = jest.fn();
+    test('does not call onClickStopButton if not in loading state', () => {
+      const onClickStopButton = jest.fn();
       const onMessageSend = jest.fn();
 
       renderInputBar({
-        onClickStop,
+        onClickStopButton,
         onMessageSend,
         textareaProps: { value: TEST_INPUT_TEXT },
       });
@@ -483,7 +499,7 @@ describe('packages/input-bar', () => {
       const sendButton = screen.getByRole('button', { name: 'Send message' });
       userEvent.click(sendButton);
 
-      expect(onClickStop).not.toHaveBeenCalled();
+      expect(onClickStopButton).not.toHaveBeenCalled();
       expect(onMessageSend).toHaveBeenCalledTimes(1);
     });
   });

--- a/chat/input-bar/src/InputBar/InputBar.tsx
+++ b/chat/input-bar/src/InputBar/InputBar.tsx
@@ -48,6 +48,7 @@ import { breakpoints } from '@leafygreen-ui/tokens';
 import { DisclaimerText } from '../DisclaimerText';
 import { InputBarFeedback } from '../InputBarFeedback';
 import { InputBarSendButton } from '../InputBarSendButton';
+import { InputBarStopButton } from '../InputBarStopButton';
 import { State } from '../shared.types';
 import { setReactTextAreaValue } from '../utils/setReactTextAreaValue';
 
@@ -76,7 +77,7 @@ export const InputBar = forwardRef<HTMLFormElement, InputBarProps>(
       dropdownFooterSlot,
       dropdownProps,
       errorMessage,
-      onClickStop,
+      onClickStopButton,
       onMessageSend,
       onSubmit,
       shouldRenderGradient: shouldRenderGradientProp = true,
@@ -145,7 +146,8 @@ export const InputBar = forwardRef<HTMLFormElement, InputBarProps>(
 
     const isLoading = state === State.Loading;
     const isSendButtonDisabled =
-      disabled || disableSend || (!isLoading && messageBody?.trim() === '');
+      disabled || disableSend || messageBody?.trim() === '';
+    const isStopButtonDisabled = disabled || !!disableSend;
     const shouldRenderGradient =
       !isCompact && shouldRenderGradientProp && isFocused && !disabled;
     const showHotkeyIndicator =
@@ -368,12 +370,6 @@ export const InputBar = forwardRef<HTMLFormElement, InputBarProps>(
         return;
       }
 
-      if (isLoading && onClickStop) {
-        onClickStop();
-        restorePreviousMessage();
-        return;
-      }
-
       if (onMessageSend && messageBody) {
         onMessageSend(messageBody, e);
         if (!isControlled) {
@@ -383,6 +379,13 @@ export const InputBar = forwardRef<HTMLFormElement, InputBarProps>(
       }
 
       onSubmit?.(e);
+    };
+
+    const handleStop = () => {
+      if (onClickStopButton) {
+        onClickStopButton();
+      }
+      restorePreviousMessage();
     };
 
     const handleFocus: FocusEventHandler<HTMLTextAreaElement> = _ => {
@@ -505,12 +508,18 @@ export const InputBar = forwardRef<HTMLFormElement, InputBarProps>(
                       /
                     </div>
                   )}
-                  <InputBarSendButton
-                    disabled={isSendButtonDisabled}
-                    isCompact={isCompact}
-                    shouldRenderButtonText={shouldRenderButtonText}
-                    state={state}
-                  />
+                  {isLoading && isCompact ? (
+                    <InputBarStopButton
+                      disabled={isStopButtonDisabled}
+                      onClick={handleStop}
+                    />
+                  ) : (
+                    <InputBarSendButton
+                      disabled={isSendButtonDisabled}
+                      isCompact={isCompact}
+                      shouldRenderButtonText={shouldRenderButtonText}
+                    />
+                  )}
                 </div>
               </div>
             </div>

--- a/chat/input-bar/src/InputBar/InputBar.types.ts
+++ b/chat/input-bar/src/InputBar/InputBar.types.ts
@@ -49,7 +49,7 @@ export type InputBarProps = React.ComponentPropsWithoutRef<'form'> &
      * Callback fired when the stop button is clicked during a loading state.
      * When triggered, the message input will be restored to the previous message body.
      */
-    onClickStop?: () => void;
+    onClickStopButton?: () => void;
 
     /**
      * Callback fired when the user sends a message.

--- a/chat/input-bar/src/InputBarSendButton/InputBarSendButton.styles.ts
+++ b/chat/input-bar/src/InputBarSendButton/InputBarSendButton.styles.ts
@@ -1,20 +1,5 @@
-import { css, cx } from '@leafygreen-ui/emotion';
 import { Theme } from '@leafygreen-ui/lib';
-import { palette } from '@leafygreen-ui/palette';
 import { color, InteractionState, Variant } from '@leafygreen-ui/tokens';
-
-/**
- * Off-palette value specific to primary button instances
- * @todo Consolidate usage of #00593F
- * @see https://jira.mongodb.org/browse/LG-5388
- *
- * @remarks This is a temporary duplicate to avoid importing the
- * `PRIMARY_BUTTON_INTERACTIVE_GREEN` constant from
- * `@leafygreen-ui/button/constants`. Consumers are blocked from upgrading
- * to the latest version of button package due to type issues from
- * `@leafygreen-ui/button@23.0.0` https://jira.mongodb.org/browse/LG-5462
- */
-const PRIMARY_BUTTON_INTERACTIVE_GREEN = '#00593F';
 
 export const getIconFill = ({
   disabled,
@@ -29,61 +14,3 @@ export const getIconFill = ({
 
   return color[theme].icon[Variant.Primary][InteractionState.Default];
 };
-
-const getBaseIconButtonStyles = ({ theme }: { theme: Theme }) => {
-  const darkMode = theme === Theme.Dark;
-  return css`
-    background-color: ${palette.green.dark2};
-    border: 1px solid ${palette.green[darkMode ? 'base' : 'dark2']};
-    color: ${palette.white};
-
-    &:active,
-    &:hover {
-      background-color: ${PRIMARY_BUTTON_INTERACTIVE_GREEN};
-      color: ${palette.white};
-      box-shadow: 0 0 0 3px ${palette.green[darkMode ? 'dark3' : 'light2']};
-    }
-
-    &:focus-visible {
-      background-color: ${PRIMARY_BUTTON_INTERACTIVE_GREEN};
-      color: ${palette.white};
-    }
-  `;
-};
-
-const getDisabledIconButtonStyles = (theme: Theme) => css`
-  background-color: ${color[theme].background[Variant.Disabled][
-    InteractionState.Default
-  ]};
-  color: ${color[theme].icon[Variant.Disabled][InteractionState.Default]};
-  border-color: ${color[theme].border[Variant.Disabled][
-    InteractionState.Default
-  ]};
-
-  &:active,
-  &:hover {
-    background-color: ${color[theme].background[Variant.Disabled][
-      InteractionState.Default
-    ]};
-    color: ${color[theme].icon[Variant.Disabled][InteractionState.Default]};
-    box-shadow: none;
-  }
-
-  &:focus-visible {
-    background-color: ${color[theme].background[Variant.Disabled][
-      InteractionState.Default
-    ]};
-    color: ${color[theme].icon[Variant.Disabled][InteractionState.Default]};
-  }
-`;
-
-export const getIconButtonStyles = ({
-  disabled,
-  theme,
-}: {
-  disabled: boolean;
-  theme: Theme;
-}) =>
-  cx(getBaseIconButtonStyles({ theme }), {
-    [getDisabledIconButtonStyles(theme)]: disabled,
-  });

--- a/chat/input-bar/src/InputBarSendButton/InputBarSendButton.tsx
+++ b/chat/input-bar/src/InputBarSendButton/InputBarSendButton.tsx
@@ -1,24 +1,21 @@
 import React, { forwardRef } from 'react';
 
-import Button from '@leafygreen-ui/button';
+import { Button } from '@leafygreen-ui/button';
 import ArrowUpIcon from '@leafygreen-ui/icon/dist/ArrowUp';
-import StopIcon from '@leafygreen-ui/icon/dist/Stop';
-import IconButton from '@leafygreen-ui/icon-button';
+import { IconButton } from '@leafygreen-ui/icon-button';
 import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
 
-import { State } from '../shared.types';
+import { getIconButtonStyles } from '../shared.styles';
 
-import { getIconButtonStyles, getIconFill } from './InputBarSendButton.styles';
+import { getIconFill } from './InputBarSendButton.styles';
 import { InputBarSendButtonProps } from './InputBarSendButton.types';
 import { ReturnIcon } from './ReturnIcon';
 
 export const InputBarSendButton = forwardRef<
   HTMLButtonElement,
   InputBarSendButtonProps
->(({ disabled, isCompact, shouldRenderButtonText, state, ...rest }, fwdRef) => {
+>(({ disabled, isCompact, shouldRenderButtonText, ...rest }, fwdRef) => {
   const { theme } = useDarkMode();
-
-  const isLoading = state === State.Loading;
 
   if (!isCompact) {
     return (
@@ -42,7 +39,7 @@ export const InputBarSendButton = forwardRef<
       type="submit"
       {...rest}
     >
-      {isLoading ? <StopIcon /> : <ArrowUpIcon />}
+      <ArrowUpIcon />
     </IconButton>
   );
 });

--- a/chat/input-bar/src/InputBarSendButton/InputBarSendButton.types.ts
+++ b/chat/input-bar/src/InputBarSendButton/InputBarSendButton.types.ts
@@ -1,7 +1,4 @@
-import { type SharedInputBarProps } from '../shared.types';
-
-export interface InputBarSendButtonProps
-  extends Pick<SharedInputBarProps, 'state'> {
+export interface InputBarSendButtonProps {
   /**
    * Whether the button is disabled
    */

--- a/chat/input-bar/src/InputBarStopButton/InputBarStopButton.tsx
+++ b/chat/input-bar/src/InputBarStopButton/InputBarStopButton.tsx
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react';
+
+import StopIcon from '@leafygreen-ui/icon/dist/Stop';
+import { IconButton } from '@leafygreen-ui/icon-button';
+import { useDarkMode } from '@leafygreen-ui/leafygreen-provider';
+
+import { getIconButtonStyles } from '../shared.styles';
+
+import { InputBarStopButtonProps } from './InputBarStopButton.types';
+
+export const InputBarStopButton = forwardRef<
+  HTMLButtonElement,
+  InputBarStopButtonProps
+>(({ disabled, onClick }, fwdRef) => {
+  const { theme } = useDarkMode();
+
+  return (
+    <IconButton
+      aria-label="Stop message"
+      className={getIconButtonStyles({ disabled: !!disabled, theme })}
+      disabled={disabled}
+      onClick={onClick}
+      ref={fwdRef}
+      type="button"
+    >
+      <StopIcon />
+    </IconButton>
+  );
+});
+
+InputBarStopButton.displayName = 'InputBarStopButton';

--- a/chat/input-bar/src/InputBarStopButton/InputBarStopButton.types.ts
+++ b/chat/input-bar/src/InputBarStopButton/InputBarStopButton.types.ts
@@ -1,0 +1,4 @@
+import { IconButtonProps } from '@leafygreen-ui/icon-button';
+
+export interface InputBarStopButtonProps
+  extends Pick<IconButtonProps, 'disabled' | 'onClick'> {}

--- a/chat/input-bar/src/InputBarStopButton/index.ts
+++ b/chat/input-bar/src/InputBarStopButton/index.ts
@@ -1,0 +1,2 @@
+export { InputBarStopButton } from './InputBarStopButton';
+export type { InputBarStopButtonProps } from './InputBarStopButton.types';

--- a/chat/input-bar/src/shared.styles.ts
+++ b/chat/input-bar/src/shared.styles.ts
@@ -1,0 +1,75 @@
+import { css, cx } from '@leafygreen-ui/emotion';
+import { Theme } from '@leafygreen-ui/lib';
+import { palette } from '@leafygreen-ui/palette';
+import { color, InteractionState, Variant } from '@leafygreen-ui/tokens';
+
+/**
+ * Off-palette value specific to primary button instances
+ * @todo Consolidate usage of #00593F
+ * @see https://jira.mongodb.org/browse/LG-5388
+ *
+ * @remarks This is a temporary duplicate to avoid importing the
+ * `PRIMARY_BUTTON_INTERACTIVE_GREEN` constant from
+ * `@leafygreen-ui/button/constants`. Consumers are blocked from upgrading
+ * to the latest version of button package due to type issues from
+ * `@leafygreen-ui/button@23.0.0` https://jira.mongodb.org/browse/LG-5462
+ */
+const PRIMARY_BUTTON_INTERACTIVE_GREEN = '#00593F';
+
+const getBaseIconButtonStyles = ({ theme }: { theme: Theme }) => {
+  const darkMode = theme === Theme.Dark;
+  return css`
+    background-color: ${palette.green.dark2};
+    border: 1px solid ${palette.green[darkMode ? 'base' : 'dark2']};
+    color: ${palette.white};
+
+    &:active,
+    &:hover {
+      background-color: ${PRIMARY_BUTTON_INTERACTIVE_GREEN};
+      color: ${palette.white};
+      box-shadow: 0 0 0 3px ${palette.green[darkMode ? 'dark3' : 'light2']};
+    }
+
+    &:focus-visible {
+      background-color: ${PRIMARY_BUTTON_INTERACTIVE_GREEN};
+      color: ${palette.white};
+    }
+  `;
+};
+
+const getDisabledIconButtonStyles = (theme: Theme) => css`
+  background-color: ${color[theme].background[Variant.Disabled][
+    InteractionState.Default
+  ]};
+  color: ${color[theme].icon[Variant.Disabled][InteractionState.Default]};
+  border-color: ${color[theme].border[Variant.Disabled][
+    InteractionState.Default
+  ]};
+
+  &:active,
+  &:hover {
+    background-color: ${color[theme].background[Variant.Disabled][
+      InteractionState.Default
+    ]};
+    color: ${color[theme].icon[Variant.Disabled][InteractionState.Default]};
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    background-color: ${color[theme].background[Variant.Disabled][
+      InteractionState.Default
+    ]};
+    color: ${color[theme].icon[Variant.Disabled][InteractionState.Default]};
+  }
+`;
+
+export const getIconButtonStyles = ({
+  disabled,
+  theme,
+}: {
+  disabled: boolean;
+  theme: Theme;
+}) =>
+  cx(getBaseIconButtonStyles({ theme }), {
+    [getDisabledIconButtonStyles(theme)]: disabled,
+  });


### PR DESCRIPTION
## ✍️ Proposed changes

This PR improves the send button disabled state during loading. Key changes include:

- Added `onClickStop` prop that fires when the stop button is clicked during loading state
- When stop is triggered, the previous message body is automatically restored to the input field
- Introduced shared `restorePreviousMessage` helper function used by both stop and error state handling
- Fixed send button to remain enabled during loading state (even with empty message body) to allow users to stop the request. The `disabled` and `disableSend` props still take precedence and will disable the button regardless of loading state

🎟️ _Jira ticket:_ [LG-5600](https://jira.mongodb.org/browse/LG-5600)

## ✅ Checklist

- [x] I have added stories/tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

1. **Test basic stop functionality:**
   - Render an `InputBar` with `state={State.Loading}` and `onClickStop` handler
   - Verify the send button is enabled even with empty message
   - Click the button and verify `onClickStop` is called

2. **Test message restoration:**
   - Type a message and submit it to trigger loading state
   - While loading, click the stop button
   - Verify the previous message is restored to the input field

3. **Test disabled state precedence:**
   - Set `disabled={true}` or `disableSend={true}` with `state={State.Loading}`
   - Verify the button remains disabled

4. **Test error state behavior:**
   - Submit a message and transition to error state
   - Verify the previous message is restored (existing behavior maintained)

5. **Run tests:** `pnpm test -- --testPathPattern=input-bar` - all 28 tests should pass

6. **Visual testing:** Check Storybook to verify no console warnings in compact variant