### PR TITLE
fix(ci): fail when version bumps lack changelog updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -223,6 +223,20 @@ jobs:
           delete-old-comments: true
           filter-changed-files: true
 
+  validate-changelogs:
+    name: Validate changelogs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Fail if any package version was bumped without a CHANGELOG.md update (LG-5521)
+      - name: Validate changelogs accompany version bumps
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: node ./scripts/validate-changelogs.mjs --base "$BASE_SHA"
+
   validate-builds:
     name: Validate builds & dependencies
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "lg test",
     "unlink": "lg unlink",
     "validate": "lg validate",
-    "version": "pnpm run build && pnpm changeset version",
+    "version": "pnpm run build && pnpm changeset version && node ./scripts/validate-changelogs.mjs",
     "watch": "npx nodemon --watch packages/ -e tsx,ts --exec 'pnpm run storybook build --test'"
   },
   "devDependencies": {

--- a/scripts/validate-changelogs.mjs
+++ b/scripts/validate-changelogs.mjs
@@ -22,7 +22,10 @@ if (baseArgIndex > -1 && !base) {
 }
 
 const git = args =>
-  execFileSync('git', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  execFileSync('git', args, {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
 
 /** Ref whose file contents represent the "old" state */
 const oldRef = base ? git(['merge-base', base, 'HEAD']).trim() : 'HEAD';
@@ -52,7 +55,9 @@ function readJsonAtRef(ref, file) {
 
 function readJsonCurrent(file) {
   if (base) return readJsonAtRef('HEAD', file);
-  return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf-8')) : null;
+  return fs.existsSync(file)
+    ? JSON.parse(fs.readFileSync(file, 'utf-8'))
+    : null;
 }
 
 const missingChangelogs = [];

--- a/scripts/validate-changelogs.mjs
+++ b/scripts/validate-changelogs.mjs
@@ -1,0 +1,80 @@
+/**
+ * Fails (exit 1) if any package's `version` field changed without a
+ * corresponding CHANGELOG.md update (LG-5521).
+ *
+ * Modes:
+ *  - default: compares the working tree against HEAD. Run after
+ *    `changeset version` to catch silent changelog-generation failures
+ *    before the Version Packages PR is created.
+ *  - --base <ref>: compares <ref>...HEAD (merge-base diff). Used in PR CI
+ *    to fail the Version Packages PR itself if changelogs are missing.
+ */
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const baseArgIndex = process.argv.indexOf('--base');
+const base = baseArgIndex > -1 ? process.argv[baseArgIndex + 1] : null;
+
+if (baseArgIndex > -1 && !base) {
+  console.error('Usage: validate-changelogs.mjs [--base <ref>]');
+  process.exit(2);
+}
+
+const git = args =>
+  execFileSync('git', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+/** Ref whose file contents represent the "old" state */
+const oldRef = base ? git(['merge-base', base, 'HEAD']).trim() : 'HEAD';
+
+const changedFiles = new Set(
+  (base
+    ? git(['diff', '--name-only', `${oldRef}...HEAD`])
+    : git(['diff', '--name-only', 'HEAD'])
+  )
+    .split('\n')
+    .filter(Boolean),
+);
+
+/** Returns parsed JSON at `ref`, or null if the file doesn't exist there */
+function readJsonAtRef(ref, file) {
+  try {
+    return JSON.parse(git(['show', `${ref}:${file}`]));
+  } catch {
+    return null;
+  }
+}
+
+function readJsonCurrent(file) {
+  if (base) return readJsonAtRef('HEAD', file);
+  return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf-8')) : null;
+}
+
+const missingChangelogs = [];
+
+for (const file of changedFiles) {
+  if (path.basename(file) !== 'package.json' || file === 'package.json') continue;
+
+  const oldPkg = readJsonAtRef(oldRef, file);
+  const newPkg = readJsonCurrent(file);
+
+  // deleted package, private package, or no version bump
+  if (!newPkg || newPkg.private || !newPkg.version) continue;
+  if (oldPkg && oldPkg.version === newPkg.version) continue;
+
+  const changelog = path.posix.join(path.posix.dirname(file), 'CHANGELOG.md');
+  if (!changedFiles.has(changelog)) {
+    missingChangelogs.push(`${newPkg.name}@${newPkg.version} (${changelog})`);
+  }
+}
+
+if (missingChangelogs.length > 0) {
+  console.error(
+    `✘ ${missingChangelogs.length} package version(s) bumped without a CHANGELOG.md update:\n` +
+      missingChangelogs.map(p => `  - ${p}`).join('\n') +
+      '\n\nThis usually means `changeset version` failed to generate changelogs (see LG-5521).',
+  );
+  process.exit(1);
+}
+
+console.log('✔ All version bumps have corresponding CHANGELOG.md updates');

--- a/scripts/validate-changelogs.mjs
+++ b/scripts/validate-changelogs.mjs
@@ -27,10 +27,15 @@ const git = args =>
 /** Ref whose file contents represent the "old" state */
 const oldRef = base ? git(['merge-base', base, 'HEAD']).trim() : 'HEAD';
 
+// In default mode, include untracked files: a package's first-ever CHANGELOG.md
+// is newly created by `changeset version` and not yet staged, so it wouldn't
+// otherwise appear in `git diff HEAD`.
 const changedFiles = new Set(
   (base
-    ? git(['diff', '--name-only', `${oldRef}...HEAD`])
-    : git(['diff', '--name-only', 'HEAD'])
+    ? git(['diff', '--name-only', `${oldRef}..HEAD`])
+    : git(['diff', '--name-only', 'HEAD']) +
+      '\n' +
+      git(['ls-files', '--others', '--exclude-standard'])
   )
     .split('\n')
     .filter(Boolean),
@@ -53,14 +58,17 @@ function readJsonCurrent(file) {
 const missingChangelogs = [];
 
 for (const file of changedFiles) {
-  if (path.basename(file) !== 'package.json' || file === 'package.json') continue;
+  if (!file.endsWith('/package.json')) continue;
 
   const oldPkg = readJsonAtRef(oldRef, file);
   const newPkg = readJsonCurrent(file);
 
-  // deleted package, private package, or no version bump
+  // deleted package, private package, or no version
   if (!newPkg || newPkg.private || !newPkg.version) continue;
-  if (oldPkg && oldPkg.version === newPkg.version) continue;
+  // new package: didn't exist in the old ref, so it has no changelog to update yet
+  if (!oldPkg) continue;
+  // no version bump
+  if (oldPkg.version === newPkg.version) continue;
 
   const changelog = path.posix.join(path.posix.dirname(file), 'CHANGELOG.md');
   if (!changedFiles.has(changelog)) {


### PR DESCRIPTION
## Summary

### Issue
`changeset version` can fail silently (LG-5521 / PR #3108) — packages published with bumped `package.json` but no CHANGELOG updates.

### Fix
New zero-dep `scripts/validate-changelogs.mjs` requires a CHANGELOG.md change for every non-private package version bump; wired into the root `version` script (fails Release workflow) and a new `validate-changelogs` PR CI job (fails the Version Packages PR).

## Testing
- [x] Working-tree mode: bump w/o changelog fails, bump+changelog passes
- [x] Replayed bad PR #3108 merge commit — fails, flags all 103 packages
- [x] Replayed good Version Packages PR #3519 — passes