### PR TITLE
Add figma registry to npm 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,8 @@ jobs:
     name: Build packages
     runs-on: ubuntu-latest
     timeout-minutes: 20 # Should not take more than 20 minutes to build
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     outputs:
       cache-primary-key: ${{ steps.build-cache.outputs.cache-primary-key }}
     steps:
@@ -91,6 +93,8 @@ jobs:
     name: Check lints
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -128,6 +132,8 @@ jobs:
     name: Chromatic
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -180,6 +186,8 @@ jobs:
       checks: write
       contents: read
       pull-requests: write
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -227,6 +235,8 @@ jobs:
     name: Validate builds & dependencies
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - uses: actions/cache/restore@v4
         name: Check for build cache
@@ -60,6 +60,15 @@ jobs:
           node-version: 22
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Check Figma token
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        run: |
+          if [ -z "$FIGMA_NPM_TOKEN" ]; then
+            echo "FIGMA_NPM_TOKEN is NOT set"
+          else
+            echo "FIGMA_NPM_TOKEN is set"
+          fi
 
       - name: Install
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
@@ -101,7 +110,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4
@@ -143,7 +152,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4
@@ -194,7 +203,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4
@@ -243,7 +252,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4

--- a/.github/workflows/react17.yml
+++ b/.github/workflows/react17.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: Build in React 17
     runs-on: ubuntu-latest
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     outputs:
       cache-primary-key: ${{ steps.build-cache.outputs.cache-primary-key }}
     steps:
@@ -70,6 +72,8 @@ jobs:
     name: Test in React 17
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/react17.yml
+++ b/.github/workflows/react17.yml
@@ -23,7 +23,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
           cache: false
 
       - uses: actions/cache/restore@v4
@@ -81,7 +81,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
           cache: false
 
       - uses: actions/cache/restore@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build packages
     runs-on: ubuntu-latest
     timeout-minutes: 30 # Should not take more than 30 minutes to build with docs
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     outputs:
       cache-primary-key: ${{ steps.build-cache.outputs.cache-primary-key }}
     steps:
@@ -98,6 +100,8 @@ jobs:
     name: Establish Chromatic baseline
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -153,6 +157,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
@@ -215,6 +221,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, release]
     if: ${{ needs.release.outputs.published == 'true' }}
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -273,6 +281,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, release]
     if: ${{ needs.release.outputs.published == 'true' }}
+    env:
+      FIGMA_NPM_TOKEN: ${{ secrets.FIGMA_NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       # Needed following Github's transition from Node 16 to 20
       - name: Install node-gyp
@@ -110,7 +110,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4
@@ -168,7 +168,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4
@@ -229,7 +229,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       - name: Use Node 22
         uses: actions/setup-node@v4
@@ -289,7 +289,7 @@ jobs:
       - name: pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.26.0
+          version: 10.27.0
 
       # Needed following Github's transition from Node 16 to 20
       - name: Install node-gyp

--- a/.npmrc
+++ b/.npmrc
@@ -9,3 +9,8 @@ public-hoist-pattern[]=@types/*
 public-hoist-pattern[]=*jest*
 public-hoist-pattern[]=react
 public-hoist-pattern[]=react-dom
+@mongodb:registry=https://registry.figma.com/npm/6ac0a675-d39f-4a9d-a1f3-9a4526b7c668/registry/
+@make-kits:registry=https://registry.figma.com/npm/6ac0a675-d39f-4a9d-a1f3-9a4526b7c668/registry/
+@leafygreen-ui:registry=https://registry.figma.com/npm/6ac0a675-d39f-4a9d-a1f3-9a4526b7c668/registry/
+
+//registry.figma.com/npm/6ac0a675-d39f-4a9d-a1f3-9a4526b7c668/registry/:_authToken=${FIGMA_NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">= 22.21.0",
     "pnpm": ">= 10.26.0"
   },
-  "packageManager": "pnpm@10.26.0",
+  "packageManager": "pnpm@10.27.0",
   "scripts": {
     "init": "pnpm install && pnpm build",
     "init:react17": "pnpm clean; npx node ./scripts/react17/init.mjs; pnpm run init",


### PR DESCRIPTION
## ✍️ Proposed changes

Figma Make has its own npm registry and require `leafygreen-ui` packages to be added to it. See [Figma docs].(https://developers.figma.com/docs/code/working-with-npm/)

- Added Figma npm token to Github screens
- Added figma registries to `.npmrc` and Github actions so that `leafygreen-ui` packages are visible and installable.
- Upgraded pnpm to 10.27 to fix `${VAR}` interpolation in the `.npmrc` file. See the screenshot below:

Warning in Github action log
<img width="1108" height="156" alt="Screenshot 2026-04-20 at 9 09 35 pm" src="https://github.com/user-attachments/assets/087ccdb9-7d95-4bc1-ae4c-4372f4f44bde" />

Github secret
<img width="1214" height="533" alt="Screenshot 2026-04-20 at 8 35 47 pm" src="https://github.com/user-attachments/assets/588e9e82-b67e-4aff-8a11-06a86c19f223" />


## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added stories/tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## 🧪 How to test changes

- [ ] All `pr.yml` jobs pass: Build, Lint, Chromatic, Tests, Validate
- [ ] No auth errors in each job's Install Dependencies step logs
