### PR TITLE
fix(tooltip): only open tooltip on keyboard-driven focus

### DIFF
--- a/.changeset/tooltip-keyboard-focus.md
+++ b/.changeset/tooltip-keyboard-focus.md
@@ -1,0 +1,6 @@
+---
+'@leafygreen-ui/tooltip': patch
+'@leafygreen-ui/code': patch
+---
+
+[LG-5488](https://jira.mongodb.org/browse/LG-5488): `Tooltip` no longer opens when its trigger receives focus from mouse interaction or programmatic focus (e.g. focus restored after closing a modal). It still opens when focus comes from keyboard navigation. `Code`'s copy button now explicitly opens its tooltip on click to continue showing the copied confirmation.

--- a/.changeset/tooltip-keyboard-focus.md
+++ b/.changeset/tooltip-keyboard-focus.md
@@ -1,6 +1,7 @@
 ---
 '@leafygreen-ui/tooltip': patch
 '@leafygreen-ui/code': patch
+'@leafygreen-ui/code-editor': patch
 ---
 
-[LG-5488](https://jira.mongodb.org/browse/LG-5488): `Tooltip` no longer opens when its trigger receives focus from mouse interaction or programmatic focus (e.g. focus restored after closing a modal). It still opens when focus comes from keyboard navigation. `Code`'s copy button now explicitly opens its tooltip on click to continue showing the copied confirmation.
+[LG-5488](https://jira.mongodb.org/browse/LG-5488): `Tooltip` no longer opens when its trigger receives focus from mouse interaction or programmatic focus (e.g. focus restored after closing a modal). It still opens when focus comes from keyboard navigation. Keyboard detection requires the app to be wrapped in `LeafyGreenProvider`; without one, focus continues to open the tooltip as before. The copy buttons in `Code` and `CodeEditor` now explicitly open their tooltips on click to continue showing the copied confirmation.

--- a/packages/code-editor/src/CodeEditorCopyButton/CodeEditorCopyButton.spec.tsx
+++ b/packages/code-editor/src/CodeEditorCopyButton/CodeEditorCopyButton.spec.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 
 import { CodeEditorCopyButton } from './CodeEditorCopyButton';
 import { CopyButtonVariant } from './CodeEditorCopyButton.types';
@@ -106,6 +114,35 @@ describe('CodeEditorCopyButton', () => {
 
       await waitFor(() => {
         expect(screen.getByText(COPY_TEXT)).toBeInTheDocument();
+      });
+    });
+
+    test('opens tooltip with copied text on keyboard activation after mouse usage', async () => {
+      render(
+        <LeafyGreenProvider>
+          <CodeEditorCopyButton
+            getContentsToCopy={mockgetContentsToCopy}
+            onCopy={mockOnCopy}
+          />
+        </LeafyGreenProvider>,
+      );
+
+      const button = screen.getByRole('button', { name: COPY_TEXT });
+
+      // Mouse usage sets usingKeyboard to false, so the focus from
+      // Enter activation no longer opens the tooltip — the click
+      // handler must open it explicitly
+      await act(async () => {
+        fireEvent.mouseDown(document.body);
+      });
+
+      await act(async () => {
+        button.focus();
+        await userEvent.keyboard('{Enter}');
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toHaveTextContent(COPIED_TEXT);
       });
     });
 

--- a/packages/code-editor/src/CodeEditorCopyButton/CodeEditorCopyButton.tsx
+++ b/packages/code-editor/src/CodeEditorCopyButton/CodeEditorCopyButton.tsx
@@ -104,6 +104,9 @@ export function CodeEditorCopyButton({
     await copyToClipboard();
     onCopy?.();
     setCopied(true);
+    // Explicitly open the tooltip to show the copied confirmation,
+    // since focus alone no longer opens the tooltip
+    openTooltip();
 
     setTimeout(() => {
       setCopied(false);

--- a/packages/code/src/CopyButton/CopyButton.tsx
+++ b/packages/code/src/CopyButton/CopyButton.tsx
@@ -80,6 +80,9 @@ function CopyButton({ onCopy, contents, className, ...rest }: CopyProps) {
     e.preventDefault();
     onCopy?.();
     setCopied(true);
+    // Explicitly open the tooltip to show the copied confirmation,
+    // since focus alone no longer opens the tooltip
+    openTooltip();
   };
 
   /**

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -2,6 +2,7 @@ import React, { createRef, ReactElement } from 'react';
 import {
   act,
   render,
+  RenderOptions,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -66,6 +67,7 @@ function renderTooltip(
       { renderMode?: 'portal'; portalClassName?: string },
       { renderMode: 'inline' | 'top-layer' }
     > = {},
+  options?: Pick<RenderOptions, 'wrapper'>,
 ) {
   const utils = render(
     <>
@@ -78,6 +80,7 @@ function renderTooltip(
         <div>Tooltip Contents!</div>
       </Tooltip>
     </>,
+    options,
   );
 
   const button = utils.getByText(buttonText);
@@ -159,29 +162,15 @@ describe('packages/tooltip', () => {
     });
 
     describe('when "triggerEvent" is "hover", focusing the trigger (LG-5488)', () => {
-      const renderTooltipWithProvider = () => {
-        const utils = render(
-          <LeafyGreenProvider>
-            <div data-testid="backdrop" />
-            <Tooltip
-              trigger={<button>{buttonText}</button>}
-              data-testid={tooltipTestId}
-              triggerEvent="hover"
-            >
-              <div>Tooltip Contents!</div>
-            </Tooltip>
-          </LeafyGreenProvider>,
+      // LeafyGreenProvider is required for keyboard detection
+      const renderTooltipWithProvider = () =>
+        renderTooltip(
+          { triggerEvent: 'hover' },
+          { wrapper: LeafyGreenProvider },
         );
 
-        const button = utils.getByText(buttonText);
-        const backdrop = utils.getByTestId('backdrop');
-
-        return { ...utils, button, backdrop };
-      };
-
       test('does not open the tooltip when focus follows mouse usage', async () => {
-        const { queryByTestId, button, backdrop } =
-          renderTooltipWithProvider();
+        const { queryByTestId, button, backdrop } = renderTooltipWithProvider();
 
         // Mouse usage sets usingKeyboard to false
         await userEvent.click(backdrop);

--- a/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.spec.tsx
@@ -11,6 +11,7 @@ import { axe } from 'jest-axe';
 
 import { Icon } from '@leafygreen-ui/icon';
 import CloudIcon from '@leafygreen-ui/icon/dist/Cloud';
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 import { HTMLElementProps, OneOf } from '@leafygreen-ui/lib';
 import { RenderMode } from '@leafygreen-ui/popover';
 import { transitionDuration } from '@leafygreen-ui/tokens';
@@ -155,6 +156,59 @@ describe('packages/tooltip', () => {
       await waitForElementToBeRemoved(getByTestId(tooltipTestId));
 
       expect(queryByTestId(tooltipTestId)).not.toBeInTheDocument();
+    });
+
+    describe('when "triggerEvent" is "hover", focusing the trigger (LG-5488)', () => {
+      const renderTooltipWithProvider = () => {
+        const utils = render(
+          <LeafyGreenProvider>
+            <div data-testid="backdrop" />
+            <Tooltip
+              trigger={<button>{buttonText}</button>}
+              data-testid={tooltipTestId}
+              triggerEvent="hover"
+            >
+              <div>Tooltip Contents!</div>
+            </Tooltip>
+          </LeafyGreenProvider>,
+        );
+
+        const button = utils.getByText(buttonText);
+        const backdrop = utils.getByTestId('backdrop');
+
+        return { ...utils, button, backdrop };
+      };
+
+      test('does not open the tooltip when focus follows mouse usage', async () => {
+        const { queryByTestId, button, backdrop } =
+          renderTooltipWithProvider();
+
+        // Mouse usage sets usingKeyboard to false
+        await userEvent.click(backdrop);
+
+        // Programmatic focus, e.g. focus restored after closing a modal
+        await act(async () => {
+          button.focus();
+          await waitForTimeout(200);
+        });
+
+        expect(button).toHaveFocus();
+        expect(queryByTestId(tooltipTestId)).not.toBeInTheDocument();
+      });
+
+      test('opens the tooltip when focus comes from keyboard navigation', async () => {
+        const { getByTestId, button, backdrop } = renderTooltipWithProvider();
+
+        // Mouse usage sets usingKeyboard to false
+        await userEvent.click(backdrop);
+
+        // Tabbing to the trigger sets usingKeyboard back to true
+        await userEvent.tab();
+
+        expect(button).toHaveFocus();
+        await waitFor(() => getByTestId(tooltipTestId));
+        expect(getByTestId(tooltipTestId)).toBeInTheDocument();
+      });
     });
 
     async function testTriggerEventWhenDisabled(

--- a/packages/tooltip/src/Tooltip/utils/useTooltipTriggerEventHandlers.spec.tsx
+++ b/packages/tooltip/src/Tooltip/utils/useTooltipTriggerEventHandlers.spec.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import LeafyGreenProvider from '@leafygreen-ui/leafygreen-provider';
 
 import { TriggerEvent } from '../Tooltip.types';
 import { CALLBACK_DEBOUNCE, DEFAULT_HOVER_DELAY } from '../tooltipConstants';
@@ -10,6 +12,10 @@ import { useTooltipTriggerEventHandlers } from './useTooltipTriggerEventHandlers
 const mockMouseEvent = {
   target: document.createElement('div'),
 } as unknown as React.MouseEvent<HTMLElement>;
+
+const mockFocusEvent = {
+  target: document.createElement('div'),
+} as unknown as React.FocusEvent<HTMLElement>;
 
 describe('packages/tooltip/useTooltipTriggerEventHandlers', () => {
   // Common test setup
@@ -113,6 +119,59 @@ describe('packages/tooltip/useTooltipTriggerEventHandlers', () => {
 
     // Handlers should be the same objects (memoized)
     expect(result.current).toBe(initialHandlers);
+  });
+
+  describe('usingKeyboard', () => {
+    test('onFocus opens tooltip when usingKeyboard is true (default)', () => {
+      const onFocus = jest.fn();
+      const hoverArgs: UseTooltipEventsArgs<typeof TriggerEvent.Hover> = {
+        setState,
+        triggerEvent: TriggerEvent.Hover,
+        onFocus,
+      };
+
+      const { result } = renderHook(() =>
+        useTooltipTriggerEventHandlers(hoverArgs),
+      );
+
+      result.current.onFocus(mockFocusEvent);
+
+      expect(onFocus).toHaveBeenCalled();
+      expect(setState).toHaveBeenCalledWith(true);
+    });
+
+    test('onFocus does not open tooltip after mouse usage', () => {
+      const onFocus = jest.fn();
+      const hoverArgs: UseTooltipEventsArgs<typeof TriggerEvent.Hover> = {
+        setState,
+        triggerEvent: TriggerEvent.Hover,
+        onFocus,
+      };
+
+      const { result } = renderHook(
+        () => useTooltipTriggerEventHandlers(hoverArgs),
+        {
+          wrapper: ({ children }: React.PropsWithChildren<unknown>) => (
+            <LeafyGreenProvider>{children}</LeafyGreenProvider>
+          ),
+        },
+      );
+
+      // Mouse usage sets usingKeyboard to false
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousedown'));
+      });
+
+      result.current.onFocus(mockFocusEvent);
+
+      // Consumer's onFocus handler still fires, but the tooltip does not open
+      expect(onFocus).toHaveBeenCalled();
+      expect(setState).not.toHaveBeenCalled();
+
+      // Blur still closes the tooltip
+      result.current.onBlur(mockFocusEvent);
+      expect(setState).toHaveBeenCalledWith(false);
+    });
   });
 
   test('only changes identity when args change', () => {

--- a/packages/tooltip/src/Tooltip/utils/useTooltipTriggerEventHandlers.ts
+++ b/packages/tooltip/src/Tooltip/utils/useTooltipTriggerEventHandlers.ts
@@ -9,6 +9,8 @@ import {
 import { flushSync } from 'react-dom';
 import debounce from 'lodash/debounce';
 
+import { useUsingKeyboardContext } from '@leafygreen-ui/leafygreen-provider';
+
 import { TriggerEvent } from '../Tooltip.types';
 import { CALLBACK_DEBOUNCE, DEFAULT_HOVER_DELAY } from '../tooltipConstants';
 
@@ -28,6 +30,8 @@ export function useTooltipTriggerEventHandlers<Trigger extends TriggerEvent>(
   args: UseTooltipEventsArgs<Trigger>,
 ): TooltipEventHandlers<Trigger> {
   const { setState, triggerEvent, tooltipRef, isEnabled = true } = args;
+
+  const { usingKeyboard } = useUsingKeyboardContext();
 
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -66,7 +70,13 @@ export function useTooltipTriggerEventHandlers<Trigger extends TriggerEvent>(
       const onFocus: FocusEventHandler = (e: FocusEvent<HTMLElement>) => {
         if (isEnabled) {
           args.onFocus?.(e);
-          setState(true);
+
+          // Only open the tooltip on keyboard-driven focus.
+          // Prevents the tooltip from appearing when focus is set
+          // programmatically (e.g. focus restored after closing a modal)
+          if (usingKeyboard) {
+            setState(true);
+          }
         }
       };
 
@@ -98,5 +108,5 @@ export function useTooltipTriggerEventHandlers<Trigger extends TriggerEvent>(
         onClick,
       } as TooltipEventHandlers<Trigger>;
     }
-  }, [args, isEnabled, setState, tooltipRef, triggerEvent]);
+  }, [args, isEnabled, setState, tooltipRef, triggerEvent, usingKeyboard]);
 }


### PR DESCRIPTION
## Summary
[UXE-120](https://jira.mongodb.org/browse/UXE-120)

### Issue
Tooltip opened whenever its trigger received focus, including programmatic focus (e.g. focus restored after closing a modal) and mouse interaction.

### Fix
`onFocus` now only opens the tooltip when `usingKeyboard` is true; `Code`'s copy button explicitly opens its tooltip on click to keep showing the copied confirmation.

## Testing
- [ ] All tests pass
- [ ] Check storybook