### PR TITLE
fix(descendants): register descendants rendered inside an iframe

### DIFF
--- a/.changeset/descendants-iframe-owner-document.md
+++ b/.changeset/descendants-iframe-owner-document.md
@@ -1,0 +1,5 @@
+---
+'@leafygreen-ui/descendants': patch
+---
+
+[UXE-495](https://jira.mongodb.org/browse/UXE-495): Fix descendant registration failing inside an iframe. Descendant components (e.g. `Tabs`) rendered in an iframe would all appear selected because the containment check compared against the top-level `document` instead of the element's own document. The check now uses `ref.current.ownerDocument`, so registration works across document boundaries.

--- a/.changeset/descendants-iframe-owner-document.md
+++ b/.changeset/descendants-iframe-owner-document.md
@@ -2,4 +2,4 @@
 '@leafygreen-ui/descendants': patch
 ---
 
-[UXE-495](https://jira.mongodb.org/browse/UXE-495): Fix descendant registration failing inside an iframe. Descendant components (e.g. `Tabs`) rendered in an iframe would all appear selected because the containment check compared against the top-level `document` instead of the element's own document. The check now uses `ref.current.ownerDocument`, so registration works across document boundaries.
+[UXE-495](https://jira.mongodb.org/browse/UXE-495): Fix Tabs (and other descendant components) all appearing selected when rendered inside an iframe.

--- a/packages/descendants/src/Descendants/Descendants.spec.tsx
+++ b/packages/descendants/src/Descendants/Descendants.spec.tsx
@@ -180,7 +180,7 @@ describe('packages/descendants', () => {
       const container = iframeDocument.createElement('div');
       iframeDocument.body.appendChild(container);
 
-      const { queryByText, unmount } = render(
+      const { queryByText } = render(
         <TestParent>
           <TestDescendant>Apple</TestDescendant>
           <TestDescendant>Banana</TestDescendant>
@@ -189,14 +189,11 @@ describe('packages/descendants', () => {
         { container },
       );
 
-      try {
-        expect(queryByText('Apple')).toHaveAttribute('data-index', '0');
-        expect(queryByText('Banana')).toHaveAttribute('data-index', '1');
-        expect(queryByText('Carrot')).toHaveAttribute('data-index', '2');
-      } finally {
-        unmount();
-        document.body.removeChild(iframe);
-      }
+      expect(queryByText('Apple')).toHaveAttribute('data-index', '0');
+      expect(queryByText('Banana')).toHaveAttribute('data-index', '1');
+      expect(queryByText('Carrot')).toHaveAttribute('data-index', '2');
+
+      document.body.removeChild(iframe);
     });
   });
 

--- a/packages/descendants/src/Descendants/Descendants.spec.tsx
+++ b/packages/descendants/src/Descendants/Descendants.spec.tsx
@@ -172,6 +172,32 @@ describe('packages/descendants', () => {
       expect(anaheim).toHaveAttribute('data-index', '0');
       expect(habanero).toHaveAttribute('data-index', '1');
     });
+
+    test('registers descendants rendered inside an iframe', () => {
+      // Elements inside an iframe belong to a different document than the
+      // top-level `document`, so registration must use the element's
+      // ownerDocument for the containment check. (UXE-495)
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      const iframeDocument = iframe.contentDocument!;
+      const container = iframeDocument.createElement('div');
+      iframeDocument.body.appendChild(container);
+
+      const { queryByText } = render(
+        <TestParent>
+          <TestDescendant>Apple</TestDescendant>
+          <TestDescendant>Banana</TestDescendant>
+          <TestDescendant>Carrot</TestDescendant>
+        </TestParent>,
+        { container },
+      );
+
+      expect(queryByText('Apple')).toHaveAttribute('data-index', '0');
+      expect(queryByText('Banana')).toHaveAttribute('data-index', '1');
+      expect(queryByText('Carrot')).toHaveAttribute('data-index', '2');
+
+      document.body.removeChild(iframe);
+    });
   });
 
   describe('useInitDescendants', () => {

--- a/packages/descendants/src/Descendants/Descendants.spec.tsx
+++ b/packages/descendants/src/Descendants/Descendants.spec.tsx
@@ -180,7 +180,7 @@ describe('packages/descendants', () => {
       const container = iframeDocument.createElement('div');
       iframeDocument.body.appendChild(container);
 
-      const { queryByText } = render(
+      const { queryByText, unmount } = render(
         <TestParent>
           <TestDescendant>Apple</TestDescendant>
           <TestDescendant>Banana</TestDescendant>
@@ -189,11 +189,14 @@ describe('packages/descendants', () => {
         { container },
       );
 
-      expect(queryByText('Apple')).toHaveAttribute('data-index', '0');
-      expect(queryByText('Banana')).toHaveAttribute('data-index', '1');
-      expect(queryByText('Carrot')).toHaveAttribute('data-index', '2');
-
-      document.body.removeChild(iframe);
+      try {
+        expect(queryByText('Apple')).toHaveAttribute('data-index', '0');
+        expect(queryByText('Banana')).toHaveAttribute('data-index', '1');
+        expect(queryByText('Carrot')).toHaveAttribute('data-index', '2');
+      } finally {
+        unmount();
+        document.body.removeChild(iframe);
+      }
     });
   });
 

--- a/packages/descendants/src/Descendants/Descendants.spec.tsx
+++ b/packages/descendants/src/Descendants/Descendants.spec.tsx
@@ -174,9 +174,6 @@ describe('packages/descendants', () => {
     });
 
     test('registers descendants rendered inside an iframe', () => {
-      // Elements inside an iframe belong to a different document than the
-      // top-level `document`, so registration must use the element's
-      // ownerDocument for the containment check. (UXE-495)
       const iframe = document.createElement('iframe');
       document.body.appendChild(iframe);
       const iframeDocument = iframe.contentDocument!;

--- a/packages/descendants/src/Descendants/useDescendant.tsx
+++ b/packages/descendants/src/Descendants/useDescendant.tsx
@@ -52,7 +52,10 @@ export const useDescendant = <T extends HTMLElement>(
   // On render, register the element as a descendant
   useIsomorphicLayoutEffect(() => {
     const _id = id.current;
-    const refExists = document.contains(ref.current);
+    // Use the element's owning document so containment checks work inside an
+    // iframe, where the global `document` differs from the element's document.
+    const refExists =
+      ref.current?.ownerDocument?.contains(ref.current) ?? false;
 
     if (refExists) {
       // Register this component as a descendant

--- a/packages/descendants/src/Descendants/useDescendant.tsx
+++ b/packages/descendants/src/Descendants/useDescendant.tsx
@@ -52,8 +52,7 @@ export const useDescendant = <T extends HTMLElement>(
   // On render, register the element as a descendant
   useIsomorphicLayoutEffect(() => {
     const _id = id.current;
-    // Use the element's owning document so containment checks work inside an
-    // iframe, where the global `document` differs from the element's document.
+    // Use ownerDocument so containment checks work when the element is in an iframe.
     const refExists =
       ref.current?.ownerDocument?.contains(ref.current) ?? false;
 


### PR DESCRIPTION
## ✍️ Proposed changes

`Tabs`/`Tab` and any component built on `@leafygreen-ui/descendants` misbehaved inside an `iframe`. Clicking one tab selected every tab and rendered all panels. The registration effect in `useDescendant` checked `document.contains(ref.current)`, which returned `false` for elements in an iframe's document and left every item with a fallback index. The fix uses the element's own document: `ref.current?.ownerDocument?.contains(ref.current) ?? false`.

🎟 _Jira ticket:_ [UXE-495](https://jira.mongodb.org/browse/UXE-495)

## ✅ Checklist

### For bug fixes, new features & breaking changes

- [x] I have added stories/tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have run `pnpm changeset` and documented my changes

## 🧪 How to test changes

1. Render `Tabs` with several `Tab`s inside an `iframe`.
2. Click a single tab.
3. Before this fix all tabs appear selected and every panel renders. After, only the clicked tab is selected.

Automated coverage: `packages/descendants/src/Descendants/Descendants.spec.tsx`, "registers descendants rendered inside an iframe" (fails on `main`, passes with this change).

## Screenshots
### Before
<img width="1200" height="897" alt="before-buggy" src="https://github.com/user-attachments/assets/dbb00056-d54d-401c-aa58-c96672c876be" />

### After
<img width="1200" height="897" alt="after-fixed" src="https://github.com/user-attachments/assets/59e8af1b-f537-446a-8038-f85769fe8283" />
