### PR TITLE
LG-6235: render 0 instead of "many" when numTotalItems is 0 in Pagination

### DIFF
--- a/.changeset/pagination-zero-total-items.md
+++ b/.changeset/pagination-zero-total-items.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/pagination': patch
+---
+
+[LG-6235](https://jira.mongodb.org/browse/LG-6235): render `0` instead of `many` when `numTotalItems` is `0`. Zero results is a valid state (e.g. a filtered table with no matches), so the summary now reads `0 - 0 of 0 items` and the navigation count reads `0 of 0`. An unknown total (`numTotalItems` is `undefined`) still renders `many`.

--- a/packages/pagination/src/Pagination.stories.tsx
+++ b/packages/pagination/src/Pagination.stories.tsx
@@ -48,7 +48,9 @@ const meta: StoryMetaType<typeof Pagination> = {
       storyNames: ['FixedItemsPerPage', 'VariableItemsPerPage'],
       combineArgs: {
         darkMode: [false, true],
-        numTotalItems: [undefined, 5, 150], // include case when numTotalItems < itemsPerPage
+        // 0 covers the empty state ("0 - 0 of 0 items" / "0 of 0"); 5 covers
+        // the case when numTotalItems < itemsPerPage.
+        numTotalItems: [undefined, 0, 5, 150],
         currentPage: [undefined, 1, 5, 10],
         shouldDisableBackArrow: [false, true],
         shouldDisableForwardArrow: [false, true],

--- a/packages/pagination/src/Pagination.stories.tsx
+++ b/packages/pagination/src/Pagination.stories.tsx
@@ -51,7 +51,9 @@ const meta: StoryMetaType<typeof Pagination> = {
         // 0 covers the empty state ("0 - 0 of 0 items" / "0 of 0"); 5 covers
         // the case when numTotalItems < itemsPerPage.
         numTotalItems: [undefined, 0, 5, 150],
-        currentPage: [undefined, 1, 5, 10],
+        // `undefined` is omitted: currentPage defaults to 1, so it would be
+        // visually identical to currentPage: 1.
+        currentPage: [1, 5, 10],
         shouldDisableBackArrow: [false, true],
         shouldDisableForwardArrow: [false, true],
         onCurrentPageOptionChange: [undefined, fn],
@@ -61,14 +63,17 @@ const meta: StoryMetaType<typeof Pagination> = {
           numTotalItems: undefined,
           onCurrentPageOptionChange: fn,
         },
+        // The empty state renders "0 of 0" regardless of currentPage, so
+        // snapshot it once (at currentPage: 1) rather than across every page.
         {
-          currentPage: undefined,
-          onCurrentPageOptionChange: fn,
-        },
-        {
+          numTotalItems: 0,
           currentPage: [5, 10],
+        },
+        // A single page of results (numTotalItems < itemsPerPage) has no
+        // page 5 or 10, so those currentPage values are invalid here.
+        {
           numTotalItems: 5,
-          itemsPerPage: 15,
+          currentPage: [5, 10],
         },
       ],
 

--- a/packages/pagination/src/Pagination/Navigation/Navigation.spec.tsx
+++ b/packages/pagination/src/Pagination/Navigation/Navigation.spec.tsx
@@ -62,6 +62,21 @@ describe('PaginationCurrentPageControls', () => {
       );
     });
 
+    test('renders "0 of 0" when numTotalItems is 0', () => {
+      const { getByTestId } = render(
+        <PaginationCurrentPageControls
+          currentPage={1}
+          numTotalItems={0}
+          itemsPerPage={10}
+          onBackArrowClick={onBackArrowClick}
+          onForwardArrowClick={onForwardArrowClick}
+        />,
+      );
+      expect(getByTestId('lg-pagination-page-range').textContent).toBe(
+        '0 of 0',
+      );
+    });
+
     test('renders correct total pages', () => {
       const { getByTestId } = render(
         <PaginationCurrentPageControls
@@ -121,6 +136,25 @@ describe('PaginationCurrentPageControls', () => {
         />,
       );
       expect(queryByTestId('lg-pagination-page-select')).toBeInTheDocument();
+    });
+
+    test('falls back to the text branch (no empty dropdown) when numTotalItems is 0', () => {
+      const { queryByTestId } = render(
+        <PaginationCurrentPageControls
+          currentPage={1}
+          numTotalItems={0}
+          itemsPerPage={10}
+          onCurrentPageOptionChange={jest.fn()}
+          onBackArrowClick={onBackArrowClick}
+          onForwardArrowClick={onForwardArrowClick}
+        />,
+      );
+      expect(
+        queryByTestId('lg-pagination-page-select'),
+      ).not.toBeInTheDocument();
+      expect(queryByTestId('lg-pagination-page-range')?.textContent).toBe(
+        '0 of 0',
+      );
     });
 
     test('page select options are rendered correctly', async () => {

--- a/packages/pagination/src/Pagination/Navigation/Navigation.spec.tsx
+++ b/packages/pagination/src/Pagination/Navigation/Navigation.spec.tsx
@@ -260,6 +260,20 @@ describe('PaginationCurrentPageControls', () => {
       expect(backButton.getAttribute('aria-disabled')).toBe('false');
     });
 
+    test('is disabled when numTotalItems is 0, even when currentPage > 1', () => {
+      const { getByTestId } = render(
+        <PaginationCurrentPageControls
+          currentPage={5}
+          numTotalItems={0}
+          itemsPerPage={10}
+          onBackArrowClick={onBackArrowClick}
+          onForwardArrowClick={onForwardArrowClick}
+        />,
+      );
+      const backButton = getByTestId('lg-pagination-back-button');
+      expect(backButton.getAttribute('aria-disabled')).toBe('true');
+    });
+
     test('calls onBackArrowClick when clicked', () => {
       const { getByTestId } = render(
         <PaginationCurrentPageControls
@@ -310,6 +324,20 @@ describe('PaginationCurrentPageControls', () => {
         <PaginationCurrentPageControls
           currentPage={10}
           numTotalItems={100}
+          itemsPerPage={10}
+          onBackArrowClick={onBackArrowClick}
+          onForwardArrowClick={onForwardArrowClick}
+        />,
+      );
+      const nextButton = getByTestId('lg-pagination-next-button');
+      expect(nextButton.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    test('is disabled when numTotalItems is 0', () => {
+      const { getByTestId } = render(
+        <PaginationCurrentPageControls
+          currentPage={1}
+          numTotalItems={0}
           itemsPerPage={10}
           onBackArrowClick={onBackArrowClick}
           onForwardArrowClick={onForwardArrowClick}

--- a/packages/pagination/src/Pagination/Navigation/Navigation.tsx
+++ b/packages/pagination/src/Pagination/Navigation/Navigation.tsx
@@ -44,7 +44,11 @@ function Navigation<T extends number>({
   const shouldDisableBackButton =
     shouldDisableBackArrow !== undefined
       ? shouldDisableBackArrow
-      : numTotalItems !== undefined && currentPage <= 1;
+      : numTotalItems !== undefined &&
+        // The empty state ("0 of 0") has no pages to navigate, so disable the
+        // back arrow regardless of currentPage. The forward arrow is already
+        // disabled here since currentPage >= 0 total pages.
+        (numTotalItems === 0 || currentPage <= 1);
   const shouldDisableForwardButton =
     shouldDisableForwardArrow !== undefined
       ? shouldDisableForwardArrow

--- a/packages/pagination/src/Pagination/Navigation/Navigation.tsx
+++ b/packages/pagination/src/Pagination/Navigation/Navigation.tsx
@@ -87,8 +87,10 @@ function Navigation<T extends number>({
         </>
       ) : (
         <Body data-testid="lg-pagination-page-range">
-          {currentPage} of{' '}
-          {numTotalItems
+          {/* A known total of 0 is a valid empty state ("0 of 0"); only an
+          unknown total (undefined) renders "many". */}
+          {numTotalItems === 0 ? 0 : currentPage} of{' '}
+          {numTotalItems !== undefined
             ? getTotalNumPages(numTotalItems, itemsPerPage)
             : 'many'}
         </Body>

--- a/packages/pagination/src/Pagination/Summary/Summary.spec.tsx
+++ b/packages/pagination/src/Pagination/Summary/Summary.spec.tsx
@@ -167,6 +167,19 @@ describe('PaginationRangeView', () => {
   });
 
   describe('edge cases', () => {
+    test('renders "0 - 0 of 0 items" when numTotalItems is 0', () => {
+      const { getByTestId } = render(
+        <PaginationRangeView
+          itemsPerPage={10}
+          currentPage={1}
+          numTotalItems={0}
+        />,
+      );
+      expect(getByTestId('lg-pagination-item-range').textContent).toBe(
+        '0 - 0 of 0 items',
+      );
+    });
+
     test('handles small total items', () => {
       const { getByTestId } = render(
         <PaginationRangeView

--- a/packages/pagination/src/Pagination/utils.spec.ts
+++ b/packages/pagination/src/Pagination/utils.spec.ts
@@ -49,6 +49,10 @@ describe('Pagination utils', () => {
     test('returns correct range without numTotalItems (undefined)', () => {
       expect(getCurrentRangeString(10, 3, undefined)).toBe('21 - 30');
     });
+
+    test('returns "0 - 0" when numTotalItems is 0', () => {
+      expect(getCurrentRangeString(10, 1, 0)).toBe('0 - 0');
+    });
   });
 
   describe('getRangeMaxString', () => {
@@ -56,8 +60,8 @@ describe('Pagination utils', () => {
       expect(getRangeMaxString()).toBe('many');
     });
 
-    test('returns "many" when numTotalItems is 0', () => {
-      expect(getRangeMaxString(0)).toBe('many');
+    test('returns "0 items" when numTotalItems is 0', () => {
+      expect(getRangeMaxString(0)).toBe('0 items');
     });
 
     test('returns correct string when numTotalItems is provided', () => {

--- a/packages/pagination/src/Pagination/utils.ts
+++ b/packages/pagination/src/Pagination/utils.ts
@@ -3,6 +3,10 @@ export const getCurrentRangeString = (
   currentPage: number,
   numTotalItems?: number,
 ) => {
+  // 0 is a valid total (e.g. a filtered table with no matches); render an empty
+  // range rather than a nonsensical "1 - 0".
+  if (numTotalItems === 0) return '0 - 0';
+
   return `${itemsPerPage * (currentPage - 1) + 1} - ${Math.min(
     itemsPerPage * currentPage,
     numTotalItems ?? itemsPerPage * currentPage,
@@ -10,7 +14,9 @@ export const getCurrentRangeString = (
 };
 
 export const getRangeMaxString = (numTotalItems?: number) => {
-  if (!numTotalItems) return 'many';
+  // Only an unknown total (undefined) renders "many"; a known total of 0 is a
+  // valid empty state and renders "0 items".
+  if (numTotalItems === undefined) return 'many';
 
   return numTotalItems === 1 ? '1 item' : `${numTotalItems} items`;
 };


### PR DESCRIPTION
Pagination showed "many" in the summary/page-count text when `numTotalItems` is `0`, even though zero results is a valid state (e.g. a filtered table with no matches). This treats a known total of `0` as a valid empty state, while still rendering "many" only for an unknown total (`undefined`).

Implements the plan from [LG-6235](https://jira.mongodb.org/browse/LG-6235). Reported by Minna KT.

## Changes
- `getRangeMaxString`: `undefined` → "many"; `0` → "0 items" (was a falsy check that returned "many" for 0).
- `getCurrentRangeString`: returns "0 - 0" for a 0 total instead of a nonsensical "1 - 0".
- `Navigation` page count: renders "0 of 0" at 0 items; `undefined` still renders "many". `0` stays on the plain-text branch (no empty page-select dropdown).
- `Navigation` arrows: both back and forward arrows are disabled in the empty state (`numTotalItems === 0`), so the controls match the "0 of 0" range even if a consumer is on a page > 1 when the result set becomes empty. Explicit `shouldDisableBackArrow` / `shouldDisableForwardArrow` overrides are still respected.
- Added a patch changeset for `@leafygreen-ui/pagination`.

Net result at `numTotalItems === 0`: summary reads **"0 - 0 of 0 items"**, nav count reads **"0 of 0"**, both arrows disabled.

## Testing
- Unit tests cover both branches (`undefined` → "many" and `0` → "0") across `utils`, `Summary`, and `Navigation`, plus the "no empty dropdown at 0" and "both arrows disabled at 0" cases.
- Added the empty state (`numTotalItems: 0`) to the generated visual-regression matrix (`FixedItemsPerPage` / `VariableItemsPerPage`) so Chromatic snapshots the empty state in light/dark and with/without `onCurrentPageOptionChange`.
- Trimmed the generated matrix to stay within Chromatic's per-story render budget: dropped the redundant `currentPage: undefined` (defaults to 1) and excluded combinations that render identically or are invalid (empty state across pages; page 5/10 of a single-page result). Each generated story is now 296 instances (was heading to 512).

Local: pagination suite passing; prettier + eslint clean.